### PR TITLE
Sharing v2: per-resource authz + internal-proxy identity forwarding

### DIFF
--- a/PLAN-acl-custom-resources.md
+++ b/PLAN-acl-custom-resources.md
@@ -1,0 +1,308 @@
+# Plan: Support Custom Resource Types in datasette-acl
+
+## Problem Statement
+
+datasette-acl currently only manages permissions for `TableResource`-scoped actions. It explicitly bails out in `permission_resources_sql` for anything else:
+
+```python
+if resource_class is None or not issubclass(resource_class, TableResource):
+    return None
+```
+
+Three sibling plugins define custom resource types with resource-scoped actions that datasette-acl cannot manage today:
+
+- **datasette-kanban**: `KanbanBoardResource(database, board_id)` -- 3 actions
+- **datasette-town**: `TownQueryResource(database, query_id)` -- 3 resource-scoped actions (+ 2 global)
+- **datasette-comments**: global actions only today, but will add resource-scoped permissions
+
+All custom resources follow datasette's 2-level `Resource(parent, child)` pattern, which is exactly what `acl_resources` already stores with its `(database, resource)` columns.
+
+## Key Insight
+
+The `acl_resources` table's `(database, resource)` columns are semantically `(parent, child)` -- they just happen to have been named for the table case. The SQL in `permission_resources_sql` already returns `parent` and `child` columns. The schema change is essentially a rename plus adding a `resource_type` discriminator so we can tell kanban boards apart from tables apart from town queries.
+
+## Schema Changes
+
+### `acl_resources` table
+
+Current:
+```sql
+create table if not exists acl_resources (
+    id integer primary key,
+    database text not null,
+    resource text,
+    unique(database, resource)
+);
+```
+
+New:
+```sql
+create table if not exists acl_resources (
+    id integer primary key,
+    resource_type text not null,  -- e.g. "table", "kanban-board", "town-query"
+    parent text not null,         -- was "database"
+    child text,                   -- was "resource"
+    unique(resource_type, parent, child)
+);
+```
+
+`resource_type` is the `Resource.name` class attribute (e.g. `"table"`, `"kanban-board"`, `"town-query"`).
+
+### Migration
+
+Add a migration step in `startup()` that runs after `CREATE_TABLES_SQL`:
+
+```python
+# Migration: rename columns and add resource_type
+# Check if old schema exists (has "database" column but no "resource_type" column)
+try:
+    await db.execute("select resource_type from acl_resources limit 0")
+except Exception:
+    # Old schema -- migrate
+    await db.execute_write_script("""
+        ALTER TABLE acl_resources RENAME TO acl_resources_old;
+
+        CREATE TABLE acl_resources (
+            id integer primary key,
+            resource_type text not null,
+            parent text not null,
+            child text,
+            unique(resource_type, parent, child)
+        );
+
+        INSERT INTO acl_resources (id, resource_type, parent, child)
+        SELECT id, 'table', database, resource
+        FROM acl_resources_old;
+
+        DROP TABLE acl_resources_old;
+    """)
+```
+
+All existing rows are migrated with `resource_type = 'table'` since that is the only type that could have been stored previously.
+
+## Changes to `permission_resources_sql` (in `__init__.py`)
+
+### Remove the `TableResource` gate
+
+Current code:
+```python
+resource_class = action_obj.resource_class
+if resource_class is None or not issubclass(resource_class, TableResource):
+    return None
+```
+
+New code:
+```python
+resource_class = action_obj.resource_class
+if resource_class is None:
+    return None  # Global-only actions -- nothing for ACL to contribute
+```
+
+### Update the SQL to filter by `resource_type`
+
+Add `resource_type` to the params and filter on it in the SQL:
+
+```python
+return PermissionSQL(
+    sql="""
+WITH actor_groups AS (
+    SELECT ag.group_id
+    FROM acl_actor_groups ag
+    JOIN acl_groups g ON ag.group_id = g.id
+    WHERE ag.actor_id = :actor_id
+      AND g.deleted IS NULL
+),
+matching_permissions AS (
+    SELECT
+        ar.parent AS parent,
+        ar.child AS child,
+        CASE
+            WHEN a.actor_id IS NOT NULL
+                THEN 'actor:' || a.actor_id
+            ELSE 'group:' || g.name
+        END AS reason_component
+    FROM acl a
+    JOIN acl_actions aa ON a.action_id = aa.id
+    JOIN acl_resources ar ON a.resource_id = ar.id
+    LEFT JOIN acl_groups g ON a.group_id = g.id
+    WHERE aa.name = :action
+      AND ar.resource_type = :resource_type
+      AND (
+        a.actor_id = :actor_id
+        OR a.group_id IN (SELECT group_id FROM actor_groups)
+      )
+      AND (a.group_id IS NULL OR g.deleted IS NULL)
+)
+SELECT
+    parent,
+    child,
+    1 AS allow,
+    'datasette-acl: ' || GROUP_CONCAT(reason_component, ', ') AS reason
+FROM matching_permissions
+GROUP BY parent, child
+    """,
+    params={
+        "actor_id": actor["id"],
+        "resource_type": resource_class.name,
+    },
+)
+```
+
+The key addition is `AND ar.resource_type = :resource_type` in the WHERE clause, plus the new `:resource_type` param bound to `resource_class.name`.
+
+## Changes to `track_event` (table-creator-permissions)
+
+Update to use the new column names:
+
+```python
+await db.execute_write(
+    "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES (?, ?, ?);",
+    ["table", event.database, event.table],
+)
+resource_id = (
+    await db.execute(
+        "SELECT id FROM acl_resources WHERE resource_type = ? AND parent = ? AND child = ?",
+        ["table", event.database, event.table],
+    )
+).single_value()
+```
+
+## Changes to `views/table_acls.py`
+
+### Update SQL for resource lookup
+
+Replace all occurrences of `database`/`resource` column references:
+
+```python
+await internal_db.execute_write(
+    "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES (?, ?, ?);",
+    ["table", database, table],
+)
+resource_id = (
+    await internal_db.execute(
+        "SELECT id FROM acl_resources WHERE resource_type = ? AND parent = ? AND child = ?",
+        ["table", database, table],
+    )
+).single_value()
+```
+
+### Dynamic action discovery (replace hardcoded action list)
+
+Currently hardcodes `["insert-row", "delete-row", "update-row", "alter-table", "drop-table"]` in two places.
+
+Replace with dynamic lookup from `datasette.actions`:
+
+```python
+from datasette.resources import TableResource
+
+# Get all actions that apply to TableResource
+table_actions_list = [
+    action_obj.name
+    for action_obj in datasette.actions.values()
+    if action_obj.resource_class is not None
+    and issubclass(action_obj.resource_class, TableResource)
+]
+```
+
+## New Generic Resource ACL View
+
+### New route: `/-/acl/resource/<resource_type>/<parent>/<child>`
+
+Create a new view `views/resource_acls.py` that works for ANY resource type. It mirrors `table_acls.py` but is parameterized by `resource_type`.
+
+The view:
+1. Looks up `resource_type` in the URL.
+2. Finds all actions from `datasette.actions` whose `resource_class.name == resource_type`.
+3. Ensures the resource row exists in `acl_resources`.
+4. Renders a generic permissions form (similar to `manage_table_acls.html` but with dynamic action names).
+
+### Keep the existing table route working
+
+The existing `/database/table/-/acl` route can delegate to the generic view internally, or simply be kept as-is but updated to use the new column names. Keeping it preserves backward compatibility for bookmarks/links.
+
+### New template: `manage_resource_acls.html`
+
+A generalized version of `manage_table_acls.html` where:
+- Title says "Permissions for {resource_type}: {parent}/{child}" instead of "Permissions for {database}/{table}"
+- Action checkboxes are driven by the `actions` list passed from the view (already dynamic)
+- Back link is configurable or omitted for non-table resources
+
+## How Plugins Register Resources with the ACL UI
+
+Plugins do NOT need any new hook. The system discovers everything from `datasette.actions`:
+
+1. **Action discovery**: `datasette.actions` (populated by `register_actions()` hooks from all plugins) already contains the `resource_class` for each action.
+2. **Resource type discovery**: Iterate `datasette.actions.values()`, collect unique `resource_class` values. Each `resource_class.name` is a resource type that ACL can manage.
+3. **Resource enumeration**: Each `Resource` subclass has `resources_sql()` which returns all instances. This is used to populate dropdowns or listing pages.
+
+Plugins can add links to the generic ACL page from their own UI. For example, datasette-kanban could add a "Manage board permissions" link pointing to `/-/acl/resource/kanban-board/{database}/{board_id}`.
+
+## Concrete File Changes Summary
+
+### `datasette_acl/__init__.py`
+
+| Section | Change |
+|---|---|
+| `CREATE_TABLES_SQL` | Rename `acl_resources` columns: `database` -> `parent`, `resource` -> `child`, add `resource_type` column and update unique constraint |
+| `startup()` | Add migration logic to detect old schema and rename columns + backfill `resource_type='table'` |
+| `permission_resources_sql()` | Remove `issubclass(resource_class, TableResource)` guard, accept any non-None `resource_class`. Add `resource_type` param. Update SQL to filter by `ar.resource_type` and reference `ar.parent`/`ar.child` |
+| `track_event()` | Update `acl_resources` INSERT/SELECT to use `resource_type`, `parent`, `child` columns |
+| `register_routes()` | Add route for generic resource ACL view |
+
+### `datasette_acl/views/table_acls.py`
+
+| Section | Change |
+|---|---|
+| Resource lookup SQL | Use `resource_type`, `parent`, `child` columns |
+| Action list | Replace hardcoded 5-action list with dynamic lookup from `datasette.actions` filtered by `TableResource` |
+
+### New file: `datasette_acl/views/resource_acls.py`
+
+Generic resource permissions view, parameterized by `resource_type`, `parent`, `child`. Handles GET (render form) and POST (save changes) for any resource type.
+
+### New file: `datasette_acl/templates/manage_resource_acls.html`
+
+Generic template for resource permissions. Parameterized title, dynamic action list, configurable back link.
+
+### `datasette_acl/views/groups.py`
+
+No changes needed -- groups are resource-type-agnostic.
+
+### `datasette_acl/utils.py`
+
+No changes needed.
+
+### `datasette_acl/hookspecs.py`
+
+No changes needed. The `datasette_acl_valid_actors` hook remains useful for all resource types.
+
+## Phased Implementation Order
+
+### Phase 1: Schema + permission_resources_sql (core functionality)
+
+1. Update `CREATE_TABLES_SQL` with new column names
+2. Add migration in `startup()`
+3. Update `permission_resources_sql()` to accept any resource type
+4. Update `track_event()` for new column names
+5. Update `table_acls.py` view for new column names
+6. Update tests for new column names
+7. Run `uv run pytest` to verify nothing breaks
+
+After Phase 1, datasette-acl can grant/check permissions for any resource type via direct DB manipulation, even though only the table UI exists.
+
+### Phase 2: Generic resource ACL view (UI)
+
+1. Create `views/resource_acls.py`
+2. Create `manage_resource_acls.html` template
+3. Register the new route
+4. Add tests for the generic view with a mock resource type
+
+### Phase 3: Dynamic action discovery in table view
+
+1. Replace hardcoded action lists with dynamic lookup
+2. This makes the table ACL page automatically show new table-scoped actions registered by plugins
+
+### Phase 4 (optional): ACL overview page
+
+1. `/-/acl` page listing all resource types with manageable actions
+2. Links to per-resource-type listings

--- a/PLAN-acl-share-component.md
+++ b/PLAN-acl-share-component.md
@@ -1,0 +1,289 @@
+# Plan: ACL Share Web Component (Google Docs-style Sharing Dialog)
+
+## Context
+
+Town already has a Google Docs-style `ShareDialog.svelte` for per-query sharing. Kanban has no sharing UI at all. Both manage permissions through their own tables/code. Meanwhile, datasette-acl already has the backend for resource-scoped ACLs with groups, actors, audit logging -- but its UI is a full admin page with action-level checkboxes, not an embeddable sharing dialog.
+
+This plan adds a `<datasette-acl-share>` web component that any plugin can drop into its UI for inline permission management. Town replaces its custom ShareDialog, kanban gains sharing it never had, and all permissions flow through datasette-acl's unified backend.
+
+## Prerequisites
+
+- datasette-acl custom resource support (see PLAN-acl-custom-resources.md) -- so ACL can manage kanban-board, town-query, etc.
+
+## 1. Role Presets Hookspec
+
+The ACL model is per-action, but users think in roles. Plugins declare role mappings:
+
+**File:** `datasette_acl/hookspecs.py`
+
+```python
+@hookspec
+def datasette_acl_roles(datasette):
+    """Return list of AclRole objects mapping friendly names to action bundles."""
+```
+
+**File:** `datasette_acl/roles.py`
+
+```python
+@dataclass
+class AclRole:
+    resource_type: str   # "kanban-board", "town-query", etc.
+    name: str            # "Viewer", "Editor", "Admin"
+    actions: list[str]   # ["kanban-view-board", "kanban-edit-board"]
+    description: str = ""
+```
+
+**Example implementations:**
+
+```python
+# In datasette-kanban/__init__.py
+@hookimpl
+def datasette_acl_roles(datasette):
+    return [
+        AclRole("kanban-board", "Viewer", ["kanban-view-board"]),
+        AclRole("kanban-board", "Editor", ["kanban-view-board", "kanban-edit-board"]),
+        AclRole("kanban-board", "Admin", ["kanban-view-board", "kanban-edit-board", "kanban-admin-board"]),
+    ]
+
+# In datasette-town/__init__.py
+@hookimpl
+def datasette_acl_roles(datasette):
+    return [
+        AclRole("town-query", "Viewer", ["datasette-town-view"]),
+        AclRole("town-query", "Editor", ["datasette-town-view", "datasette-town-edit"]),
+    ]
+```
+
+If no roles are registered for a resource type, the web component falls back to showing raw action checkboxes (like the current admin page).
+
+Roles are collected at startup into a `{resource_type: [AclRole]}` registry, same pattern as the provider registry in datasette-comments.
+
+## 2. JSON API Endpoints
+
+datasette-acl currently uses form POSTs. Add JSON API endpoints for the web component.
+
+**File:** `datasette_acl/views/api.py` (new)
+
+### `GET /-/acl/api/resource/{resource_type}/{parent}/{child}`
+
+Returns current grants for a resource:
+
+```json
+{
+  "resource_type": "town-query",
+  "parent": "mydb",
+  "child": "query-abc",
+  "roles": [
+    {"name": "Viewer", "actions": ["datasette-town-view"]},
+    {"name": "Editor", "actions": ["datasette-town-view", "datasette-town-edit"]}
+  ],
+  "grants": [
+    {"type": "actor", "id": "alice", "display": "Alice", "role": "Editor", "actions": ["datasette-town-view", "datasette-town-edit"]},
+    {"type": "group", "id": "2", "display": "staff", "role": "Viewer", "actions": ["datasette-town-view"]}
+  ]
+}
+```
+
+The `role` field is resolved by matching the actor/group's granted actions against the registered roles. If no role matches exactly, `role` is `null` and raw `actions` are shown.
+
+### `POST /-/acl/api/resource/{resource_type}/{parent}/{child}/grant`
+
+```json
+{"actor_id": "bob", "role": "Editor"}
+// or for raw actions:
+{"actor_id": "bob", "actions": ["datasette-town-view"]}
+// or for groups:
+{"group_id": 3, "role": "Viewer"}
+```
+
+Resolves role to actions, upserts ACL rows, records audit log entries.
+
+### `POST /-/acl/api/resource/{resource_type}/{parent}/{child}/revoke`
+
+```json
+{"actor_id": "bob"}
+// or
+{"group_id": 3}
+```
+
+Removes all ACL rows for that actor/group on this resource.
+
+### `POST /-/acl/api/resource/{resource_type}/{parent}/{child}/update`
+
+```json
+{"actor_id": "bob", "role": "Viewer"}
+```
+
+Changes role (revokes old actions, grants new ones atomically). Records audit.
+
+### `GET /-/acl/api/actors?prefix=al`
+
+Actor autocomplete. Calls `datasette_acl_valid_actors` hook, filters by prefix. Returns:
+
+```json
+{"actors": [{"id": "alice", "display": "Alice"}]}
+```
+
+### `GET /-/acl/api/groups`
+
+List available groups for the group picker:
+
+```json
+{"groups": [{"id": 1, "name": "staff", "member_count": 5}]}
+```
+
+All endpoints require the `datasette-acl` permission (same gate as the admin pages).
+
+## 3. Web Component
+
+**New Vite entry:** `datasette_acl/frontend/src/web_components/acl_share.tsx`
+
+Note: datasette-acl currently has no frontend build system. This plan adds one (Vite + Preact, same stack as datasette-comments) to build the web component. Alternatively, this could be vanilla JS/lit-element to avoid adding a build step -- but Preact keeps consistency with datasette-comments' web components and is tiny (~3KB).
+
+### `<datasette-acl-share>` Element
+
+```html
+<datasette-acl-share
+  resource-type="town-query"
+  parent="mydb"
+  child="query-abc"
+  actor-json='{"id":"alice","name":"Alice"}'
+></datasette-acl-share>
+```
+
+**Attributes:**
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `resource-type` | yes | Resource type string |
+| `parent` | yes | Parent identifier (usually database name) |
+| `child` | yes | Child identifier (board_id, query_id, etc.) |
+| `actor-json` | yes | Current user (for "Owner" display, permission gating) |
+
+**Rendered UI** (Google Docs-style dialog content, not the modal wrapper -- the host plugin wraps it in its own modal/popover):
+
+```
+┌─────────────────────────────────────────────┐
+│  Add people                                 │
+│  [actor search input________] [Share]       │
+│                                             │
+│  People with access                         │
+│  ┌─────────────────────────────────────────┐│
+│  │ 👤 alice (you)              Owner       ││
+│  │ 👤 bob                      [Editor ▾]  ││
+│  │ 👥 staff (3 members)        [Viewer ▾] ×││
+│  └─────────────────────────────────────────┘│
+│                                             │
+│  [Copy link]                                │
+└─────────────────────────────────────────────┘
+```
+
+- Actor input with autocomplete (calls `GET /-/acl/api/actors?prefix=...`)
+- Role dropdown per grant (populated from roles API response)
+- Remove button (×) per grant
+- Groups show member count
+- Changing dropdown calls update endpoint
+- "Owner" is display-only (determined by host plugin, passed as attribute or derived)
+
+**Events emitted:**
+
+| Event | Detail | Description |
+|-------|--------|-------------|
+| `grant-added` | `{actor_id, role}` | New grant created |
+| `grant-removed` | `{actor_id}` or `{group_id}` | Grant revoked |
+| `grant-updated` | `{actor_id, role}` | Role changed |
+
+Host plugins can listen to these for side effects (e.g., town could clear its is_public flag when all shares are removed).
+
+**CSS:** Ships its own scoped styles. No shadow DOM (consistent with datasette-comments components). CSS classes prefixed with `datasette-acl-`.
+
+## 4. Frontend Build Setup for datasette-acl
+
+Add to datasette-acl:
+- `frontend/package.json` (Preact, Vite, preact-custom-element)
+- `frontend/vite.config.ts` (single entry: `acl_share` web component)
+- `frontend/src/web_components/acl_share.tsx`
+- Build output: `datasette_acl/static/gen/`
+
+datasette-acl exposes a Python helper (like datasette-comments does) for consuming plugins to include the JS/CSS:
+
+```python
+# In datasette_acl/__init__.py
+def datasette_acl_share_entry(datasette):
+    """Returns vite entry HTML for the share web component."""
+    return vite_entry(datasette=datasette, plugin_package="datasette_acl", ...)
+```
+
+This adds `datasette-vite` as a dependency of datasette-acl.
+
+## 5. Town Integration
+
+### Remove:
+- `datasette_town_shares` table + migrations
+- Share CRUD methods from `internal_db.py` (`add_share`, `remove_share`, `update_share`, `list_shares`, `get_share_for_actor`)
+- Share API routes from `routes/api.py` (4 endpoints)
+- `ShareDialog.svelte` component
+- `is_public` field from queries table (public access becomes a grant to a wildcard/anonymous actor, or a separate toggle that maps to an ACL rule)
+
+### Replace in `QueryDetailPage.svelte`:
+```svelte
+<!-- Before: custom ShareDialog -->
+<ShareDialog {shares} {isPublic} ... />
+
+<!-- After: shared web component -->
+<datasette-acl-share
+  resource-type="town-query"
+  parent={database}
+  child={queryId}
+  actor-json={JSON.stringify(currentActor)}
+></datasette-acl-share>
+```
+
+### Permission changes:
+- Town's `permission_resources_sql` hook (the UNION queries for owner/shared/public) gets removed
+- datasette-acl handles all permission checks via its own `permission_resources_sql`
+- Town only needs to `register_actions()` with its resource types -- ACL does the rest
+- Query creation still inserts initial "owner" grant via ACL API
+
+## 6. Kanban Integration
+
+### Add to board settings or board page:
+```svelte
+<datasette-acl-share
+  resource-type="kanban-board"
+  parent={database}
+  child={String(boardId)}
+  actor-json={JSON.stringify(currentActor)}
+></datasette-acl-share>
+```
+
+### Permission changes:
+- Kanban's existing `check_permission` decorator continues to call `datasette.allowed()` -- no change needed
+- datasette-acl's `permission_resources_sql` now handles `kanban-view-board` / `kanban-edit-board` / `kanban-admin-board` (from PLAN-acl-custom-resources.md)
+- Board creation auto-grants admin to creator (via ACL API call in the create-board route)
+
+Kanban gains per-board sharing that it never had -- currently permissions are configured in `datasette.yaml` only.
+
+## 7. Public Access Pattern
+
+Town has `is_public` as a query-level flag. In the ACL model, "public" = grant to a well-known actor ID (e.g., `"*"` or `"_anonymous"`). The web component can include a "General access" toggle at the bottom (like town's current UI) that adds/removes a grant for the anonymous actor.
+
+This requires datasette-acl to understand a convention: a grant to actor `"*"` means "anyone, including unauthenticated users." The `permission_resources_sql` query would need a clause like:
+
+```sql
+OR a.actor_id = '*'  -- public grant
+```
+
+## Implementation Order
+
+1. **Roles hookspec + registry** (datasette-acl)
+2. **JSON API endpoints** (datasette-acl)
+3. **Frontend build setup** (datasette-acl)
+4. **`<datasette-acl-share>` web component** (datasette-acl)
+5. **Town integration** (remove shares, use web component)
+6. **Kanban integration** (add web component to board UI)
+
+## Dependencies
+
+- Requires PLAN-acl-custom-resources.md to be implemented first (so ACL handles non-table resources)
+- datasette-acl gains dependencies: `datasette-vite`, `preact`, `preact-custom-element`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,41 @@ Permission can be granted for each of the above table actions. They can be assig
 
 An audit log tracks which permissions were added and removed, displayed at the bottom of the table permissions page.
 
+### Custom resource types
+
+`datasette-acl` is not limited to tables. It can store and resolve grants for *any* resource type defined by a plugin - documents, lists, workbooks, comment spaces, kanban boards and so on.
+
+There is no dedicated hook for this. A plugin makes its resource type manageable by `datasette-acl` simply by registering actions whose `resource_class` is a [Resource](https://docs.datasette.io/en/latest/internals.html) subclass:
+
+```python
+from datasette import hookimpl
+from datasette.permissions import Action, Resource
+
+
+class PaperDoc(Resource):
+    name = "paper-doc"
+
+
+@hookimpl
+def register_actions(datasette):
+    return [
+        Action(name="paper-view", description="View a doc", resource_class=PaperDoc),
+        Action(name="paper-edit", description="Edit a doc", resource_class=PaperDoc),
+    ]
+```
+
+`datasette-acl` discovers resource types from the actions registered across all plugins (`datasette.actions`). Both the action set offered on the table permissions page and the resource types managed by the generic admin page are derived dynamically from this - nothing is hardcoded.
+
+A generic admin page for any resource type lives at:
+
+```
+/-/acl/resource/<resource-type>/<parent>/<child>
+```
+
+For example `/-/acl/resource/paper-doc/workspace-1/doc-42`. The `<child>` segment is optional for parent-only resource types (`/-/acl/resource/<resource-type>/<parent>`). The page presents the same group/user grant interface and audit log as the table page, with checkboxes for exactly the actions registered for that resource type. Access to this admin page is gated on the `datasette-acl` permission described below.
+
+Grants made here flow through Datasette's permission system: once granted, `await datasette.allowed(actor=..., action="paper-edit", resource=PaperDoc("workspace-1", "doc-42"))` returns `True`.
+
 ### Controlling who can edit permissions
 
 Users with the new `datasette-acl` permission will have the ability to access a UI for setting permissions for users and groups on a table.

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -12,6 +12,8 @@ from datasette_acl.views.api import (
     grant_json,
     revoke_json,
     update_json,
+    groups_json,
+    actors_json,
 )
 from datasette_acl.roles import build_roles_registry
 from . import hookspecs
@@ -311,6 +313,7 @@ def permission_resources_sql(datasette, actor, action):
         # General-access (wildcard) principals always apply:
         #   '*'          -> anyone, including anonymous
         #   '_signed_in' -> any actor that has an id (only when signed in)
+        #   '_anonymous' -> only unauthenticated callers (no actor id)
         # Direct actor grants and group grants only apply when signed in.
         # NOTE: this must be a single SELECT statement with no leading CTE
         # (WITH ...). Datasette core inlines this SQL after a "UNION ALL" when
@@ -341,6 +344,7 @@ WHERE aa.name = :action
     a.actor_id = '*'
     OR (:actor_id IS NOT NULL AND a.actor_id = :actor_id)
     OR (:actor_id IS NOT NULL AND a.actor_id = '_signed_in')
+    OR (:actor_id IS NULL AND a.actor_id = '_anonymous')
     OR a.group_id IN (
         SELECT ag.group_id
         FROM acl_actor_groups ag
@@ -491,6 +495,10 @@ def register_routes():
             "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/update$",
             update_json,
         ),
+        # JSON API pickers (phase-02/05): the share dialog's group + actor
+        # autocomplete sources. Both gate on the global datasette-acl permission.
+        ("^/-/acl/api/groups$", groups_json),
+        ("^/-/acl/api/actors$", actors_json),
         # JSON API read (phase-02/03). The child segment is optional so
         # parent-only resource types resolve through the same route.
         (

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -17,9 +17,10 @@ pm.add_hookspecs(hookspecs)
 CREATE_TABLES_SQL = """
 create table if not exists acl_resources (
     id integer primary key,
-    database text not null,
-    resource text,
-    unique(database, resource)
+    resource_type text not null,
+    parent text not null,
+    child text,
+    unique(resource_type, parent, child)
 );
 
 create table if not exists acl_actions (
@@ -122,6 +123,28 @@ def startup(datasette):
     async def inner():
         db = datasette.get_internal_database()
         await db.execute_write_script(CREATE_TABLES_SQL)
+        # Migrate old acl_resources (database, resource) schema to the
+        # generalized (resource_type, parent, child) schema. Feature-detect by
+        # probing for the resource_type column; if it is missing we have the
+        # old schema and rewrite the table, backfilling resource_type='table'.
+        try:
+            await db.execute("select resource_type from acl_resources limit 0")
+        except Exception:
+            await db.execute_write_script(
+                """
+                ALTER TABLE acl_resources RENAME TO acl_resources_old;
+                CREATE TABLE acl_resources (
+                    id integer primary key,
+                    resource_type text not null,
+                    parent text not null,
+                    child text,
+                    unique(resource_type, parent, child)
+                );
+                INSERT INTO acl_resources (id, resource_type, parent, child)
+                    SELECT id, 'table', database, resource FROM acl_resources_old;
+                DROP TABLE acl_resources_old;
+                """
+            )
         # Ensure permissions are in the DB
         await db.execute_write_many(
             """
@@ -284,8 +307,8 @@ WITH actor_groups AS (
 ),
 matching_permissions AS (
     SELECT
-        ar.database AS parent,
-        ar.resource AS child,
+        ar.parent AS parent,
+        ar.child AS child,
         CASE
             WHEN a.actor_id IS NOT NULL
                 THEN 'actor:' || a.actor_id
@@ -357,12 +380,12 @@ def track_event(datasette, event):
         db = datasette.get_internal_database()
         # Ensure resource exists for table
         await db.execute_write(
-            "INSERT OR IGNORE INTO acl_resources (database, resource) VALUES (?, ?);",
+            "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES ('table', ?, ?);",
             [event.database, event.table],
         )
         resource_id = (
             await db.execute(
-                "SELECT id FROM acl_resources WHERE database = ? AND resource = ?",
+                "SELECT id FROM acl_resources WHERE resource_type = 'table' AND parent = ? AND child = ?",
                 [event.database, event.table],
             )
         ).single_value()

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -7,7 +7,12 @@ from datasette_acl.utils import can_edit_permissions
 from datasette_acl.views.table_acls import manage_table_acls
 from datasette_acl.views.resource_acls import manage_resource_acls
 from datasette_acl.views.groups import manage_groups, manage_group
-from datasette_acl.views.api import resource_grants_json
+from datasette_acl.views.api import (
+    resource_grants_json,
+    grant_json,
+    revoke_json,
+    update_json,
+)
 from datasette_acl.roles import build_roles_registry
 from . import hookspecs
 import json
@@ -458,8 +463,36 @@ def register_routes():
             "^/-/acl/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)$",
             manage_resource_acls,
         ),
-        # JSON API (phase-02). The child segment is optional so parent-only
-        # resource types resolve through the same route.
+        # JSON API mutations (phase-02/04). Registered BEFORE the read routes so
+        # the trailing /grant|/revoke|/update verb isn't swallowed as a {child}
+        # path segment by the generic read route. The child segment is optional
+        # so parent-only resource types resolve through both variants.
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)/grant$",
+            grant_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/grant$",
+            grant_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)/revoke$",
+            revoke_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/revoke$",
+            revoke_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)/update$",
+            update_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/update$",
+            update_json,
+        ),
+        # JSON API read (phase-02/03). The child segment is optional so
+        # parent-only resource types resolve through the same route.
         (
             "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)$",
             resource_grants_json,

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -7,6 +7,7 @@ from datasette_acl.utils import can_edit_permissions
 from datasette_acl.views.table_acls import manage_table_acls
 from datasette_acl.views.resource_acls import manage_resource_acls
 from datasette_acl.views.groups import manage_groups, manage_group
+from datasette_acl.views.api import resource_grants_json
 from datasette_acl.roles import build_roles_registry
 from . import hookspecs
 import json
@@ -456,5 +457,15 @@ def register_routes():
         (
             "^/-/acl/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)$",
             manage_resource_acls,
+        ),
+        # JSON API (phase-02). The child segment is optional so parent-only
+        # resource types resolve through the same route.
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)$",
+            resource_grants_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)$",
+            resource_grants_json,
         ),
     ]

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -1,7 +1,6 @@
 from datasette import hookimpl
 from datasette.events import CreateTableEvent
 from datasette.permissions import Action, PermissionSQL
-from datasette.resources import TableResource
 from datasette.utils import actor_matches_allow
 from datasette.plugins import pm
 from datasette_acl.utils import can_edit_permissions
@@ -287,54 +286,64 @@ def permission_resources_sql(datasette, actor, action):
     if not action_obj:
         return None
     resource_class = action_obj.resource_class
-    if resource_class is None or not issubclass(resource_class, TableResource):
+    if resource_class is None:
+        # Global-only actions: nothing for ACL to contribute
         return None
 
     async def inner():
-        if not actor or not actor.get("id"):
-            return None
-        await update_dynamic_groups(
-            datasette, actor, skip_cache=hasattr(sys, "_pytest_running")
-        )
+        actor_id = actor.get("id") if actor else None
+        if actor_id:
+            await update_dynamic_groups(
+                datasette, actor, skip_cache=hasattr(sys, "_pytest_running")
+            )
+        # General-access (wildcard) principals always apply:
+        #   '*'          -> anyone, including anonymous
+        #   '_signed_in' -> any actor that has an id (only when signed in)
+        # Direct actor grants and group grants only apply when signed in.
+        # NOTE: this must be a single SELECT statement with no leading CTE
+        # (WITH ...). Datasette core inlines this SQL after a "UNION ALL" when
+        # building its anon_rules block for include_is_private queries, and a
+        # leading WITH there is a SQLite syntax error. The actor-groups lookup
+        # is therefore expressed as an inline subquery rather than a CTE.
         return PermissionSQL(
             sql="""
-WITH actor_groups AS (
-    SELECT ag.group_id
-    FROM acl_actor_groups ag
-    JOIN acl_groups g ON ag.group_id = g.id
-    WHERE ag.actor_id = :actor_id
-      AND g.deleted IS NULL
-),
-matching_permissions AS (
-    SELECT
-        ar.parent AS parent,
-        ar.child AS child,
+SELECT
+    ar.parent AS parent,
+    ar.child AS child,
+    1 AS allow,
+    'datasette-acl: ' || GROUP_CONCAT(
         CASE
             WHEN a.actor_id IS NOT NULL
                 THEN 'actor:' || a.actor_id
             ELSE 'group:' || g.name
-        END AS reason_component
-    FROM acl a
-    JOIN acl_actions aa ON a.action_id = aa.id
-    JOIN acl_resources ar ON a.resource_id = ar.id
-    LEFT JOIN acl_groups g ON a.group_id = g.id
-    WHERE aa.name = :action
-      AND (
-        a.actor_id = :actor_id
-        OR a.group_id IN (SELECT group_id FROM actor_groups)
-      )
-      AND (a.group_id IS NULL OR g.deleted IS NULL)
-)
-SELECT
-    parent,
-    child,
-    1 AS allow,
-    'datasette-acl: ' || GROUP_CONCAT(reason_component, ', ') AS reason
-FROM matching_permissions
-GROUP BY parent, child
+        END,
+        ', '
+    ) AS reason
+FROM acl a
+JOIN acl_actions aa ON a.action_id = aa.id
+JOIN acl_resources ar ON a.resource_id = ar.id
+LEFT JOIN acl_groups g ON a.group_id = g.id
+WHERE aa.name = :action
+  AND ar.resource_type = :resource_type
+  AND (
+    a.actor_id = '*'
+    OR (:actor_id IS NOT NULL AND a.actor_id = :actor_id)
+    OR (:actor_id IS NOT NULL AND a.actor_id = '_signed_in')
+    OR a.group_id IN (
+        SELECT ag.group_id
+        FROM acl_actor_groups ag
+        JOIN acl_groups ig ON ag.group_id = ig.id
+        WHERE :actor_id IS NOT NULL
+          AND ag.actor_id = :actor_id
+          AND ig.deleted IS NULL
+    )
+  )
+  AND (a.group_id IS NULL OR g.deleted IS NULL)
+GROUP BY ar.parent, ar.child
             """,
             params={
-                "actor_id": actor["id"],
+                "actor_id": actor_id,
+                "resource_type": resource_class.name,
             },
         )
 

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -7,6 +7,7 @@ from datasette_acl.utils import can_edit_permissions
 from datasette_acl.views.table_acls import manage_table_acls
 from datasette_acl.views.resource_acls import manage_resource_acls
 from datasette_acl.views.groups import manage_groups, manage_group
+from datasette_acl.roles import build_roles_registry
 from . import hookspecs
 import json
 import sys
@@ -160,6 +161,10 @@ def startup(datasette):
                 "insert or ignore into acl_groups (name) values (:name)",
                 [{"name": name} for name in groups.keys()],
             )
+        # Collect friendly roles declared by plugins via datasette_acl_roles
+        # into a registry keyed by resource_type and stash it on datasette.
+        # Re-gathering is cheap; we do it once at startup.
+        datasette._acl_roles_registry = await build_roles_registry(datasette)
 
     return inner
 

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -5,6 +5,7 @@ from datasette.utils import actor_matches_allow
 from datasette.plugins import pm
 from datasette_acl.utils import can_edit_permissions
 from datasette_acl.views.table_acls import manage_table_acls
+from datasette_acl.views.resource_acls import manage_resource_acls
 from datasette_acl.views.groups import manage_groups, manage_group
 from . import hookspecs
 import json
@@ -441,4 +442,14 @@ def register_routes():
         ("^/(?P<database>[^/]+)/(?P<table>[^/]+)/-/acl$", manage_table_acls),
         ("^/-/acl/groups$", manage_groups),
         ("^/-/acl/groups/(?P<name>[^/]+)$", manage_group),
+        # Generic per-resource-type admin page. The child segment is optional
+        # so parent-only resource types (e.g. a database) are also managed here.
+        (
+            "^/-/acl/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)$",
+            manage_resource_acls,
+        ),
+        (
+            "^/-/acl/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)$",
+            manage_resource_acls,
+        ),
     ]

--- a/datasette_acl/grants.py
+++ b/datasette_acl/grants.py
@@ -1,0 +1,306 @@
+"""Reusable Python grant helpers for datasette-acl.
+
+acl historically had no public Python API: callers wanting to grant access had
+to write raw SQL into acl's tables. These helpers centralize the writes so other
+plugins (the JSON API in tasks 03-05, and consumer data-migrations in later
+phases) call functions instead of touching acl's schema directly.
+
+Every mutating helper:
+  * ensures the ``acl_resources`` row exists for ``(resource_type, parent, child)``,
+  * ensures the relevant ``acl_actions`` rows exist,
+  * writes the ``acl`` rows, and
+  * appends ``acl_audit`` entries (``operation_by`` = ``by_actor``).
+
+Principal invariant: exactly one of ``actor_id`` / ``group_id`` is set, matching
+the CHECK constraint on the ``acl`` table.
+"""
+
+from datasette_acl.roles import actions_for_role
+
+
+def _roles_for(datasette, resource_type):
+    registry = getattr(datasette, "_acl_roles_registry", None) or {}
+    return registry.get(resource_type, [])
+
+
+def _resolve_actions(datasette, resource_type, role, actions):
+    """Resolve the action list for a grant from either ``role`` or ``actions``.
+
+    Exactly one of ``role`` / ``actions`` must be provided. ``role`` is resolved
+    against the startup roles registry via :func:`actions_for_role`.
+    """
+    if (role is None) == (actions is None):
+        raise ValueError("Provide exactly one of role= or actions=")
+    if role is not None:
+        resolved = actions_for_role(_roles_for(datasette, resource_type), role)
+        if resolved is None:
+            raise ValueError(
+                f"Unknown role {role!r} for resource type {resource_type!r}"
+            )
+        return list(resolved)
+    return list(actions)
+
+
+def _check_principal(actor_id, group_id):
+    """Enforce the acl CHECK invariant: exactly one of actor_id / group_id."""
+    if (actor_id is None) == (group_id is None):
+        raise ValueError("Provide exactly one of actor_id= or group_id=")
+
+
+async def _ensure_resource_id(db, resource_type, parent, child):
+    # NOTE: the acl_resources UNIQUE(resource_type, parent, child) constraint
+    # treats NULL children as distinct in SQLite, so a bare INSERT OR IGNORE for
+    # a parent-only resource (child IS NULL) would create a duplicate row on
+    # every call. Select first and only insert when absent; return the lowest
+    # existing id so repeated calls are stable.
+    select_sql = (
+        "SELECT id FROM acl_resources "
+        "WHERE resource_type = ? AND parent = ? AND child IS ? "
+        "ORDER BY id LIMIT 1"
+    )
+    existing = await db.execute(select_sql, [resource_type, parent, child])
+    if existing.rows:
+        return existing.rows[0][0]
+    await db.execute_write(
+        "INSERT INTO acl_resources (resource_type, parent, child) VALUES (?, ?, ?)",
+        [resource_type, parent, child],
+    )
+    return (
+        await db.execute(select_sql, [resource_type, parent, child])
+    ).single_value()
+
+
+async def _ensure_actions(db, actions):
+    if actions:
+        await db.execute_write_many(
+            "INSERT OR IGNORE INTO acl_actions (name) VALUES (:name)",
+            [{"name": name} for name in actions],
+        )
+
+
+async def _current_actions(db, resource_id, actor_id, group_id):
+    """Return the set of action names currently granted to a principal."""
+    if actor_id is not None:
+        where = "acl.actor_id = :actor_id AND acl.group_id IS NULL"
+    else:
+        where = "acl.group_id = :group_id AND acl.actor_id IS NULL"
+    rows = await db.execute(
+        f"""
+        SELECT acl_actions.name AS name
+        FROM acl
+        JOIN acl_actions ON acl.action_id = acl_actions.id
+        WHERE acl.resource_id = :resource_id AND {where}
+        """,
+        {"resource_id": resource_id, "actor_id": actor_id, "group_id": group_id},
+    )
+    return {row["name"] for row in rows.rows}
+
+
+async def _insert_grant(db, resource_id, actor_id, group_id, action_name, by_actor):
+    await db.execute_write(
+        """
+        INSERT OR IGNORE INTO acl (actor_id, group_id, resource_id, action_id)
+        VALUES (
+            :actor_id,
+            :group_id,
+            :resource_id,
+            (SELECT id FROM acl_actions WHERE name = :action_name)
+        )
+        """,
+        {
+            "actor_id": actor_id,
+            "group_id": group_id,
+            "resource_id": resource_id,
+            "action_name": action_name,
+        },
+    )
+    await _audit(db, "added", resource_id, actor_id, group_id, action_name, by_actor)
+
+
+async def _delete_grant(db, resource_id, actor_id, group_id, action_name, by_actor):
+    if actor_id is not None:
+        principal_where = "actor_id = :actor_id AND group_id IS NULL"
+    else:
+        principal_where = "group_id = :group_id AND actor_id IS NULL"
+    await db.execute_write(
+        f"""
+        DELETE FROM acl
+        WHERE {principal_where}
+          AND resource_id = :resource_id
+          AND action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
+        """,
+        {
+            "actor_id": actor_id,
+            "group_id": group_id,
+            "resource_id": resource_id,
+            "action_name": action_name,
+        },
+    )
+    await _audit(db, "removed", resource_id, actor_id, group_id, action_name, by_actor)
+
+
+async def _audit(db, operation, resource_id, actor_id, group_id, action_name, by_actor):
+    await db.execute_write(
+        """
+        INSERT INTO acl_audit (
+            operation, actor_id, group_id, resource_id, action_id, operation_by
+        ) VALUES (
+            :operation,
+            :actor_id,
+            :group_id,
+            :resource_id,
+            (SELECT id FROM acl_actions WHERE name = :action_name),
+            :operation_by
+        )
+        """,
+        {
+            "operation": operation,
+            "actor_id": actor_id,
+            "group_id": group_id,
+            "resource_id": resource_id,
+            "action_name": action_name,
+            "operation_by": by_actor,
+        },
+    )
+
+
+async def grant(
+    datasette,
+    resource_type,
+    parent,
+    child=None,
+    *,
+    actor_id=None,
+    group_id=None,
+    role=None,
+    actions=None,
+    by_actor=None,
+):
+    """Grant a principal access to a resource, by role or by raw actions.
+
+    Exactly one of ``actor_id`` / ``group_id`` and exactly one of ``role`` /
+    ``actions`` must be supplied. Only actions not already granted are inserted
+    (idempotent). Returns the list of action names now held by the principal.
+    """
+    _check_principal(actor_id, group_id)
+    resolved = _resolve_actions(datasette, resource_type, role, actions)
+    db = datasette.get_internal_database()
+    resource_id = await _ensure_resource_id(db, resource_type, parent, child)
+    await _ensure_actions(db, resolved)
+    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    for action_name in resolved:
+        if action_name not in existing:
+            await _insert_grant(
+                db, resource_id, actor_id, group_id, action_name, by_actor
+            )
+    return sorted(existing | set(resolved))
+
+
+async def revoke(
+    datasette,
+    resource_type,
+    parent,
+    child=None,
+    *,
+    actor_id=None,
+    group_id=None,
+    by_actor=None,
+):
+    """Remove all acl rows for a principal on a resource. Audits each removal.
+
+    Returns the list of action names that were removed.
+    """
+    _check_principal(actor_id, group_id)
+    db = datasette.get_internal_database()
+    resource_id = await _ensure_resource_id(db, resource_type, parent, child)
+    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    for action_name in sorted(existing):
+        await _delete_grant(
+            db, resource_id, actor_id, group_id, action_name, by_actor
+        )
+    return sorted(existing)
+
+
+async def update_role(
+    datasette,
+    resource_type,
+    parent,
+    child=None,
+    *,
+    actor_id=None,
+    group_id=None,
+    role,
+    by_actor=None,
+):
+    """Atomically swap a principal's action set on a resource to ``role``.
+
+    Removes any currently-granted actions that are not in the new role, then
+    adds any missing ones. Audits each change. Returns the new action list.
+    """
+    _check_principal(actor_id, group_id)
+    resolved = set(_resolve_actions(datasette, resource_type, role, None))
+    db = datasette.get_internal_database()
+    resource_id = await _ensure_resource_id(db, resource_type, parent, child)
+    await _ensure_actions(db, resolved)
+    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    for action_name in sorted(existing - resolved):
+        await _delete_grant(
+            db, resource_id, actor_id, group_id, action_name, by_actor
+        )
+    for action_name in sorted(resolved - existing):
+        await _insert_grant(
+            db, resource_id, actor_id, group_id, action_name, by_actor
+        )
+    return sorted(resolved)
+
+
+async def list_grants(datasette, resource_type, parent, child=None):
+    """Return the grants on a resource as a list of dicts.
+
+    Each dict is ``{"principal": "actor"|"group", "actor_id", "group_id",
+    "group_name", "actions": [...]}`` with actions sorted. Group grants whose
+    group is soft-deleted are omitted. The list is ordered by principal then id.
+    """
+    db = datasette.get_internal_database()
+    resource_id = await _ensure_resource_id(db, resource_type, parent, child)
+    rows = await db.execute(
+        """
+        SELECT
+            acl.actor_id AS actor_id,
+            acl.group_id AS group_id,
+            acl_groups.name AS group_name,
+            acl_actions.name AS action_name
+        FROM acl
+        JOIN acl_actions ON acl.action_id = acl_actions.id
+        LEFT JOIN acl_groups ON acl.group_id = acl_groups.id
+        WHERE acl.resource_id = :resource_id
+          AND (acl.group_id IS NULL OR acl_groups.deleted IS NULL)
+        """,
+        {"resource_id": resource_id},
+    )
+    grants = {}
+    for row in rows.rows:
+        if row["actor_id"] is not None:
+            key = ("actor", row["actor_id"], None, None)
+        else:
+            key = ("group", None, row["group_id"], row["group_name"])
+        grants.setdefault(key, set()).add(row["action_name"])
+    out = []
+    for (principal, actor_id, group_id, group_name), action_set in grants.items():
+        out.append(
+            {
+                "principal": principal,
+                "actor_id": actor_id,
+                "group_id": group_id,
+                "group_name": group_name,
+                "actions": sorted(action_set),
+            }
+        )
+    out.sort(
+        key=lambda g: (
+            g["principal"],
+            g["actor_id"] or "",
+            g["group_id"] or 0,
+        )
+    )
+    return out

--- a/datasette_acl/hookspecs.py
+++ b/datasette_acl/hookspecs.py
@@ -13,3 +13,18 @@ def datasette_acl_valid_actors(datasette):
     - A list of dictionaries with "id" and "display" keys
     - A function or awaitable function that returns one of the above
     """
+
+
+@hookspec
+def datasette_acl_roles(datasette):
+    """
+    Return list[AclRole] mapping friendly role names to action bundles per
+    resource type.
+
+    Each AclRole declares a resource_type, a friendly name (e.g. "Editor"), and
+    the list of action names that role grants. A `rank` orders roles (highest
+    wins for display) and `manage=True` marks the role(s) whose actions
+    authorize re-sharing the resource.
+
+    May return a list directly, or a function / awaitable returning one.
+    """

--- a/datasette_acl/roles.py
+++ b/datasette_acl/roles.py
@@ -1,0 +1,92 @@
+"""Friendly roles layer for datasette-acl.
+
+acl stores per-action grants, but users think in roles (Viewer / Editor /
+Manager). Plugins declare roles for their resource types via the
+``datasette_acl_roles`` hook; they are collected at startup into a registry
+keyed by ``resource_type``. Helpers resolve a granted action-set to its
+best-matching role and back.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+from datasette.plugins import pm
+from datasette.utils import await_me_maybe
+
+
+@dataclass
+class AclRole:
+    """A friendly role mapping a name to an action bundle for one resource type.
+
+    Attributes:
+        resource_type: the Resource.name this role applies to, e.g. "paper-doc".
+        name: friendly role name, e.g. "Editor".
+        actions: action names this role grants, e.g. ["paper-view", "paper-edit"].
+        rank: ordering / "highest role wins" weight; larger means higher.
+        manage: True => holders of this role may change sharing (Manager/Owner).
+        description: optional human-readable description.
+    """
+
+    resource_type: str
+    name: str
+    actions: List[str] = field(default_factory=list)
+    rank: int = 0
+    manage: bool = False
+    description: str = ""
+
+
+async def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
+    """Gather declared roles into ``{resource_type: [AclRole, ...]}``.
+
+    Calls the ``datasette_acl_roles`` hook across all plugins, awaiting any
+    callables/awaitables they return, and groups the resulting AclRole objects
+    by ``resource_type``. Within each resource type the roles are sorted by
+    ``rank`` ascending (so the highest-rank role is last) for stable ordering.
+    """
+    registry: Dict[str, List[AclRole]] = {}
+    for hook_result in pm.hook.datasette_acl_roles(datasette=datasette):
+        roles = await await_me_maybe(hook_result)
+        if not roles:
+            continue
+        for role in roles:
+            registry.setdefault(role.resource_type, []).append(role)
+    for resource_type in registry:
+        registry[resource_type].sort(key=lambda r: r.rank)
+    return registry
+
+
+def role_for_actions(
+    roles: List[AclRole], granted: Set[str]
+) -> Optional[AclRole]:
+    """Pick the highest-rank role whose actions are a subset of ``granted``.
+
+    Returns the matching :class:`AclRole`, or ``None`` if no role's action set
+    fits within the granted actions (the caller can then show raw actions).
+    """
+    granted = set(granted)
+    best: Optional[AclRole] = None
+    for role in roles:
+        if set(role.actions) <= granted:
+            if best is None or role.rank > best.rank:
+                best = role
+    return best
+
+
+def actions_for_role(roles: List[AclRole], name: str) -> Optional[List[str]]:
+    """Return the action list for the role named ``name``, or ``None``."""
+    for role in roles:
+        if role.name == name:
+            return list(role.actions)
+    return None
+
+
+def manage_actions(roles: List[AclRole]) -> Set[str]:
+    """Union of actions across all ``manage=True`` roles for a resource type.
+
+    These are the actions that authorize re-sharing a resource (see task 04).
+    """
+    actions: Set[str] = set()
+    for role in roles:
+        if role.manage:
+            actions.update(role.actions)
+    return actions

--- a/datasette_acl/roles.py
+++ b/datasette_acl/roles.py
@@ -83,10 +83,36 @@ def actions_for_role(roles: List[AclRole], name: str) -> Optional[List[str]]:
 def manage_actions(roles: List[AclRole]) -> Set[str]:
     """Union of actions across all ``manage=True`` roles for a resource type.
 
-    These are the actions that authorize re-sharing a resource (see task 04).
+    This is the full action bundle a manage role carries (e.g. Manager =
+    view+edit+manage). Use :func:`manage_only_actions` for the authorization
+    check — see its docstring for why the union is the wrong gate.
     """
     actions: Set[str] = set()
     for role in roles:
         if role.manage:
             actions.update(role.actions)
     return actions
+
+
+def manage_only_actions(roles: List[AclRole]) -> Set[str]:
+    """Actions that authorize re-sharing: those exclusive to ``manage`` roles.
+
+    A manage role typically *bundles* the lower roles' actions (Manager =
+    Viewer + Editor + ``manage``). Authorizing against the full bundle
+    (:func:`manage_actions`) would wrongly let any Viewer/Editor manage sharing,
+    since they too hold ``doc-view``. The action(s) that actually distinguish a
+    manager are those appearing only in ``manage=True`` roles and in no
+    non-manage role — typically a single ``*-manage`` action. Holding any one of
+    these is what grants re-share ability (task 04 §D).
+
+    Returns the empty set if no role is marked ``manage`` (callers then fall back
+    to the global ``datasette-acl`` permission).
+    """
+    manage_union: Set[str] = set()
+    non_manage_union: Set[str] = set()
+    for role in roles:
+        if role.manage:
+            manage_union.update(role.actions)
+        else:
+            non_manage_union.update(role.actions)
+    return manage_union - non_manage_union

--- a/datasette_acl/templates/manage_resource_acls.html
+++ b/datasette_acl/templates/manage_resource_acls.html
@@ -1,0 +1,171 @@
+{% extends "base.html" %}
+
+{% block title %}Permissions for {{ resource_type }}: {{ parent }}{% if child %}/{{ child }}{% endif %}{% endblock %}
+
+{% block extra_head %}
+<script src="{{ urls.static_plugins("datasette-acl", "choices-9.0.1.min.js") }}"></script>
+<link rel="stylesheet" href="{{ urls.static_plugins("datasette-acl", "choices-9.0.1.min.css") }}">
+<style>
+#needs-save-message {
+  color: rgb(249, 114, 114);
+  font-weight: bold;
+  margin-top: 10px;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  padding-left: 0.8em;
+}
+#needs-save-message.visible {
+  opacity: 1;
+}
+table.audit {
+  border-collapse: collapse;
+}
+table.audit td {
+  border-top: 1px solid #aaa;
+  border-right: 1px solid #eee;
+  padding: 4px;
+  vertical-align: top;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<h1>Permissions for {{ resource_type }}: {{ parent }}{% if child %}/{{ child }}{% endif %}</h1>
+
+<form action="{{ request.path }}" method="post">
+  {% if groups %}
+  <h3>Groups</h3>
+  {% for group in groups %}
+    <div style="margin-bottom: 1em">
+      <label style="display: block" for="id_group_permissions_{{ group }}"><a href="{{ urls.path("/-/acl/groups/" + group) }}">{{ group }}</a> ({{ group_sizes[group] }})</label>
+      <select multiple name="group_permissions_{{ group }}" id="id_group_permissions_{{ group }}">
+        {% for action in actions %}
+          <option value="{{ action }}" {% if group_permissions and group_permissions.get(group, {}).get(action) %}selected{% endif %}>{{ action }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  {% endfor %}
+{% endif %}
+
+<h3>Users</h3>
+{% for user in user_permissions %}
+  <div>
+    {{ user }}
+    <select multiple name="user_permissions_{{ user }}">
+      {% for action in actions %}
+        <option value="{{ action }}" {% if user_permissions and user_permissions.get(user, {}).get(action) %}selected{% endif %}>{{ action }}</option>
+      {% endfor %}
+    </select>
+  </div>
+{% endfor %}
+
+<div style="margin-top: 2em">
+  <label for="id_new_actor_id" style="display: block; font-size: 0.8em">Other user:</label>
+  {% if valid_actors %}
+    <select id="id_new_actor_id" name="new_actor_id">
+      <option></option>
+      {% for actor in valid_actors %}
+        <option value="{{ actor[0] }}">{{ actor[1] }}</option>
+      {% endfor %}
+    </select>
+  {% else %}
+    <input data-1p-ignore placeholder="User ID" style="width: 8em" id="id_new_actor_id" name="new_actor_id">
+  {% endif %}
+</div>
+
+<div>
+  <label for="id_new_user_actions" style="display: block; font-size: 0.8em">Permissions for the additional user:</label>
+  <select multiple name="new_user_actions" id="id_new_user_actions">
+    {% for action in actions %}
+      <option value="{{ action }}">{{ action }}</option>
+    {% endfor %}
+  </select>
+</div>
+
+<p style="margin-top: 1em">
+  <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+  <input type="submit" value="Save changes" class="core">
+  <span id="needs-save-message"></span>
+</p>
+</form>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const selects = document.querySelectorAll('select');
+    selects.forEach(select => {
+        new Choices(select, {
+            removeItemButton: true,
+            containerOuter: 'choices'
+        });
+    });
+});
+</script>
+
+{% if audit_log %}
+<h2>Audit history</h2>
+<table class="audit">
+  <thead>
+    <tr>
+      <th>Date and time</th>
+      <th>Operation by</th>
+      <th>Operation</th>
+      <th>Group</th>
+      <th>User</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for entry in audit_log %}
+      <tr>
+        <td>{{ entry.timestamp }}</td>
+        <td>{{ entry.operation_by }}</td>
+        <td>{{ entry.operation }}</td>
+        <td>{{ entry.group_name or '' }}</td>
+        <td>{{ entry.actor_id or '' }}</td>
+        <td>{{ entry.action_name }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+<script>
+// "You have unsaved changes" message
+const initialState = {};
+const checkboxes = document.querySelectorAll('table input[type="checkbox"]');
+const messageElement = document.getElementById("needs-save-message");
+
+function updateInitialState() {
+  checkboxes.forEach((checkbox) => {
+    initialState[checkbox.name] = checkbox.checked;
+  });
+}
+
+function hasStateChanged() {
+  return Array.from(checkboxes).some(
+    (checkbox) => initialState[checkbox.name] !== checkbox.checked,
+  );
+}
+
+function updateMessage() {
+  if (hasStateChanged()) {
+    messageElement.textContent = "You have unsaved changes";
+    messageElement.classList.add("visible");
+  } else {
+    messageElement.classList.remove("visible");
+    setTimeout(() => {
+      if (!hasStateChanged()) {
+        messageElement.textContent = "";
+      }
+    }, 500);
+  }
+}
+
+updateInitialState();
+
+checkboxes.forEach((checkbox) => {
+  checkbox.addEventListener("change", updateMessage);
+});
+</script>
+
+{% endblock %}

--- a/datasette_acl/utils.py
+++ b/datasette_acl/utils.py
@@ -7,6 +7,30 @@ async def can_edit_permissions(datasette, actor):
     return await datasette.allowed(actor=actor, action="datasette-acl")
 
 
+def resource_class_for(datasette, resource_type):
+    """Return the Resource subclass whose .name == resource_type, or None.
+
+    Resource types are discovered from registered actions (datasette.actions),
+    so any plugin that registers actions with a resource_class is manageable by
+    acl without a dedicated hook.
+    """
+    for action in datasette.actions.values():
+        rc = action.resource_class
+        if rc is not None and rc.name == resource_type:
+            return rc
+    return None
+
+
+def actions_for_resource_type(datasette, resource_type):
+    """Action names whose resource_class.name == resource_type, in registration order."""
+    return [
+        action.name
+        for action in datasette.actions.values()
+        if action.resource_class is not None
+        and action.resource_class.name == resource_type
+    ]
+
+
 def generate_changes_message(changes_made, noun):
     messages = []
     for action, changes in changes_made.items():

--- a/datasette_acl/utils.py
+++ b/datasette_acl/utils.py
@@ -31,6 +31,31 @@ def actions_for_resource_type(datasette, resource_type):
     ]
 
 
+def build_resource(datasette, resource_type, parent, child=None):
+    """Build a core ``Resource`` instance for ``(resource_type, parent, child)``.
+
+    The acl JSON API and consumer data-migrations receive resources as strings
+    but ``datasette.allowed()`` needs a ``Resource`` instance. We discover the
+    resource class from the registered actions (see ``resource_class_for``) and
+    construct it.
+
+    Constructor convention: ``Resource.__init__(parent, child)`` accepts both
+    positionally. A 2-level resource type (``parent_class`` set, e.g. a table
+    inside a database) is built as ``rc(parent, child)``; a parent-only type
+    (``parent_class is None``) is built as ``rc(parent)``. Consumers whose
+    constructors do not follow this positional convention should add a
+    ``from_parent_child`` classmethod (none do today).
+
+    Raises ``ValueError`` if ``resource_type`` is unknown.
+    """
+    rc = resource_class_for(datasette, resource_type)
+    if rc is None:
+        raise ValueError(f"Unknown resource type: {resource_type}")
+    if rc.parent_class is not None:
+        return rc(parent, child)
+    return rc(parent)
+
+
 def generate_changes_message(changes_made, noun):
     messages = []
     for action, changes in changes_made.items():

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -14,16 +14,37 @@ to a name + member count from ``acl_groups`` / ``acl_actor_groups``. Wildcard
 principals (``*`` / ``_signed_in`` / ``_anonymous``) are flagged ``kind:"public"``
 and surface in the dialog's "General access" section.
 
-Per-resource authorization (the manage check) is formalized in task 04. Until
-then ``can_manage`` is computed here from either the global ``datasette-acl``
-permission OR the per-resource manage action (via the roles registry); the read
-endpoint is gated on ``can_manage``.
+Task 04 adds the *write* side — three JSON POST endpoints, each authorized by a
+**per-resource** manage check rather than a global flag:
+
+    POST /-/acl/api/resource/{resource_type}/{parent}/{child}/grant
+    POST .../revoke
+    POST .../update
+
+``can_manage`` (and its raising sibling ``_ensure_can_manage``) is the
+authoritative authz gate: an actor may manage sharing if EITHER they hold the
+global ``datasette-acl`` permission (admin) OR they are ``datasette.allowed`` a
+``manage=True`` role's action on *this specific resource* (i.e. they hold a
+Manager/Owner grant — which itself flows through the same acl machinery, so it
+composes with groups). A resource type that registers no ``manage`` role falls
+back to the global ``datasette-acl`` permission, so table-style resources still
+work.
+
+CSRF: datasette 1.0a30 replaced token-based asgi-csrf with the header-based
+``CrossOriginProtectionMiddleware`` (Sec-Fetch-Site + Origin). That core
+middleware rejects cross-origin browser writes before they reach these
+handlers, so the endpoints carry no server-side CSRF token logic of their own;
+the share component sends same-origin requests (and may set ``x-csrftoken`` for
+forward compat, which core ignores). Non-browser clients (the test client,
+curl) send neither header and pass through.
 """
+
+import json
 
 from datasette import Response, Forbidden
 
-from datasette_acl.grants import list_grants
-from datasette_acl.roles import role_for_actions, manage_actions
+from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.roles import role_for_actions, manage_only_actions
 from datasette_acl.utils import build_resource, resource_class_for, can_edit_permissions
 
 # Wildcard / "general access" principals. These are stored as actor_id values in
@@ -57,19 +78,30 @@ def _roles_payload(roles):
 async def can_manage(datasette, actor, resource_type, parent, child=None):
     """Whether ``actor`` may manage sharing for this resource.
 
-    Task 04 will own the authoritative per-resource manage check; this is the
-    forward-compatible version it will build on. An actor can manage if EITHER:
+    The authoritative per-resource manage check (task 04). An actor can manage
+    if EITHER:
 
-      * they hold the global ``datasette-acl`` permission (admin), OR
-      * they are allowed the resource type's "manage" action on this specific
-        resource (i.e. they hold a ``manage=True`` role grant).
+      * they are ``datasette.allowed`` one of the resource type's *manage-only*
+        actions on this specific resource — i.e. they hold a ``manage=True``
+        role grant (Manager/Owner), which flows through the same acl machinery
+        and so composes with groups; OR
+      * the resource type registers no ``manage`` role, in which case we fall
+        back to the global ``datasette-acl`` permission so table-style resources
+        (which only have raw actions, no roles) still work.
+
+    The manage check authorizes against :func:`manage_only_actions` (the action
+    exclusive to manage roles, e.g. ``paper-manage``) rather than the full
+    Manager action bundle — otherwise any Viewer/Editor, who also holds
+    ``*-view``, would pass. The global ``datasette-acl`` admin always wins.
 
     Returns False (rather than raising) for unknown resource types.
     """
     if await can_edit_permissions(datasette, actor):
         return True
-    manage = manage_actions(_roles_for(datasette, resource_type))
+    manage = manage_only_actions(_roles_for(datasette, resource_type))
     if not manage:
+        # No manage role for this type: fall back to global admin (already
+        # checked above and was False), so non-admins cannot manage.
         return False
     try:
         resource = build_resource(datasette, resource_type, parent, child)
@@ -79,6 +111,18 @@ async def can_manage(datasette, actor, resource_type, parent, child=None):
         if await datasette.allowed(action=action, resource=resource, actor=actor):
             return True
     return False
+
+
+async def _ensure_can_manage(datasette, request, resource_type, parent, child=None):
+    """Raise ``Forbidden`` unless ``request.actor`` may manage this resource.
+
+    The authoritative per-resource authz gate for the mutation endpoints: it
+    delegates to :func:`can_manage` (global ``datasette-acl`` perm OR a
+    per-resource ``manage=True`` role action) and raises rather than returning a
+    bool so handlers can guard with a single ``await``.
+    """
+    if not await can_manage(datasette, request.actor, resource_type, parent, child):
+        raise Forbidden("Cannot manage sharing for this resource")
 
 
 def _kind_for(actor_id, enriched):
@@ -117,6 +161,79 @@ async def _group_info(datasette, group_ids):
         row["id"]: {"name": row["name"], "member_count": row["member_count"]}
         for row in rows.rows
     }
+
+
+async def _actor_grant_entry(datasette, roles, actor_id, actions):
+    """Build the enriched API entry for one actor-principal grant.
+
+    Resolves the granted action-set to its best role, enriches via core
+    ``actors_from_ids`` (skipped for wildcard principals), and tags ``kind``.
+    """
+    role = role_for_actions(roles, set(actions))
+    enriched = {}
+    if actor_id not in PUBLIC_PRINCIPALS:
+        enriched = (await datasette.actors_from_ids([actor_id])) or {}
+    info = enriched.get(actor_id) or {}
+    entry = {
+        "principal": "actor",
+        "id": actor_id,
+        "role": role.name if role else None,
+        "actions": sorted(actions),
+        "kind": _kind_for(actor_id, info),
+    }
+    for key in ("display_name", "email", "avatar_url"):
+        if info.get(key):
+            entry[key] = info[key]
+    return entry
+
+
+async def _group_grant_entry(datasette, roles, group_id, actions):
+    """Build the enriched API entry for one group-principal grant."""
+    role = role_for_actions(roles, set(actions))
+    info = (await _group_info(datasette, [group_id])).get(group_id, {})
+    return {
+        "principal": "group",
+        "id": str(group_id),
+        "role": role.name if role else None,
+        "actions": sorted(actions),
+        "kind": "group",
+        "display_name": info.get("name"),
+        "member_count": info.get("member_count", 0),
+    }
+
+
+def _principal_from_body(body):
+    """Extract ``(actor_id, group_id)`` from a request body, enforcing exactly one.
+
+    Returns ``(actor_id, group_id)`` with exactly one non-None. Raises
+    ``ValueError`` if neither or both are supplied (mirrors the acl CHECK
+    invariant) so handlers can translate it to a 400.
+    """
+    actor_id = body.get("actor_id")
+    group_id = body.get("group_id")
+    if (actor_id is None) == (group_id is None):
+        raise ValueError("Provide exactly one of actor_id or group_id")
+    return actor_id, group_id
+
+
+def _parse_json_body(request_body):
+    """Parse the raw POST body as a JSON object, or raise ``ValueError``."""
+    if not request_body:
+        return {}
+    try:
+        data = json.loads(request_body)
+    except json.JSONDecodeError:
+        raise ValueError("Request body must be valid JSON")
+    if not isinstance(data, dict):
+        raise ValueError("Request body must be a JSON object")
+    return data
+
+
+async def _enriched_grant(datasette, roles, actor_id, group_id, actions):
+    """Build the enriched grant entry for whichever principal was supplied."""
+    if actor_id is not None:
+        return await _actor_grant_entry(datasette, roles, actor_id, actions)
+    return await _group_grant_entry(datasette, roles, group_id, actions)
 
 
 async def resource_grants_json(request, datasette):
@@ -196,3 +313,134 @@ async def resource_grants_json(request, datasette):
             "grants": grants,
         }
     )
+
+
+class _ApiError(Exception):
+    """Carries an HTTP status + message for a JSON error response."""
+
+    def __init__(self, status, message):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+def _error_response(exc):
+    return Response.json({"ok": False, "error": exc.message}, status=exc.status)
+
+
+async def _begin_mutation(request, datasette):
+    """Shared preamble for the mutation endpoints.
+
+    Enforces POST, a known resource type, and the per-resource manage gate, then
+    parses the JSON body. Returns ``(resource_type, parent, child, roles,
+    body)``. Raises ``Forbidden`` (403) for the authz / unknown-type cases
+    (handled by core) and ``_ApiError`` for a bad method (405) or unparseable
+    body (400), which each handler catches and renders as a JSON error response.
+    """
+    if request.method != "POST":
+        raise _ApiError(405, "Method not allowed")
+    resource_type = request.url_vars["resource_type"]
+    parent = request.url_vars["parent"]
+    child = request.url_vars.get("child")
+    if resource_class_for(datasette, resource_type) is None:
+        raise Forbidden(f"Unknown resource type: {resource_type}")
+    # Per-resource authorization — the correctness fix over a global flag.
+    await _ensure_can_manage(datasette, request, resource_type, parent, child)
+    try:
+        body = _parse_json_body(await request.post_body())
+    except ValueError as exc:
+        raise _ApiError(400, str(exc))
+    roles = _roles_for(datasette, resource_type)
+    return resource_type, parent, child, roles, body
+
+
+async def grant_json(request, datasette):
+    """POST /-/acl/api/resource/{type}/{parent}/{child}/grant.
+
+    Body: ``{actor_id|group_id, role}`` or ``{actor_id|group_id, actions: [...]}``.
+    Upserts the grant (idempotent), audits, and returns the enriched grant.
+    """
+    try:
+        resource_type, parent, child, roles, body = await _begin_mutation(
+            request, datasette
+        )
+        actor_id, group_id = _principal_from_body(body)
+        by_actor = (request.actor or {}).get("id")
+        actions = await grant(
+            datasette,
+            resource_type,
+            parent,
+            child,
+            actor_id=actor_id,
+            group_id=group_id,
+            role=body.get("role"),
+            actions=body.get("actions"),
+            by_actor=by_actor,
+        )
+    except _ApiError as exc:
+        return _error_response(exc)
+    except ValueError as exc:
+        return _error_response(_ApiError(400, str(exc)))
+    entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
+    return Response.json({"ok": True, "grant": entry})
+
+
+async def revoke_json(request, datasette):
+    """POST /-/acl/api/resource/{type}/{parent}/{child}/revoke.
+
+    Body: ``{actor_id}`` or ``{group_id}``. Deletes all acl rows for that
+    principal on this resource, audits each removal, returns ``{ok: true}``.
+    """
+    try:
+        resource_type, parent, child, roles, body = await _begin_mutation(
+            request, datasette
+        )
+        actor_id, group_id = _principal_from_body(body)
+        by_actor = (request.actor or {}).get("id")
+        removed = await revoke(
+            datasette,
+            resource_type,
+            parent,
+            child,
+            actor_id=actor_id,
+            group_id=group_id,
+            by_actor=by_actor,
+        )
+    except _ApiError as exc:
+        return _error_response(exc)
+    except ValueError as exc:
+        return _error_response(_ApiError(400, str(exc)))
+    return Response.json({"ok": True, "removed": removed})
+
+
+async def update_json(request, datasette):
+    """POST /-/acl/api/resource/{type}/{parent}/{child}/update.
+
+    Body: ``{actor_id|group_id, role}``. Atomically swaps the principal's action
+    set to the new role, audits each change, and returns the enriched grant.
+    """
+    try:
+        resource_type, parent, child, roles, body = await _begin_mutation(
+            request, datasette
+        )
+        actor_id, group_id = _principal_from_body(body)
+        role = body.get("role")
+        if not role:
+            raise _ApiError(400, "update requires a role")
+        by_actor = (request.actor or {}).get("id")
+        actions = await update_role(
+            datasette,
+            resource_type,
+            parent,
+            child,
+            actor_id=actor_id,
+            group_id=group_id,
+            role=role,
+            by_actor=by_actor,
+        )
+    except _ApiError as exc:
+        return _error_response(exc)
+    except ValueError as exc:
+        return _error_response(_ApiError(400, str(exc)))
+    entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
+    return Response.json({"ok": True, "grant": entry})

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -402,20 +402,45 @@ async def grant_json(request, datasette):
 #     ``datasette_acl_valid_actors`` in Python, so the picker still works on an
 #     acl-only deployment (plan §C).
 #
-# Both gate on the global ``datasette-acl`` permission: listing every group /
-# directory actor is an admin-directory read, not a per-resource share read.
-# (The per-resource grant list endpoint above has its own per-resource gate.)
+# Authorization: the share dialog is driven by per-resource Managers (a doc
+# owner) who don't hold the global ``datasette-acl`` admin permission, so the
+# pickers accept OPTIONAL ``resource_type`` / ``parent`` / ``child`` query
+# params. When supplied, the request is authorized via the same per-resource
+# :func:`can_manage` gate the read + mutation endpoints use (global admin OR a
+# ``manage=True`` role action on that specific resource). When omitted, we fall
+# back to the global ``datasette-acl`` permission (back-compat for acl's own
+# admin pages). Neither passing → ``Forbidden``.
+
+
+async def _ensure_can_pick(datasette, request, message):
+    """Authorize a picker request.
+
+    If ``resource_type`` / ``parent`` (+ optional ``child``) query params are
+    present, authorize against the per-resource :func:`can_manage` gate.
+    Otherwise fall back to the global ``datasette-acl`` admin check. Raises
+    ``Forbidden(message)`` when neither passes.
+    """
+    resource_type = request.args.get("resource_type")
+    parent = request.args.get("parent")
+    if resource_type and parent:
+        child = request.args.get("child")
+        if await can_manage(datasette, request.actor, resource_type, parent, child):
+            return
+        raise Forbidden(message)
+    if await can_edit_permissions(datasette, request.actor):
+        return
+    raise Forbidden(message)
 
 
 async def groups_json(request, datasette):
-    """GET /-/acl/api/groups.
+    """GET /-/acl/api/groups[?resource_type=&parent=&child=].
 
     Returns ``{"groups": [{"id", "name", "member_count"}]}`` for every active
-    (non soft-deleted) group, with a member-count subquery. Gated by the global
-    ``datasette-acl`` permission.
+    (non soft-deleted) group, with a member-count subquery. Authorized per
+    :func:`_ensure_can_pick`: a per-resource Manager (when the resource is
+    supplied) or the global ``datasette-acl`` admin.
     """
-    if not await can_edit_permissions(datasette, request.actor):
-        raise Forbidden("Cannot list groups")
+    await _ensure_can_pick(datasette, request, "Cannot list groups")
     db = datasette.get_internal_database()
     rows = await db.execute(
         """
@@ -490,15 +515,16 @@ async def _valid_actors_fallback(datasette, q):
 
 
 async def actors_json(request, datasette):
-    """GET /-/acl/api/actors?q=&kind=.
+    """GET /-/acl/api/actors?q=&kind=[&resource_type=&parent=&child=].
 
     Thin actor-autocomplete proxy. Delegates to the user-profiles search API
     when available, else falls back to ``datasette_acl_valid_actors`` filtered by
     ``q`` in Python. Returns ``{"results": [{"id", "display_name", "avatar_url",
-    "kind", ...}]}``. Gated by the global ``datasette-acl`` permission.
+    "kind", ...}]}``. Authorized per :func:`_ensure_can_pick`: a per-resource
+    Manager (when the resource is supplied) or the global ``datasette-acl``
+    admin.
     """
-    if not await can_edit_permissions(datasette, request.actor):
-        raise Forbidden("Cannot search actors")
+    await _ensure_can_pick(datasette, request, "Cannot search actors")
     q = (request.args.get("q") or "").strip()
     kind = request.args.get("kind")
     results = await _profiles_search(datasette, q, kind)

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -462,7 +462,7 @@ async def groups_json(request, datasette):
     return Response.json({"groups": groups})
 
 
-async def _profiles_search(datasette, q, kind):
+async def _profiles_search(datasette, q, kind, actor):
     """Delegate the actor search to user-profiles' search API, if installed.
 
     Issues an internal request to ``GET /-/profiles/api/search`` (carrying the
@@ -470,6 +470,13 @@ async def _profiles_search(datasette, q, kind):
     is not installed / the route is absent (so the caller falls back). Any error
     response (e.g. 403) is treated as "no results" rather than propagated, since
     this is an autocomplete helper.
+
+    ``actor`` is the caller's actor. The internal ``datasette.client`` request is
+    otherwise anonymous, so profiles' ``profile_access`` gate would 403 it and we
+    would silently return no results. We forward the caller's identity via the
+    ``actor=`` kwarg, which signs a ``ds_actor`` cookie for the internal request,
+    so the gate evaluates against the real caller (just as the share dialog's
+    direct browser call does).
     """
     params = {}
     if q:
@@ -478,7 +485,9 @@ async def _profiles_search(datasette, q, kind):
         params["kind"] = kind
     try:
         response = await datasette.client.get(
-            datasette.urls.path("/-/profiles/api/search"), params=params
+            datasette.urls.path("/-/profiles/api/search"),
+            params=params,
+            actor=actor,
         )
     except Exception:
         return None
@@ -527,7 +536,7 @@ async def actors_json(request, datasette):
     await _ensure_can_pick(datasette, request, "Cannot search actors")
     q = (request.args.get("q") or "").strip()
     kind = request.args.get("kind")
-    results = await _profiles_search(datasette, q, kind)
+    results = await _profiles_search(datasette, q, kind, request.actor)
     if results is None:
         results = await _valid_actors_fallback(datasette, q)
     return Response.json({"results": results})

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -45,7 +45,12 @@ from datasette import Response, Forbidden
 
 from datasette_acl.grants import grant, revoke, update_role, list_grants
 from datasette_acl.roles import role_for_actions, manage_only_actions
-from datasette_acl.utils import build_resource, resource_class_for, can_edit_permissions
+from datasette_acl.utils import (
+    build_resource,
+    resource_class_for,
+    can_edit_permissions,
+    get_acl_valid_actors,
+)
 
 # Wildcard / "general access" principals. These are stored as actor_id values in
 # acl rows but represent classes of actor rather than a specific person, so the
@@ -383,6 +388,123 @@ async def grant_json(request, datasette):
         return _error_response(_ApiError(400, str(exc)))
     entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
     return Response.json({"ok": True, "grant": entry})
+
+
+# --- pickers ---------------------------------------------------------------
+#
+# The share dialog needs to populate the "add a person / group" boxes. Two
+# decoupled endpoints back that:
+#
+#   GET /-/acl/api/groups          -> the group picker, drawn from acl_groups.
+#   GET /-/acl/api/actors?q=&kind= -> the actor picker. The dialog MAY call the
+#     user-profiles search API directly; this endpoint is the decoupled fallback
+#     that delegates to profiles when installed and otherwise filters acl's own
+#     ``datasette_acl_valid_actors`` in Python, so the picker still works on an
+#     acl-only deployment (plan §C).
+#
+# Both gate on the global ``datasette-acl`` permission: listing every group /
+# directory actor is an admin-directory read, not a per-resource share read.
+# (The per-resource grant list endpoint above has its own per-resource gate.)
+
+
+async def groups_json(request, datasette):
+    """GET /-/acl/api/groups.
+
+    Returns ``{"groups": [{"id", "name", "member_count"}]}`` for every active
+    (non soft-deleted) group, with a member-count subquery. Gated by the global
+    ``datasette-acl`` permission.
+    """
+    if not await can_edit_permissions(datasette, request.actor):
+        raise Forbidden("Cannot list groups")
+    db = datasette.get_internal_database()
+    rows = await db.execute(
+        """
+        SELECT
+            acl_groups.id AS id,
+            acl_groups.name AS name,
+            count(acl_actor_groups.actor_id) AS member_count
+        FROM acl_groups
+        LEFT JOIN acl_actor_groups ON acl_groups.id = acl_actor_groups.group_id
+        WHERE acl_groups.deleted IS NULL
+        GROUP BY acl_groups.id, acl_groups.name
+        ORDER BY acl_groups.name
+        """
+    )
+    groups = [
+        {"id": row["id"], "name": row["name"], "member_count": row["member_count"]}
+        for row in rows.rows
+    ]
+    return Response.json({"groups": groups})
+
+
+async def _profiles_search(datasette, q, kind):
+    """Delegate the actor search to user-profiles' search API, if installed.
+
+    Issues an internal request to ``GET /-/profiles/api/search`` (carrying the
+    same query). Returns the parsed ``results`` list, or ``None`` when profiles
+    is not installed / the route is absent (so the caller falls back). Any error
+    response (e.g. 403) is treated as "no results" rather than propagated, since
+    this is an autocomplete helper.
+    """
+    params = {}
+    if q:
+        params["q"] = q
+    if kind:
+        params["kind"] = kind
+    try:
+        response = await datasette.client.get(
+            datasette.urls.path("/-/profiles/api/search"), params=params
+        )
+    except Exception:
+        return None
+    if response.status_code == 404:
+        return None
+    if response.status_code != 200:
+        return []
+    try:
+        data = response.json()
+    except Exception:
+        return []
+    return data.get("results", [])
+
+
+async def _valid_actors_fallback(datasette, q):
+    """Filter ``datasette_acl_valid_actors`` by ``q`` (substring, case-insensitive).
+
+    The acl-only fallback when user-profiles is not installed. ``valid_actors``
+    yields ``(id, display)`` pairs with no avatar/email, so the entries are
+    minimal: ``{"id", "display_name", "kind": "user"}``.
+    """
+    actors = await get_acl_valid_actors(datasette)
+    needle = (q or "").lower()
+    results = []
+    for actor_id, display in actors:
+        if needle and needle not in actor_id.lower() and needle not in (
+            display or ""
+        ).lower():
+            continue
+        results.append(
+            {"id": actor_id, "display_name": display, "kind": "user"}
+        )
+    return results
+
+
+async def actors_json(request, datasette):
+    """GET /-/acl/api/actors?q=&kind=.
+
+    Thin actor-autocomplete proxy. Delegates to the user-profiles search API
+    when available, else falls back to ``datasette_acl_valid_actors`` filtered by
+    ``q`` in Python. Returns ``{"results": [{"id", "display_name", "avatar_url",
+    "kind", ...}]}``. Gated by the global ``datasette-acl`` permission.
+    """
+    if not await can_edit_permissions(datasette, request.actor):
+        raise Forbidden("Cannot search actors")
+    q = (request.args.get("q") or "").strip()
+    kind = request.args.get("kind")
+    results = await _profiles_search(datasette, q, kind)
+    if results is None:
+        results = await _valid_actors_fallback(datasette, q)
+    return Response.json({"results": results})
 
 
 async def revoke_json(request, datasette):

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -1,0 +1,198 @@
+"""JSON API for datasette-acl (the share component's backend).
+
+acl was form-POST only; this is the first JSON endpoint. Task 03 adds the
+*read* side:
+
+    GET /-/acl/api/resource/{resource_type}/{parent}/{child}
+
+returning the share state for one resource — the dialog's main read. Grants are
+grouped by principal, each principal's granted action-set is resolved to a
+friendly role, and actor grants are enriched with display name / email / avatar
+via core ``datasette.actors_from_ids`` (owned by user-profiles in phase-03;
+degrades to ``{"id": id}`` when profiles is not installed). Group grants resolve
+to a name + member count from ``acl_groups`` / ``acl_actor_groups``. Wildcard
+principals (``*`` / ``_signed_in`` / ``_anonymous``) are flagged ``kind:"public"``
+and surface in the dialog's "General access" section.
+
+Per-resource authorization (the manage check) is formalized in task 04. Until
+then ``can_manage`` is computed here from either the global ``datasette-acl``
+permission OR the per-resource manage action (via the roles registry); the read
+endpoint is gated on ``can_manage``.
+"""
+
+from datasette import Response, Forbidden
+
+from datasette_acl.grants import list_grants
+from datasette_acl.roles import role_for_actions, manage_actions
+from datasette_acl.utils import build_resource, resource_class_for, can_edit_permissions
+
+# Wildcard / "general access" principals. These are stored as actor_id values in
+# acl rows but represent classes of actor rather than a specific person, so the
+# UI renders them in a separate "General access" section.
+PUBLIC_PRINCIPALS = {"*", "_signed_in", "_anonymous"}
+
+
+def _roles_for(datasette, resource_type):
+    registry = getattr(datasette, "_acl_roles_registry", None) or {}
+    return registry.get(resource_type, [])
+
+
+def _roles_payload(roles):
+    """Serialize the roles registry for a resource type to the API shape."""
+    payload = []
+    for role in roles:
+        entry = {
+            "name": role.name,
+            "actions": list(role.actions),
+            "rank": role.rank,
+        }
+        if role.manage:
+            entry["manage"] = True
+        if role.description:
+            entry["description"] = role.description
+        payload.append(entry)
+    return payload
+
+
+async def can_manage(datasette, actor, resource_type, parent, child=None):
+    """Whether ``actor`` may manage sharing for this resource.
+
+    Task 04 will own the authoritative per-resource manage check; this is the
+    forward-compatible version it will build on. An actor can manage if EITHER:
+
+      * they hold the global ``datasette-acl`` permission (admin), OR
+      * they are allowed the resource type's "manage" action on this specific
+        resource (i.e. they hold a ``manage=True`` role grant).
+
+    Returns False (rather than raising) for unknown resource types.
+    """
+    if await can_edit_permissions(datasette, actor):
+        return True
+    manage = manage_actions(_roles_for(datasette, resource_type))
+    if not manage:
+        return False
+    try:
+        resource = build_resource(datasette, resource_type, parent, child)
+    except ValueError:
+        return False
+    for action in manage:
+        if await datasette.allowed(action=action, resource=resource, actor=actor):
+            return True
+    return False
+
+
+def _kind_for(actor_id, enriched):
+    """Resolve the ``kind`` for an actor-principal grant.
+
+    Wildcard principals are ``public``. Otherwise prefer a ``kind`` supplied by
+    the actor-resolution layer (profiles / agents); default to ``user``.
+    """
+    if actor_id in PUBLIC_PRINCIPALS:
+        return "public"
+    if enriched and enriched.get("kind"):
+        return enriched["kind"]
+    return "user"
+
+
+async def _group_info(datasette, group_ids):
+    """Return ``{group_id: {"name", "member_count"}}`` for the given ids."""
+    if not group_ids:
+        return {}
+    db = datasette.get_internal_database()
+    placeholders = ", ".join("?" for _ in group_ids)
+    rows = await db.execute(
+        f"""
+        SELECT
+            acl_groups.id AS id,
+            acl_groups.name AS name,
+            count(acl_actor_groups.actor_id) AS member_count
+        FROM acl_groups
+        LEFT JOIN acl_actor_groups ON acl_groups.id = acl_actor_groups.group_id
+        WHERE acl_groups.id IN ({placeholders})
+        GROUP BY acl_groups.id, acl_groups.name
+        """,
+        list(group_ids),
+    )
+    return {
+        row["id"]: {"name": row["name"], "member_count": row["member_count"]}
+        for row in rows.rows
+    }
+
+
+async def resource_grants_json(request, datasette):
+    """GET /-/acl/api/resource/{resource_type}/{parent}/{child}.
+
+    The child segment is optional so parent-only resource types also resolve.
+    """
+    resource_type = request.url_vars["resource_type"]
+    parent = request.url_vars["parent"]
+    child = request.url_vars.get("child")
+
+    if resource_class_for(datasette, resource_type) is None:
+        raise Forbidden(f"Unknown resource type: {resource_type}")
+
+    # Gate: for v1 the full grant list is readable only by managers.
+    actor_can_manage = await can_manage(
+        datasette, request.actor, resource_type, parent, child
+    )
+    if not actor_can_manage:
+        raise Forbidden("Cannot manage sharing for this resource")
+
+    roles = _roles_for(datasette, resource_type)
+    raw_grants = await list_grants(datasette, resource_type, parent, child)
+
+    # Enrich actor grants in one batch via core actors_from_ids. Wildcard
+    # principals are not real actors; we never look them up.
+    actor_ids = [
+        g["actor_id"]
+        for g in raw_grants
+        if g["principal"] == "actor" and g["actor_id"] not in PUBLIC_PRINCIPALS
+    ]
+    enriched = {}
+    if actor_ids:
+        enriched = await datasette.actors_from_ids(actor_ids) or {}
+
+    group_ids = [g["group_id"] for g in raw_grants if g["principal"] == "group"]
+    group_info = await _group_info(datasette, group_ids)
+
+    grants = []
+    for g in raw_grants:
+        role = role_for_actions(roles, set(g["actions"]))
+        if g["principal"] == "actor":
+            actor_id = g["actor_id"]
+            entry = {
+                "principal": "actor",
+                "id": actor_id,
+                "role": role.name if role else None,
+                "actions": g["actions"],
+                "kind": _kind_for(actor_id, enriched.get(actor_id)),
+            }
+            info = enriched.get(actor_id) or {}
+            for key in ("display_name", "email", "avatar_url"):
+                if info.get(key):
+                    entry[key] = info[key]
+            grants.append(entry)
+        else:
+            info = group_info.get(g["group_id"], {})
+            grants.append(
+                {
+                    "principal": "group",
+                    "id": str(g["group_id"]),
+                    "role": role.name if role else None,
+                    "actions": g["actions"],
+                    "kind": "group",
+                    "display_name": info.get("name", g["group_name"]),
+                    "member_count": info.get("member_count", 0),
+                }
+            )
+
+    return Response.json(
+        {
+            "resource_type": resource_type,
+            "parent": parent,
+            "child": child,
+            "can_manage": actor_can_manage,
+            "roles": _roles_payload(roles),
+            "grants": grants,
+        }
+    )

--- a/datasette_acl/views/resource_acls.py
+++ b/datasette_acl/views/resource_acls.py
@@ -1,52 +1,51 @@
 from datasette import Response, Forbidden
-from datasette.resources import TableResource
-from datasette.utils import MultiParams
 from datasette_acl.utils import (
+    actions_for_resource_type,
     can_edit_permissions,
     generate_changes_message,
     get_acl_valid_actors,
+    resource_class_for,
     validate_actor_id,
 )
+from datasette.utils import MultiParams
 from urllib.parse import parse_qs
 
 
-def table_actions_list(datasette):
-    """Action names whose resource_class is (a subclass of) TableResource.
-
-    Discovered dynamically from datasette.actions rather than hardcoded, so any
-    plugin that registers table-scoped actions is managed here automatically.
-    """
-    return [
-        action.name
-        for action in datasette.actions.values()
-        if action.resource_class is not None
-        and issubclass(action.resource_class, TableResource)
-    ]
-
-
-async def manage_table_acls(request, datasette):
+async def manage_resource_acls(request, datasette):
+    # Admin page: gated on the global datasette-acl permission. Per-resource
+    # authorization (who may manage a specific resource) arrives with the JSON
+    # API in phase-02.
     if not await can_edit_permissions(datasette, request.actor):
         raise Forbidden("You do not have permission to edit permissions")
-    table = request.url_vars["table"]
-    database = request.url_vars["database"]
-    actions = table_actions_list(datasette)
+
+    resource_type = request.url_vars["resource_type"]
+    parent = request.url_vars["parent"]
+    child = request.url_vars.get("child")
+
+    # The resource type must correspond to a known, action-bearing resource
+    # class, otherwise there is nothing to manage.
+    if resource_class_for(datasette, resource_type) is None:
+        raise Forbidden(f"Unknown resource type: {resource_type}")
+
+    actions = actions_for_resource_type(datasette, resource_type)
+
     internal_db = datasette.get_internal_database()
     groups = [
         g["name"]
-        for g in await datasette.get_internal_database().execute(
+        for g in await internal_db.execute(
             "select name from acl_groups where deleted is null"
         )
     ]
 
-    # Ensure we have a resource_id for this table
+    # Ensure we have a resource_id for this resource
     await internal_db.execute_write(
-        "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES ('table', ?, ?);",
-        [database, table],
+        "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES (?, ?, ?);",
+        [resource_type, parent, child],
     )
     resource_id = (
         await internal_db.execute(
-            "SELECT id FROM acl_resources WHERE resource_type = 'table' AND parent = ? AND child = ?",
-            [database, table],
+            "SELECT id FROM acl_resources WHERE resource_type = ? AND parent = ? AND child IS ?",
+            [resource_type, parent, child],
         )
     ).single_value()
 
@@ -71,7 +70,6 @@ async def manage_table_acls(request, datasette):
         action_name = row["action_name"]
         if group_name:
             current_group_permissions.setdefault(group_name, {})[action_name] = True
-            current_group_permissions[group_name][action_name] = True
         else:
             assert actor_id
             current_user_permissions.setdefault(actor_id, {})[action_name] = True
@@ -93,7 +91,6 @@ async def manage_table_acls(request, datasette):
                 )
                 if new_value != current_value:
                     if new_value:
-                        # They added it, add the record
                         await internal_db.execute_write(
                             """
                             INSERT INTO acl (actor_id, group_id, resource_id, action_id)
@@ -113,11 +110,10 @@ async def manage_table_acls(request, datasette):
                         operation = "added"
                         group_changes_made["added"].append((group_name, action_name))
                     else:
-                        # They removed it
                         await internal_db.execute_write(
                             """
                             delete from acl where
-                                actor_id is null and 
+                                actor_id is null and
                                 group_id = (SELECT id FROM acl_groups WHERE name = :group_name)
                                 and resource_id = :resource_id
                                 and action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
@@ -159,7 +155,6 @@ async def manage_table_acls(request, datasette):
         user_changes_made = {"added": [], "removed": []}
         for actor_id in list(current_user_permissions) + [None]:
             if actor_id is None:
-                # This is the special case for new_user_{{ action }}
                 actor_id = (post_vars.get("new_actor_id") or "").strip()
                 if not actor_id:
                     continue
@@ -181,7 +176,6 @@ async def manage_table_acls(request, datasette):
                 )
                 if new_value != current_value:
                     if new_value:
-                        # They added the permission
                         await internal_db.execute_write(
                             """
                             insert into acl (actor_id, group_id, resource_id, action_id)
@@ -201,7 +195,6 @@ async def manage_table_acls(request, datasette):
                         operation = "added"
                         user_changes_made["added"].append((actor_id, action_name))
                     else:
-                        # They removed the permission
                         await internal_db.execute_write(
                             """
                             delete from acl where
@@ -274,7 +267,6 @@ async def manage_table_acls(request, datasette):
         [resource_id],
     )
 
-    # group_sizes dictionary for displaying their sizes
     group_sizes = {
         row["name"]: row["size"]
         for row in await internal_db.execute(
@@ -296,10 +288,11 @@ async def manage_table_acls(request, datasette):
 
     return Response.html(
         await datasette.render_template(
-            "manage_table_acls.html",
+            "manage_resource_acls.html",
             {
-                "database_name": request.url_vars["database"],
-                "table_name": request.url_vars["table"],
+                "resource_type": resource_type,
+                "parent": parent,
+                "child": child,
                 "actions": actions,
                 "groups": groups,
                 "group_sizes": group_sizes,

--- a/datasette_acl/views/table_acls.py
+++ b/datasette_acl/views/table_acls.py
@@ -24,12 +24,12 @@ async def manage_table_acls(request, datasette):
 
     # Ensure we have a resource_id for this table
     await internal_db.execute_write(
-        "INSERT OR IGNORE INTO acl_resources (database, resource) VALUES (?, ?);",
+        "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES ('table', ?, ?);",
         [database, table],
     )
     resource_id = (
         await internal_db.execute(
-            "SELECT id FROM acl_resources WHERE database = ? AND resource = ?",
+            "SELECT id FROM acl_resources WHERE resource_type = 'table' AND parent = ? AND child = ?",
             [database, table],
         )
     ).single_value()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,10 +42,10 @@ async def ds():
 
 @pytest_asyncio.fixture
 async def csrftoken(ds):
-    csrf_token_response = await ds.client.get(
-        "/db/t/-/acl",
-        cookies={
-            "ds_actor": ds.client.actor_cookie({"id": "root"}),
-        },
-    )
-    return csrf_token_response.cookies["ds_csrftoken"]
+    # Datasette 1.0a30 replaced token-based asgi-csrf with header-based
+    # CrossOriginProtectionMiddleware (Sec-Fetch-Site + Origin). There is no
+    # longer a ds_csrftoken cookie. The test client is a non-browser client
+    # (sends neither Sec-Fetch-Site nor Origin) so unsafe-method requests pass
+    # through unchanged and no token is required. This value is still accepted
+    # in form posts but is unused. See datasette/csrf.py.
+    return "csrf-not-required-in-datasette-1.0a30"

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -1,0 +1,458 @@
+"""Tests for the JSON mutation endpoints (task 04):
+
+    POST /-/acl/api/resource/{resource_type}/{parent}/{child}/grant
+    POST .../revoke
+    POST .../update
+
+Covers the grant/revoke/update happy paths (they mutate acl + write audit rows
+and return the expected JSON), per-resource authorization (a non-manager gets
+403; granting them the Manager role — directly or via a group — then lets them
+manage), and the datasette 1.0a30 header-based CSRF behavior (a cross-origin
+browser POST is rejected; a same-origin / non-browser POST is accepted).
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+from datasette_acl.grants import grant, list_grants
+from datasette_acl.roles import AclRole
+import pytest
+import pytest_asyncio
+
+
+class DocResource(Resource):
+    """Parent-only mock resource type used by these tests."""
+
+    name = "mock-doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT '42' AS parent, NULL AS child"
+
+
+DOC_ROLES = [
+    AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    AclRole(
+        "mock-doc",
+        "Manager",
+        ["doc-view", "doc-edit", "doc-manage"],
+        rank=3,
+        manage=True,
+    ),
+]
+
+FAKE_ACTORS = {
+    "alice": {
+        "id": "alice",
+        "display_name": "Alice Garcia",
+        "email": "alice@example.com",
+        "avatar_url": "/-/profile/pic/alice",
+        "kind": "user",
+    },
+}
+
+
+class ApiMutationPlugin:
+    __name__ = "ApiMutationPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(
+                name="doc-manage", description="Manage", resource_class=DocResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(DOC_ROLES)
+
+    @hookimpl
+    def actors_from_ids(self, datasette, actor_ids):
+        return {
+            actor_id: FAKE_ACTORS.get(actor_id, {"id": actor_id})
+            for actor_id in actor_ids
+        }
+
+
+@pytest_asyncio.fixture
+async def api_ds():
+    plugin = ApiMutationPlugin()
+    pm.register(plugin, name="api-mutation-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        await datasette.get_internal_database().execute_write(
+            "INSERT INTO acl_groups (name) VALUES ('staff')"
+        )
+        yield datasette
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="api-mutation-plugin")
+
+
+def _cookie(datasette, actor_id):
+    return {"ds_actor": datasette.client.actor_cookie({"id": actor_id})}
+
+
+def _root_cookie(datasette):
+    return _cookie(datasette, "root")
+
+
+async def _group_id(datasette, name):
+    return (
+        await datasette.get_internal_database().execute(
+            "SELECT id FROM acl_groups WHERE name = ?", [name]
+        )
+    ).single_value()
+
+
+async def _audit_rows(datasette):
+    rows = await datasette.get_internal_database().execute(
+        "SELECT operation, actor_id, group_id, operation_by FROM acl_audit ORDER BY id"
+    )
+    return [dict(r) for r in rows.rows]
+
+
+async def _post(datasette, path, json=None, cookies=None, headers=None):
+    return await datasette.client.post(
+        path,
+        json=json if json is not None else {},
+        cookies=cookies or {},
+        headers=headers or {},
+    )
+
+
+GRANT_URL = "/-/acl/api/resource/mock-doc/42/grant"
+REVOKE_URL = "/-/acl/api/resource/mock-doc/42/revoke"
+UPDATE_URL = "/-/acl/api/resource/mock-doc/42/update"
+
+
+# --- happy paths ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grant_by_role(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Editor"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["grant"]["id"] == "bob"
+    assert data["grant"]["role"] == "Editor"
+    assert data["grant"]["actions"] == ["doc-edit", "doc-view"]
+    assert data["grant"]["kind"] == "user"
+
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    bob = [g for g in grants if g["actor_id"] == "bob"][0]
+    assert bob["actions"] == ["doc-edit", "doc-view"]
+
+    audit = await _audit_rows(api_ds)
+    added = [r for r in audit if r["operation"] == "added" and r["actor_id"] == "bob"]
+    assert len(added) == 2
+    assert all(r["operation_by"] == "root" for r in added)
+
+
+@pytest.mark.asyncio
+async def test_grant_by_actions(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "carol", "actions": ["doc-view"]},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grant"]["role"] == "Viewer"
+    assert data["grant"]["actions"] == ["doc-view"]
+
+
+@pytest.mark.asyncio
+async def test_grant_enriched_display(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "alice", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    grant_entry = response.json()["grant"]
+    assert grant_entry["display_name"] == "Alice Garcia"
+    assert grant_entry["email"] == "alice@example.com"
+    assert grant_entry["avatar_url"] == "/-/profile/pic/alice"
+
+
+@pytest.mark.asyncio
+async def test_grant_group(api_ds):
+    gid = await _group_id(api_ds, "staff")
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"group_id": gid, "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    data = response.json()
+    assert data["grant"]["principal"] == "group"
+    assert data["grant"]["id"] == str(gid)
+    assert data["grant"]["role"] == "Viewer"
+    assert data["grant"]["kind"] == "group"
+    assert data["grant"]["display_name"] == "staff"
+
+
+@pytest.mark.asyncio
+async def test_grant_wildcard_principal(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "_signed_in", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    data = response.json()
+    assert data["grant"]["id"] == "_signed_in"
+    assert data["grant"]["kind"] == "public"
+    assert "display_name" not in data["grant"]
+
+
+@pytest.mark.asyncio
+async def test_update_swaps_role(api_ds):
+    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    response = await _post(
+        api_ds,
+        UPDATE_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grant"]["role"] == "Viewer"
+    assert data["grant"]["actions"] == ["doc-view"]
+
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    bob = [g for g in grants if g["actor_id"] == "bob"][0]
+    assert bob["actions"] == ["doc-view"]
+
+    audit = await _audit_rows(api_ds)
+    removed = [r for r in audit if r["operation"] == "removed" and r["actor_id"] == "bob"]
+    # Manager -> Viewer drops doc-edit and doc-manage.
+    assert {r["operation_by"] for r in removed} == {"root"}
+    assert len(removed) == 2
+
+
+@pytest.mark.asyncio
+async def test_revoke_removes_all(api_ds):
+    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    response = await _post(
+        api_ds,
+        REVOKE_URL,
+        json={"actor_id": "bob"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert sorted(data["removed"]) == ["doc-edit", "doc-manage", "doc-view"]
+
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    assert [g for g in grants if g["actor_id"] == "bob"] == []
+
+    audit = await _audit_rows(api_ds)
+    removed = [r for r in audit if r["operation"] == "removed" and r["actor_id"] == "bob"]
+    assert len(removed) == 3
+    assert all(r["operation_by"] == "root" for r in removed)
+
+
+@pytest.mark.asyncio
+async def test_revoke_group(api_ds):
+    gid = await _group_id(api_ds, "staff")
+    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    response = await _post(
+        api_ds,
+        REVOKE_URL,
+        json={"group_id": gid},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    assert grants == []
+
+
+# --- per-resource authorization -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_manager_cannot_grant(api_ds):
+    # mallory has no manage action and is not the global admin.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_cookie(api_ds, "mallory"),
+    )
+    assert response.status_code == 403
+    # Nothing was written.
+    assert await list_grants(api_ds, "mock-doc", "42") == []
+
+
+@pytest.mark.asyncio
+async def test_anonymous_cannot_grant(api_ds):
+    response = await _post(api_ds, GRANT_URL, json={"actor_id": "bob", "role": "Viewer"})
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_manager_role_grants_manage_ability(api_ds):
+    # Granting mallory the Manager role (which includes doc-manage) lets her
+    # re-share, without the global datasette-acl permission.
+    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root")
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_cookie(api_ds, "mallory"),
+    )
+    assert response.status_code == 200
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    assert any(g["actor_id"] == "bob" for g in grants)
+
+
+@pytest.mark.asyncio
+async def test_non_manager_role_cannot_grant(api_ds):
+    # Editor is not a manage role, so it must NOT confer re-share ability.
+    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Editor", by_actor="root")
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_cookie(api_ds, "mallory"),
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_group_manager_role_grants_manage_ability(api_ds):
+    # mallory is in the staff group; the staff group holds the Manager role.
+    gid = await _group_id(api_ds, "staff")
+    db = api_ds.get_internal_database()
+    await db.execute_write(
+        "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
+        ["mallory", gid],
+    )
+    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Manager", by_actor="root")
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_cookie(api_ds, "mallory"),
+    )
+    assert response.status_code == 200
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    assert any(g["actor_id"] == "bob" for g in grants)
+
+
+@pytest.mark.asyncio
+async def test_unknown_resource_type(api_ds):
+    response = await _post(
+        api_ds,
+        "/-/acl/api/resource/nope/42/grant",
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 403
+
+
+# --- bad input ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grant_requires_exactly_one_principal(api_ds):
+    # Neither principal.
+    response = await _post(
+        api_ds, GRANT_URL, json={"role": "Viewer"}, cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    # Both principals.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "group_id": 1, "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_grant_unknown_role(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Nope"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_requires_role(api_ds):
+    response = await _post(
+        api_ds, UPDATE_URL, json={"actor_id": "bob"}, cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_on_mutation_route_not_allowed(api_ds):
+    response = await api_ds.client.get(GRANT_URL, cookies=_root_cookie(api_ds))
+    assert response.status_code == 405
+
+
+# --- CSRF (datasette 1.0a30 header-based protection) ----------------------
+
+
+@pytest.mark.asyncio
+async def test_csrf_cross_origin_browser_post_rejected(api_ds, csrftoken):
+    # A browser cross-origin POST sends an Origin that does not match Host and
+    # no Sec-Fetch-Site=same-origin; core's CrossOriginProtectionMiddleware
+    # rejects it before our handler runs.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+        headers={"origin": "https://evil.example.com"},
+    )
+    assert response.status_code == 403
+    # The grant did not happen.
+    assert await list_grants(api_ds, "mock-doc", "42") == []
+
+
+@pytest.mark.asyncio
+async def test_csrf_same_origin_post_accepted(api_ds, csrftoken):
+    # Sec-Fetch-Site: same-origin is the signal a same-origin browser fetch
+    # sends; core lets it through. (The non-browser test client with no headers
+    # is already exercised by the happy-path tests above.)
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+        headers={"sec-fetch-site": "same-origin", "x-csrftoken": csrftoken},
+    )
+    assert response.status_code == 200
+    assert response.json()["ok"] is True

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -236,6 +236,73 @@ async def test_actors_delegates_q_to_profiles(profiles_ds):
     assert [r["id"] for r in results] == ["evan"]
 
 
+# --- actors picker: the proxy forwards the caller's identity ---------------
+#
+# The actor picker proxies to profiles' search API via an internal
+# ``datasette.client`` request. That request is anonymous by default, so a
+# profiles ``profile_access`` gate would 403 it and the proxy would silently
+# return no results. The fix forwards ``request.actor`` on the internal call.
+# This fake search route enforces the same identity gate so the test fails if
+# the caller's actor is not forwarded.
+
+
+async def _gated_profiles_search(request, datasette):
+    """Stand-in for profiles' search API that enforces a ``profile_access`` gate.
+
+    Returns 403 unless the (forwarded) caller is the actor that holds access.
+    """
+    if not (request.actor and request.actor.get("id") == "root"):
+        return Response.json({"error": "forbidden"}, status=403)
+    return await _fake_profiles_search(request, datasette)
+
+
+class GatedProfilesPlugin:
+    __name__ = "GatedProfilesPlugin"
+
+    @hookimpl
+    def register_routes(self):
+        return [("^/-/profiles/api/search$", _gated_profiles_search)]
+
+    @hookimpl
+    def datasette_acl_valid_actors(self, datasette):
+        # If the gated delegation returns 403, the proxy must NOT silently fall
+        # back to these — it returns an empty list. So these never appear.
+        return [{"id": "fallback-leak", "display": "Fallback Leak"}]
+
+
+@pytest_asyncio.fixture
+async def gated_profiles_ds():
+    pm.register(GatedProfilesPlugin(), name="gated-profiles-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        yield datasette
+        db = datasette.get_internal_database()
+        for table in await db.table_names():
+            if table.startswith("acl"):
+                await db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="gated-profiles-plugin")
+
+
+@pytest.mark.asyncio
+async def test_actors_forwards_actor_to_gated_profiles(gated_profiles_ds):
+    # root passes the proxy's own datasette-acl admin gate AND the downstream
+    # profiles profile_access gate — but only if the internal request carries
+    # root's identity. This is the regression test for the identity-forwarding
+    # bug: an anonymous internal call would 403 and return an empty list.
+    response = await gated_profiles_ds.client.get(
+        "/-/acl/api/actors", cookies=_root_cookie(gated_profiles_ds)
+    )
+    assert response.status_code == 200
+    ids = {r["id"] for r in response.json()["results"]}
+    assert ids == {"dora", "evan"}
+    # The fallback was not consulted (the gated delegation succeeded).
+    assert "fallback-leak" not in ids
+
+
 # --- per-resource authorization (the share-dialog Manager) -----------------
 #
 # The share dialog is driven by per-resource Managers (a doc owner) who do NOT

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -1,0 +1,229 @@
+"""Tests for the picker endpoints (task 05):
+
+    GET /-/acl/api/groups
+    GET /-/acl/api/actors?q=&kind=
+
+The group picker draws from ``acl_groups`` (active groups + member counts). The
+actor picker is a thin proxy: it delegates to the user-profiles search API
+(``GET /-/profiles/api/search``) when installed, and otherwise falls back to
+``datasette_acl_valid_actors`` filtered by ``q`` in Python. Both endpoints gate
+on the global ``datasette-acl`` permission. Wildcard / public principals
+(``*``, ``_signed_in``, ``_anonymous``) need no write path — they are plain
+``actor_id`` strings — so they are exercised through the grant helpers in
+``test_custom_resources.py`` rather than here.
+"""
+
+from datasette import hookimpl
+from datasette import Response
+from datasette.app import Datasette
+from datasette.plugins import pm
+import pytest
+import pytest_asyncio
+
+
+def _root_cookie(datasette):
+    return {"ds_actor": datasette.client.actor_cookie({"id": "root"})}
+
+
+# --- groups picker --------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def groups_ds():
+    datasette = Datasette(config={"permissions": {"datasette-acl": {"id": "root"}}})
+    await datasette.invoke_startup()
+    db = datasette.get_internal_database()
+    await db.execute_write("INSERT INTO acl_groups (name) VALUES ('staff')")
+    await db.execute_write("INSERT INTO acl_groups (name) VALUES ('admins')")
+    # A soft-deleted group must not appear in the picker.
+    await db.execute_write(
+        "INSERT INTO acl_groups (name, deleted) VALUES ('old', 1)"
+    )
+    # Members so member_count is exercised.
+    staff_id = (
+        await db.execute("SELECT id FROM acl_groups WHERE name = 'staff'")
+    ).single_value()
+    for actor_id in ("a", "b"):
+        await db.execute_write(
+            "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
+            [actor_id, staff_id],
+        )
+    yield datasette
+    for table in await db.table_names():
+        if table.startswith("acl"):
+            await db.execute_write(f"drop table {table}")
+
+
+@pytest.mark.asyncio
+async def test_groups_requires_permission(groups_ds):
+    response = await groups_ds.client.get("/-/acl/api/groups")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_groups_lists_active_with_counts(groups_ds):
+    response = await groups_ds.client.get(
+        "/-/acl/api/groups", cookies=_root_cookie(groups_ds)
+    )
+    assert response.status_code == 200
+    groups = {g["name"]: g for g in response.json()["groups"]}
+    # Soft-deleted group excluded.
+    assert set(groups) == {"staff", "admins"}
+    assert groups["staff"]["member_count"] == 2
+    assert groups["admins"]["member_count"] == 0
+    # ids are present and integers.
+    assert isinstance(groups["staff"]["id"], int)
+
+
+# --- actors picker: fallback (no profiles) --------------------------------
+
+
+class ValidActorsPlugin:
+    __name__ = "ValidActorsPlugin"
+
+    @hookimpl
+    def datasette_acl_valid_actors(self, datasette):
+        return [
+            {"id": "alice", "display": "Alice Garcia"},
+            {"id": "bob", "display": "Bob Lee"},
+            {"id": "carol", "display": "Carol"},
+        ]
+
+
+@pytest_asyncio.fixture
+async def fallback_ds():
+    pm.register(ValidActorsPlugin(), name="valid-actors-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        yield datasette
+        db = datasette.get_internal_database()
+        for table in await db.table_names():
+            if table.startswith("acl"):
+                await db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="valid-actors-plugin")
+
+
+@pytest.mark.asyncio
+async def test_actors_requires_permission(fallback_ds):
+    response = await fallback_ds.client.get("/-/acl/api/actors")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_actors_fallback_returns_valid_actors(fallback_ds):
+    response = await fallback_ds.client.get(
+        "/-/acl/api/actors", cookies=_root_cookie(fallback_ds)
+    )
+    assert response.status_code == 200
+    results = response.json()["results"]
+    ids = {r["id"] for r in results}
+    assert ids == {"alice", "bob", "carol"}
+    alice = next(r for r in results if r["id"] == "alice")
+    assert alice["display_name"] == "Alice Garcia"
+    assert alice["kind"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_actors_fallback_filters_by_q(fallback_ds):
+    # q matches against id OR display_name, case-insensitively.
+    response = await fallback_ds.client.get(
+        "/-/acl/api/actors?q=garcia", cookies=_root_cookie(fallback_ds)
+    )
+    results = response.json()["results"]
+    assert [r["id"] for r in results] == ["alice"]
+
+    response = await fallback_ds.client.get(
+        "/-/acl/api/actors?q=BO", cookies=_root_cookie(fallback_ds)
+    )
+    results = response.json()["results"]
+    assert [r["id"] for r in results] == ["bob"]
+
+
+# --- actors picker: delegates to profiles search API ----------------------
+
+
+async def _fake_profiles_search(request, datasette):
+    """Stand-in for user-profiles' GET /-/profiles/api/search."""
+    q = (request.args.get("q") or "").strip().lower()
+    directory = [
+        {
+            "id": "dora",
+            "display_name": "Dora Profile",
+            "email": "dora@example.com",
+            "avatar_url": "/-/profile/pic/dora",
+            "kind": "user",
+        },
+        {
+            "id": "evan",
+            "display_name": "Evan Profile",
+            "email": "evan@example.com",
+            "avatar_url": "/-/profile/pic/evan",
+            "kind": "user",
+        },
+    ]
+    if q:
+        directory = [
+            r
+            for r in directory
+            if q in r["id"].lower() or q in r["display_name"].lower()
+        ]
+    return Response.json({"results": directory})
+
+
+class FakeProfilesPlugin:
+    __name__ = "FakeProfilesPlugin"
+
+    @hookimpl
+    def register_routes(self):
+        return [("^/-/profiles/api/search$", _fake_profiles_search)]
+
+    @hookimpl
+    def datasette_acl_valid_actors(self, datasette):
+        # If delegation works, these must NOT appear in the results.
+        return [{"id": "should-not-appear", "display": "Fallback Only"}]
+
+
+@pytest_asyncio.fixture
+async def profiles_ds():
+    pm.register(FakeProfilesPlugin(), name="fake-profiles-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        yield datasette
+        db = datasette.get_internal_database()
+        for table in await db.table_names():
+            if table.startswith("acl"):
+                await db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="fake-profiles-plugin")
+
+
+@pytest.mark.asyncio
+async def test_actors_delegates_to_profiles(profiles_ds):
+    response = await profiles_ds.client.get(
+        "/-/acl/api/actors", cookies=_root_cookie(profiles_ds)
+    )
+    assert response.status_code == 200
+    results = response.json()["results"]
+    ids = {r["id"] for r in results}
+    # Profiles results used; the valid_actors fallback was NOT consulted.
+    assert ids == {"dora", "evan"}
+    assert "should-not-appear" not in ids
+    dora = next(r for r in results if r["id"] == "dora")
+    assert dora["email"] == "dora@example.com"
+    assert dora["avatar_url"] == "/-/profile/pic/dora"
+
+
+@pytest.mark.asyncio
+async def test_actors_delegates_q_to_profiles(profiles_ds):
+    response = await profiles_ds.client.get(
+        "/-/acl/api/actors?q=evan", cookies=_root_cookie(profiles_ds)
+    )
+    results = response.json()["results"]
+    assert [r["id"] for r in results] == ["evan"]

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -16,13 +16,20 @@ on the global ``datasette-acl`` permission. Wildcard / public principals
 from datasette import hookimpl
 from datasette import Response
 from datasette.app import Datasette
+from datasette.permissions import Action, Resource
 from datasette.plugins import pm
+from datasette_acl.grants import grant
+from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
 
 
 def _root_cookie(datasette):
     return {"ds_actor": datasette.client.actor_cookie({"id": "root"})}
+
+
+def _cookie(datasette, actor_id):
+    return {"ds_actor": datasette.client.actor_cookie({"id": actor_id})}
 
 
 # --- groups picker --------------------------------------------------------
@@ -227,3 +234,149 @@ async def test_actors_delegates_q_to_profiles(profiles_ds):
     )
     results = response.json()["results"]
     assert [r["id"] for r in results] == ["evan"]
+
+
+# --- per-resource authorization (the share-dialog Manager) -----------------
+#
+# The share dialog is driven by per-resource Managers (a doc owner) who do NOT
+# hold the global ``datasette-acl`` permission. They authorize the pickers by
+# passing the dialog's resource (resource_type / parent / child); the endpoints
+# then run the same per-resource ``can_manage`` gate the read + mutation
+# endpoints use. Omitting the resource still requires global admin.
+
+
+class DocResource(Resource):
+    """Parent-only mock resource type for the per-resource picker tests."""
+
+    name = "mock-doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT '42' AS parent, NULL AS child"
+
+
+DOC_ROLES = [
+    AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    AclRole(
+        "mock-doc",
+        "Manager",
+        ["doc-view", "doc-edit", "doc-manage"],
+        rank=3,
+        manage=True,
+    ),
+]
+
+
+class DocPickerPlugin:
+    __name__ = "DocPickerPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(
+                name="doc-manage", description="Manage", resource_class=DocResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(DOC_ROLES)
+
+
+@pytest_asyncio.fixture
+async def resource_ds():
+    pm.register(DocPickerPlugin(), name="doc-picker-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        db = datasette.get_internal_database()
+        await db.execute_write("INSERT INTO acl_groups (name) VALUES ('staff')")
+        # bruce is a per-resource Manager (no global admin).
+        await grant(
+            datasette, "mock-doc", "42", actor_id="bruce", role="Manager",
+            by_actor="root",
+        )
+        yield datasette
+        for table in await db.table_names():
+            if table.startswith("acl"):
+                await db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="doc-picker-plugin")
+
+
+_RES = "resource_type=mock-doc&parent=42"
+
+
+@pytest.mark.asyncio
+async def test_manager_can_use_groups_picker_with_resource(resource_ds):
+    # bruce is not a global admin but manages mock-doc/42, so passing the
+    # resource lets him list groups.
+    response = await resource_ds.client.get(
+        f"/-/acl/api/groups?{_RES}", cookies=_cookie(resource_ds, "bruce")
+    )
+    assert response.status_code == 200
+    names = {g["name"] for g in response.json()["groups"]}
+    assert "staff" in names
+
+
+@pytest.mark.asyncio
+async def test_manager_can_use_actors_picker_with_resource(resource_ds):
+    response = await resource_ds.client.get(
+        f"/-/acl/api/actors?{_RES}", cookies=_cookie(resource_ds, "bruce")
+    )
+    assert response.status_code == 200
+    assert "results" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_non_manager_cannot_use_pickers_with_resource(resource_ds):
+    # mallory holds no manage action on the resource and is not global admin.
+    for path in (
+        f"/-/acl/api/groups?{_RES}",
+        f"/-/acl/api/actors?{_RES}",
+    ):
+        response = await resource_ds.client.get(
+            path, cookies=_cookie(resource_ds, "mallory")
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_anonymous_cannot_use_pickers_with_resource(resource_ds):
+    for path in (
+        f"/-/acl/api/groups?{_RES}",
+        f"/-/acl/api/actors?{_RES}",
+    ):
+        response = await resource_ds.client.get(path)
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_manager_without_resource_still_requires_global_admin(resource_ds):
+    # Without the resource params, the global-admin fallback applies, so a
+    # per-resource Manager who lacks global admin is rejected (existing behavior).
+    for path in ("/-/acl/api/groups", "/-/acl/api/actors"):
+        response = await resource_ds.client.get(
+            path, cookies=_cookie(resource_ds, "bruce")
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_global_admin_still_works_without_resource(resource_ds):
+    # root holds the global datasette-acl permission → pickers work with no
+    # resource params (back-compat).
+    for path in ("/-/acl/api/groups", "/-/acl/api/actors"):
+        response = await resource_ds.client.get(
+            path, cookies=_root_cookie(resource_ds)
+        )
+        assert response.status_code == 200

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -1,0 +1,264 @@
+"""Tests for the JSON read endpoint (task 03):
+
+    GET /-/acl/api/resource/{resource_type}/{parent}/{child}
+
+Seeds actor / group / wildcard grants on a mock resource and asserts the JSON
+shape: grants grouped by principal with a resolved role, actor enrichment from a
+fake ``actors_from_ids`` test plugin (display name / email / avatar / kind),
+group ``member_count``, wildcard principals flagged ``kind:"public"``, and the
+``roles`` registry + ``can_manage`` flag.
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+from datasette_acl.grants import grant
+from datasette_acl.roles import AclRole
+import pytest
+import pytest_asyncio
+
+
+class DocResource(Resource):
+    """Parent-only mock resource type used by these tests."""
+
+    name = "mock-doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT '42' AS parent, NULL AS child"
+
+
+DOC_ROLES = [
+    AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    AclRole(
+        "mock-doc",
+        "Manager",
+        ["doc-view", "doc-edit", "doc-manage"],
+        rank=3,
+        manage=True,
+    ),
+]
+
+# Fake directory the test plugin's actors_from_ids resolves against. Includes a
+# user and an agent (with kind) so enrichment + kind passthrough are exercised.
+FAKE_ACTORS = {
+    "alice": {
+        "id": "alice",
+        "display_name": "Alice Garcia",
+        "email": "alice@example.com",
+        "avatar_url": "/-/profile/pic/alice",
+        "kind": "user",
+    },
+    "agent:researcher": {
+        "id": "agent:researcher",
+        "display_name": "Researcher",
+        "avatar_url": "/-/agent/pic/researcher",
+        "kind": "agent",
+    },
+}
+
+
+class ApiDocPlugin:
+    __name__ = "ApiDocPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(
+                name="doc-manage", description="Manage", resource_class=DocResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(DOC_ROLES)
+
+    @hookimpl
+    def actors_from_ids(self, datasette, actor_ids):
+        # Resolve known ids; unknown ids fall back to {"id": id} (mirrors the
+        # core default so the endpoint still returns a usable grant).
+        return {
+            actor_id: FAKE_ACTORS.get(actor_id, {"id": actor_id})
+            for actor_id in actor_ids
+        }
+
+
+@pytest_asyncio.fixture
+async def api_ds():
+    plugin = ApiDocPlugin()
+    pm.register(plugin, name="api-doc-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        await datasette.get_internal_database().execute_write(
+            "INSERT INTO acl_groups (name) VALUES ('staff')"
+        )
+        yield datasette
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="api-doc-plugin")
+
+
+async def _group_id(datasette, name):
+    return (
+        await datasette.get_internal_database().execute(
+            "SELECT id FROM acl_groups WHERE name = ?", [name]
+        )
+    ).single_value()
+
+
+def _root_cookie(datasette):
+    return {"ds_actor": datasette.client.actor_cookie({"id": "root"})}
+
+
+async def _get(datasette, path, cookies=None):
+    return await datasette.client.get(path, cookies=cookies or {})
+
+
+# --- gating ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_requires_manage(api_ds):
+    # Anonymous / non-manager is forbidden.
+    response = await _get(api_ds, "/-/acl/api/resource/mock-doc/42")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_read_unknown_resource_type(api_ds):
+    response = await _get(
+        api_ds, "/-/acl/api/resource/nope/42", cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_per_resource_manager_can_read(api_ds):
+    # Grant alice the Manager role (which includes the manage action) and prove
+    # she can read the endpoint without the global datasette-acl permission.
+    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    cookies = {"ds_actor": api_ds.client.actor_cookie({"id": "alice"})}
+    response = await _get(api_ds, "/-/acl/api/resource/mock-doc/42", cookies=cookies)
+    assert response.status_code == 200
+    assert response.json()["can_manage"] is True
+
+
+# --- shape ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_full_shape(api_ds):
+    gid = await _group_id(api_ds, "staff")
+    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    await grant(
+        api_ds, "mock-doc", "42", actor_id="agent:researcher", role="Editor", by_actor="root"
+    )
+    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        api_ds, "mock-doc", "42", actor_id="_signed_in", role="Viewer", by_actor="root"
+    )
+
+    response = await _get(
+        api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["resource_type"] == "mock-doc"
+    assert data["parent"] == "42"
+    assert data["child"] is None
+    assert data["can_manage"] is True
+
+    # roles registry surfaced, in rank order, manage flag preserved.
+    assert [r["name"] for r in data["roles"]] == ["Viewer", "Editor", "Manager"]
+    assert data["roles"][-1]["manage"] is True
+    assert data["roles"][0]["actions"] == ["doc-view"]
+
+    grants = {(g["principal"], g["id"]): g for g in data["grants"]}
+
+    # Actor grant enriched + role resolved.
+    alice = grants[("actor", "alice")]
+    assert alice["role"] == "Manager"
+    assert alice["kind"] == "user"
+    assert alice["display_name"] == "Alice Garcia"
+    assert alice["email"] == "alice@example.com"
+    assert alice["avatar_url"] == "/-/profile/pic/alice"
+
+    # Agent: kind passthrough from actors_from_ids.
+    agent = grants[("actor", "agent:researcher")]
+    assert agent["role"] == "Editor"
+    assert agent["kind"] == "agent"
+    assert agent["display_name"] == "Researcher"
+
+    # Group grant: name + member_count + kind group.
+    group = grants[("group", str(gid))]
+    assert group["role"] == "Viewer"
+    assert group["kind"] == "group"
+    assert group["display_name"] == "staff"
+    assert group["member_count"] == 0
+
+    # Wildcard principal flagged public.
+    wildcard = grants[("actor", "_signed_in")]
+    assert wildcard["role"] == "Viewer"
+    assert wildcard["kind"] == "public"
+    # No enrichment looked up for a wildcard principal.
+    assert "display_name" not in wildcard
+
+
+@pytest.mark.asyncio
+async def test_group_member_count(api_ds):
+    gid = await _group_id(api_ds, "staff")
+    db = api_ds.get_internal_database()
+    for actor_id in ("a", "b", "c"):
+        await db.execute_write(
+            "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
+            [actor_id, gid],
+        )
+    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    response = await _get(
+        api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
+    )
+    group = response.json()["grants"][0]
+    assert group["principal"] == "group"
+    assert group["member_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_read_empty_resource(api_ds):
+    response = await _get(
+        api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grants"] == []
+    # roles + can_manage still present.
+    assert data["can_manage"] is True
+    assert len(data["roles"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_unknown_actor_falls_back(api_ds):
+    # An actor with no directory entry still resolves (kind user, no names).
+    await grant(api_ds, "mock-doc", "42", actor_id="ghost", role="Viewer", by_actor="root")
+    response = await _get(
+        api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
+    )
+    ghost = response.json()["grants"][0]
+    assert ghost["id"] == "ghost"
+    assert ghost["role"] == "Viewer"
+    assert ghost["kind"] == "user"
+    assert "display_name" not in ghost

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -39,6 +39,11 @@ class WidgetPlugin:
                 description="View a widget",
                 resource_class=WidgetResource,
             ),
+            Action(
+                name="widget-edit",
+                description="Edit a widget",
+                resource_class=WidgetResource,
+            ),
         ]
 
 
@@ -199,4 +204,126 @@ async def test_anonymous_wildcard_grant(widget_ds):
     )
     assert await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+
+
+# csrftoken is unused in datasette 1.0a30 (header-based CSRF); the non-browser
+# test client needs no token. We pass a dummy string for form-field parity.
+DUMMY_CSRF = "csrf-not-required-in-datasette-1.0a30"
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_lists_dynamic_actions(widget_ds):
+    # The generic admin page renders the action set discovered for this resource
+    # type (widget-view, widget-edit), not a hardcoded table list.
+    response = await widget_ds.client.get(
+        "/-/acl/resource/widget/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 200
+    assert "Permissions for widget: shelf/gadget" in response.text
+    assert "widget-view" in response.text
+    assert "widget-edit" in response.text
+    # Table-only actions must not appear for a widget resource
+    assert "insert-row" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_requires_permission(widget_ds):
+    response = await widget_ds.client.get(
+        "/-/acl/resource/widget/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "other"})},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_unknown_type(widget_ds):
+    response = await widget_ds.client.get(
+        "/-/acl/resource/nope/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_grants_via_post(widget_ds):
+    actor = {"id": "alice"}
+    resource = WidgetResource("shelf", "gadget")
+    # No grant yet
+    assert not await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=actor
+    )
+    # Grant widget-edit to alice through the generic admin POST
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={
+            "new_actor_id": "alice",
+            "new_user_actions": "widget-edit",
+            "csrftoken": DUMMY_CSRF,
+        },
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+
+    # The acl row exists for the right (resource_type, parent, child)
+    internal_db = widget_ds.get_internal_database()
+    rows = [
+        dict(r)
+        for r in (
+            await internal_db.execute(
+                """
+                select
+                  acl.actor_id,
+                  acl_actions.name as action_name,
+                  acl_resources.resource_type,
+                  acl_resources.parent,
+                  acl_resources.child
+                from acl
+                join acl_actions on acl.action_id = acl_actions.id
+                join acl_resources on acl.resource_id = acl_resources.id
+                """
+            )
+        )
+    ]
+    assert rows == [
+        {
+            "actor_id": "alice",
+            "action_name": "widget-edit",
+            "resource_type": "widget",
+            "parent": "shelf",
+            "child": "gadget",
+        }
+    ]
+
+    # And datasette.allowed reflects the new grant
+    assert await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=actor
+    )
+    # The other action is still denied
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=actor
+    )
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_revokes_via_post(widget_ds):
+    actor = {"id": "alice"}
+    resource = WidgetResource("shelf", "gadget")
+    await _grant_actor(widget_ds, "alice", "widget", "shelf", "gadget", "widget-edit")
+    assert await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=actor
+    )
+    # POST with the existing user's checkbox unchecked removes the grant
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={
+            "user_permissions_alice": "",
+            "csrftoken": DUMMY_CSRF,
+        },
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+    assert not await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=actor
     )

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -1,0 +1,202 @@
+"""
+Tests for permission_resources_sql supporting arbitrary resource types (not
+just tables). Exercises a throwaway custom resource type registered via a test
+plugin and asserts grant resolution through datasette.allowed().
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+import pytest
+import pytest_asyncio
+
+
+class WidgetResource(Resource):
+    """Throwaway two-level resource type used only in these tests."""
+
+    name = "widget"
+    parent_class = None  # parent-only; (parent, child) still both stored
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        # Advertise the single widget we use in the tests so that
+        # allowed_resources()/allowed() have a base resource to match against.
+        return "SELECT 'shelf' AS parent, 'gadget' AS child"
+
+
+class WidgetPlugin:
+    __name__ = "WidgetPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(
+                name="widget-view",
+                description="View a widget",
+                resource_class=WidgetResource,
+            ),
+        ]
+
+
+@pytest_asyncio.fixture
+async def widget_ds():
+    pm.register(WidgetPlugin(), name="widget-plugin")
+    try:
+        datasette = Datasette(
+            config={
+                "permissions": {"datasette-acl": {"id": "root"}},
+            }
+        )
+        db = datasette.add_memory_database("db")
+        await db.execute_write("create table t (id primary key)")
+        # Plugin is registered before startup so widget-view lands in acl_actions
+        await datasette.invoke_startup()
+        yield datasette
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+        await db.execute_write("drop table t")
+    finally:
+        pm.unregister(name="widget-plugin")
+
+
+async def _grant_actor(datasette, actor_id, resource_type, parent, child, action):
+    db = datasette.get_internal_database()
+    await db.execute_write(
+        "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES (?, ?, ?)",
+        [resource_type, parent, child],
+    )
+    await db.execute_write(
+        """
+        INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+        VALUES (
+            :actor_id,
+            null,
+            (SELECT id FROM acl_resources WHERE resource_type = :rt AND parent = :p AND child = :c),
+            (SELECT id FROM acl_actions WHERE name = :action)
+        )
+        """,
+        {
+            "actor_id": actor_id,
+            "rt": resource_type,
+            "p": parent,
+            "c": child,
+            "action": action,
+        },
+    )
+
+
+async def _grant_group(datasette, group_name, resource_type, parent, child, action):
+    db = datasette.get_internal_database()
+    await db.execute_write(
+        "INSERT OR IGNORE INTO acl_groups (name) VALUES (?)", [group_name]
+    )
+    await db.execute_write(
+        "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES (?, ?, ?)",
+        [resource_type, parent, child],
+    )
+    await db.execute_write(
+        """
+        INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+        VALUES (
+            null,
+            (SELECT id FROM acl_groups WHERE name = :group_name),
+            (SELECT id FROM acl_resources WHERE resource_type = :rt AND parent = :p AND child = :c),
+            (SELECT id FROM acl_actions WHERE name = :action)
+        )
+        """,
+        {
+            "group_name": group_name,
+            "rt": resource_type,
+            "p": parent,
+            "c": child,
+            "action": action,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_direct_grant_on_custom_resource(widget_ds):
+    actor = {"id": "alice"}
+    resource = WidgetResource("shelf", "gadget")
+    # No grant yet
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=actor
+    )
+    # Grant a direct actor permission on the custom resource type
+    await _grant_actor(widget_ds, "alice", "widget", "shelf", "gadget", "widget-view")
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=actor
+    )
+    # A different actor is still denied
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "bob"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_group_grant_on_custom_resource(widget_ds):
+    # Put alice in the widgets group and grant the group access
+    db = widget_ds.get_internal_database()
+    await db.execute_write("INSERT OR IGNORE INTO acl_groups (name) VALUES ('widgets')")
+    await db.execute_write(
+        """
+        INSERT INTO acl_actor_groups (actor_id, group_id)
+        VALUES ('alice', (SELECT id FROM acl_groups WHERE name = 'widgets'))
+        """
+    )
+    await _grant_group(
+        widget_ds, "widgets", "widget", "shelf", "gadget", "widget-view"
+    )
+    resource = WidgetResource("shelf", "gadget")
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "alice"}
+    )
+    # An actor not in the group is denied
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "carol"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_resource_type_does_not_leak(widget_ds):
+    # Grant alice access to a *table* resource with the same parent/child
+    await _grant_actor(widget_ds, "alice", "table", "shelf", "gadget", "insert-row")
+    # That must NOT grant her the widget-view action on the widget resource
+    resource = WidgetResource("shelf", "gadget")
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "alice"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_signed_in_wildcard_grant(widget_ds):
+    # Grant _signed_in => any actor with an id is allowed, anonymous is not
+    await _grant_actor(
+        widget_ds, "_signed_in", "widget", "shelf", "gadget", "widget-view"
+    )
+    resource = WidgetResource("shelf", "gadget")
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_anonymous_wildcard_grant(widget_ds):
+    # Grant '*' => literally anyone, including anonymous
+    await _grant_actor(widget_ds, "*", "widget", "shelf", "gadget", "widget-view")
+    resource = WidgetResource("shelf", "gadget")
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -195,7 +195,7 @@ async def test_signed_in_wildcard_grant(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_anonymous_wildcard_grant(widget_ds):
+async def test_star_wildcard_grant(widget_ds):
     # Grant '*' => literally anyone, including anonymous
     await _grant_actor(widget_ds, "*", "widget", "shelf", "gadget", "widget-view")
     resource = WidgetResource("shelf", "gadget")
@@ -203,6 +203,22 @@ async def test_anonymous_wildcard_grant(widget_ds):
         action="widget-view", resource=resource, actor=None
     )
     assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_anonymous_wildcard_grant(widget_ds):
+    # Grant '_anonymous' => only unauthenticated callers; a signed-in actor is not
+    # matched by this grant.
+    await _grant_actor(
+        widget_ds, "_anonymous", "widget", "shelf", "gadget", "widget-view"
+    )
+    resource = WidgetResource("shelf", "gadget")
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert not await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "anyone"}
     )
 

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -1,0 +1,355 @@
+"""Tests for the Python grant helpers (grants.py) and build_resource (utils.py).
+
+These back the JSON API (tasks 03-05) and consumer data-migrations: grant by
+role / by raw actions, revoke, atomic update_role, audit rows, the actor/group
+CHECK invariant, and building a core Resource for 2-level and parent-only types.
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.roles import AclRole
+from datasette_acl.utils import build_resource
+import pytest
+import pytest_asyncio
+
+
+class DocResource(Resource):
+    """Parent-only resource type (no parent_class)."""
+
+    name = "doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT '42' AS parent, NULL AS child"
+
+
+class FolderResource(Resource):
+    name = "folder"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT 'home' AS parent, NULL AS child"
+
+
+class FileResource(Resource):
+    """Two-level resource type: a file inside a folder."""
+
+    name = "file"
+    parent_class = FolderResource
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT 'home' AS parent, 'notes.txt' AS child"
+
+
+DOC_ROLES = [
+    AclRole("doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    AclRole(
+        "doc", "Manager", ["doc-view", "doc-edit", "doc-manage"], rank=3, manage=True
+    ),
+]
+
+
+class GrantsPlugin:
+    __name__ = "GrantsPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(name="doc-manage", description="Manage", resource_class=DocResource),
+            Action(
+                name="file-view", description="View file", resource_class=FileResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(DOC_ROLES)
+
+
+@pytest_asyncio.fixture
+async def grants_ds():
+    pm.register(GrantsPlugin(), name="grants-plugin")
+    try:
+        datasette = Datasette(config={"permissions": {"datasette-acl": {"id": "root"}}})
+        await datasette.invoke_startup()
+        # A group to grant to
+        await datasette.get_internal_database().execute_write(
+            "INSERT INTO acl_groups (name) VALUES ('staff')"
+        )
+        yield datasette
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="grants-plugin")
+
+
+async def _actions_for(datasette, actor_id):
+    """Read the action names granted to actor_id on the doc/42 resource."""
+    rows = await datasette.get_internal_database().execute(
+        """
+        SELECT acl_actions.name AS name
+        FROM acl
+        JOIN acl_actions ON acl.action_id = acl_actions.id
+        JOIN acl_resources ON acl.resource_id = acl_resources.id
+        WHERE acl.actor_id = :actor_id
+          AND acl_resources.resource_type = 'doc'
+          AND acl_resources.parent = '42'
+        """,
+        {"actor_id": actor_id},
+    )
+    return sorted(row["name"] for row in rows.rows)
+
+
+async def _group_id(datasette, name):
+    return (
+        await datasette.get_internal_database().execute(
+            "SELECT id FROM acl_groups WHERE name = ?", [name]
+        )
+    ).single_value()
+
+
+async def _audit_ops(datasette):
+    rows = await datasette.get_internal_database().execute(
+        """
+        SELECT acl_audit.operation, acl_audit.actor_id, acl_audit.group_id,
+               acl_actions.name AS action_name, acl_audit.operation_by
+        FROM acl_audit
+        JOIN acl_actions ON acl_audit.action_id = acl_actions.id
+        ORDER BY acl_audit.id
+        """
+    )
+    return [dict(r) for r in rows.rows]
+
+
+# --- build_resource -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_resource_parent_only(grants_ds):
+    resource = build_resource(grants_ds, "doc", "42")
+    assert isinstance(resource, DocResource)
+    assert resource.parent == "42"
+    assert resource.child is None
+
+
+@pytest.mark.asyncio
+async def test_build_resource_two_level(grants_ds):
+    resource = build_resource(grants_ds, "file", "home", "notes.txt")
+    assert isinstance(resource, FileResource)
+    assert resource.parent == "home"
+    assert resource.child == "notes.txt"
+
+
+@pytest.mark.asyncio
+async def test_build_resource_unknown_type(grants_ds):
+    with pytest.raises(ValueError):
+        build_resource(grants_ds, "nope", "x")
+
+
+# --- grant ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grant_by_role(grants_ds):
+    result = await grant(
+        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+    )
+    assert result == ["doc-edit", "doc-view"]
+    assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
+    # datasette.allowed reflects it
+    assert await grants_ds.allowed(
+        action="doc-edit", resource=DocResource("42"), actor={"id": "alice"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_grant_by_raw_actions(grants_ds):
+    result = await grant(
+        grants_ds, "doc", "42", actor_id="bob", actions=["doc-view"], by_actor="root"
+    )
+    assert result == ["doc-view"]
+    assert await _actions_for(grants_ds, "bob") == ["doc-view"]
+
+
+@pytest.mark.asyncio
+async def test_grant_is_idempotent(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    # Granting again with overlap only inserts the new action
+    result = await grant(
+        grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root"
+    )
+    assert result == ["doc-edit", "doc-manage", "doc-view"]
+    assert await _actions_for(grants_ds, "alice") == [
+        "doc-edit",
+        "doc-manage",
+        "doc-view",
+    ]
+    # Only one row per action despite the overlap
+    count = (
+        await grants_ds.get_internal_database().execute(
+            "SELECT count(*) FROM acl WHERE actor_id = 'alice'"
+        )
+    ).single_value()
+    assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_grant_to_group(grants_ds):
+    gid = await _group_id(grants_ds, "staff")
+    result = await grant(
+        grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root"
+    )
+    assert result == ["doc-view"]
+    grants = await list_grants(grants_ds, "doc", "42")
+    assert grants == [
+        {
+            "principal": "group",
+            "actor_id": None,
+            "group_id": gid,
+            "group_name": "staff",
+            "actions": ["doc-view"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_grant_unknown_role_raises(grants_ds):
+    with pytest.raises(ValueError):
+        await grant(grants_ds, "doc", "42", actor_id="alice", role="Nope")
+
+
+@pytest.mark.asyncio
+async def test_grant_requires_exactly_one_principal(grants_ds):
+    with pytest.raises(ValueError):
+        await grant(grants_ds, "doc", "42", role="Viewer")
+    gid = await _group_id(grants_ds, "staff")
+    with pytest.raises(ValueError):
+        await grant(grants_ds, "doc", "42", actor_id="a", group_id=gid, role="Viewer")
+
+
+@pytest.mark.asyncio
+async def test_grant_requires_exactly_one_of_role_or_actions(grants_ds):
+    with pytest.raises(ValueError):
+        await grant(grants_ds, "doc", "42", actor_id="a")
+    with pytest.raises(ValueError):
+        await grant(
+            grants_ds, "doc", "42", actor_id="a", role="Viewer", actions=["doc-view"]
+        )
+
+
+# --- revoke ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_removes_all_rows(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    removed = await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    assert removed == ["doc-edit", "doc-manage", "doc-view"]
+    assert await _actions_for(grants_ds, "alice") == []
+
+
+@pytest.mark.asyncio
+async def test_revoke_only_targets_principal(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(grants_ds, "doc", "42", actor_id="bob", role="Viewer", by_actor="root")
+    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    assert await _actions_for(grants_ds, "alice") == []
+    assert await _actions_for(grants_ds, "bob") == ["doc-view"]
+
+
+# --- update_role ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_role_swaps_atomically(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    result = await update_role(
+        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root"
+    )
+    assert result == ["doc-view"]
+    # Only doc-view remains: doc-edit and doc-manage removed
+    assert await _actions_for(grants_ds, "alice") == ["doc-view"]
+
+
+@pytest.mark.asyncio
+async def test_update_role_upgrades(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    result = await update_role(
+        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+    )
+    assert result == ["doc-edit", "doc-view"]
+    assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
+
+
+# --- audit ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_rows_written(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await update_role(
+        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="admin"
+    )
+    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    ops = await _audit_ops(grants_ds)
+    # grant Editor: +doc-view +doc-edit; update to Viewer: -doc-edit;
+    # revoke: -doc-view
+    summary = [(o["operation"], o["action_name"], o["operation_by"]) for o in ops]
+    assert ("added", "doc-view", "root") in summary
+    assert ("added", "doc-edit", "root") in summary
+    assert ("removed", "doc-edit", "admin") in summary
+    assert ("removed", "doc-view", "root") in summary
+    # All audit rows recorded the actor principal, no group
+    assert all(o["actor_id"] == "alice" and o["group_id"] is None for o in ops)
+
+
+# --- list_grants ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_grants_actor_and_group(grants_ds):
+    gid = await _group_id(grants_ds, "staff")
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    grants = await list_grants(grants_ds, "doc", "42")
+    assert grants == [
+        {
+            "principal": "actor",
+            "actor_id": "alice",
+            "group_id": None,
+            "group_name": None,
+            "actions": ["doc-edit", "doc-view"],
+        },
+        {
+            "principal": "group",
+            "actor_id": None,
+            "group_id": gid,
+            "group_name": "staff",
+            "actions": ["doc-view"],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_grants_empty(grants_ds):
+    assert await list_grants(grants_ds, "doc", "42") == []

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,129 @@
+"""
+Tests for the friendly-roles layer: the datasette_acl_roles hook, the startup
+registry keyed by resource_type, and the role<->action resolution helpers.
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+from datasette_acl.roles import (
+    AclRole,
+    role_for_actions,
+    actions_for_role,
+    manage_actions,
+)
+import pytest
+import pytest_asyncio
+
+
+class DocResource(Resource):
+    """Throwaway resource type used only in these tests."""
+
+    name = "mock-doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+
+# Roles declared for the mock-doc resource type, deliberately registered out of
+# rank order to prove the registry sorts/resolves correctly.
+MOCK_ROLES = [
+    AclRole("mock-doc", "Manager", ["doc-view", "doc-edit", "doc-manage"],
+            rank=3, manage=True),
+    AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+]
+
+
+class MockDocPlugin:
+    __name__ = "MockDocPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(
+                name="doc-manage", description="Manage", resource_class=DocResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(MOCK_ROLES)
+
+
+@pytest_asyncio.fixture
+async def doc_ds():
+    pm.register(MockDocPlugin(), name="mock-doc-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        yield datasette
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="mock-doc-plugin")
+
+
+@pytest.mark.asyncio
+async def test_registry_built_and_grouped_by_resource_type(doc_ds):
+    registry = doc_ds._acl_roles_registry
+    assert set(registry.keys()) == {"mock-doc"}
+    roles = registry["mock-doc"]
+    # All three roles present, sorted by rank ascending
+    assert [r.name for r in roles] == ["Viewer", "Editor", "Manager"]
+    assert [r.rank for r in roles] == [1, 2, 3]
+
+
+def test_role_for_actions_picks_highest_rank_subset():
+    roles = list(MOCK_ROLES)
+    # Exactly the Editor set => Editor
+    assert role_for_actions(roles, {"doc-view", "doc-edit"}).name == "Editor"
+    # Just view => Viewer
+    assert role_for_actions(roles, {"doc-view"}).name == "Viewer"
+    # Superset of Manager => Manager (highest rank whose actions are a subset)
+    assert (
+        role_for_actions(
+            roles, {"doc-view", "doc-edit", "doc-manage", "extra"}
+        ).name
+        == "Manager"
+    )
+    # Granted spans Editor but not Manager (no doc-manage) => Editor
+    assert (
+        role_for_actions(roles, {"doc-view", "doc-edit", "other"}).name
+        == "Editor"
+    )
+
+
+def test_role_for_actions_no_match_returns_none():
+    roles = list(MOCK_ROLES)
+    # No granted actions => no role fits (every role needs at least doc-view)
+    assert role_for_actions(roles, set()) is None
+    # An unrelated action set matches no role
+    assert role_for_actions(roles, {"doc-edit"}) is None
+
+
+def test_actions_for_role():
+    roles = list(MOCK_ROLES)
+    assert actions_for_role(roles, "Editor") == ["doc-view", "doc-edit"]
+    assert actions_for_role(roles, "Nope") is None
+
+
+def test_manage_actions_returns_manager_actions():
+    roles = list(MOCK_ROLES)
+    assert manage_actions(roles) == {"doc-view", "doc-edit", "doc-manage"}
+
+
+def test_manage_actions_empty_when_no_manage_role():
+    roles = [
+        AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+        AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    ]
+    assert manage_actions(roles) == set()

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -12,6 +12,7 @@ from datasette_acl.roles import (
     role_for_actions,
     actions_for_role,
     manage_actions,
+    manage_only_actions,
 )
 import pytest
 import pytest_asyncio
@@ -127,3 +128,19 @@ def test_manage_actions_empty_when_no_manage_role():
         AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
     ]
     assert manage_actions(roles) == set()
+
+
+def test_manage_only_actions_excludes_shared_actions():
+    # The manage gate must authorize against only the action(s) exclusive to a
+    # manage role; the bundled view/edit actions must NOT count (otherwise any
+    # Viewer/Editor would pass the manage check).
+    roles = list(MOCK_ROLES)
+    assert manage_only_actions(roles) == {"doc-manage"}
+
+
+def test_manage_only_actions_empty_when_no_manage_role():
+    roles = [
+        AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+        AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    ]
+    assert manage_only_actions(roles) == set()

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -299,8 +299,8 @@ async def test_manage_table_permissions(
           acl_groups.name as group_name,
           acl.actor_id,
           acl_actions.name as action_name,
-          acl_resources.database as database_name,
-          acl_resources.resource as resource_name
+          acl_resources.parent as database_name,
+          acl_resources.child as resource_name
         from acl
         left join acl_groups on acl.group_id = acl_groups.id
         join acl_actions on acl.action_id = acl_actions.id
@@ -325,8 +325,8 @@ async def test_manage_table_permissions(
           acl_groups.name as group_name,
           acl_audit.actor_id,
           acl_actions.name as action_name,
-          acl_resources.database as database_name,
-          acl_resources.resource as resource_name,
+          acl_resources.parent as database_name,
+          acl_resources.child as resource_name,
           acl_audit.operation_by,
           acl_audit.operation
         from acl_audit
@@ -499,13 +499,13 @@ async def test_table_creator_permissions():
         select
           acl.actor_id,
           acl_actions.name as action_name,
-          acl_resources.database as database_name,
-          acl_resources.resource as resource_name
+          acl_resources.parent as database_name,
+          acl_resources.child as resource_name
         from acl
         join acl_actions on acl.action_id = acl_actions.id
         join acl_resources on acl.resource_id = acl_resources.id
-        where acl_resources.database = 'db'
-        and acl_resources.resource = 'new_table'
+        where acl_resources.parent = 'db'
+        and acl_resources.child = 'new_table'
     """
             )
         )
@@ -540,6 +540,73 @@ async def test_table_creator_permissions():
         action="update-row",
         resource=TableResource("db", "new_table"),
     )
+
+
+@pytest.mark.asyncio
+async def test_fresh_acl_resources_schema():
+    # A fresh internal DB should get the new (resource_type, parent, child) schema.
+    datasette = Datasette(memory=True)
+    await datasette.invoke_startup()
+    db = datasette.get_internal_database()
+    cols = [r["name"] for r in (await db.execute("PRAGMA table_info(acl_resources)"))]
+    assert cols == ["id", "resource_type", "parent", "child"]
+
+
+@pytest.mark.asyncio
+async def test_acl_resources_migration():
+    # An internal DB carrying the OLD (database, resource) schema with rows
+    # should migrate in place to (resource_type, parent, child), backfilling
+    # resource_type='table' and preserving id/parent/child values.
+    datasette = Datasette(memory=True)
+    db = datasette.get_internal_database()
+    await db.execute_write_script(
+        """
+        create table acl_resources (
+            id integer primary key,
+            database text not null,
+            resource text,
+            unique(database, resource)
+        );
+        """
+    )
+    await db.execute_write(
+        "insert into acl_resources (database, resource) values (?, ?)", ["db1", "t1"]
+    )
+    await db.execute_write(
+        "insert into acl_resources (database, resource) values (?, ?)", ["db2", "t2"]
+    )
+
+    # Sanity check: old columns present before startup
+    cols_before = [
+        r["name"] for r in (await db.execute("PRAGMA table_info(acl_resources)"))
+    ]
+    assert cols_before == ["id", "database", "resource"]
+
+    await datasette.invoke_startup()
+
+    cols_after = [
+        r["name"] for r in (await db.execute("PRAGMA table_info(acl_resources)"))
+    ]
+    assert cols_after == ["id", "resource_type", "parent", "child"]
+
+    rows = [
+        dict(r)
+        for r in (await db.execute("select * from acl_resources order by id"))
+    ]
+    assert rows == [
+        {"id": 1, "resource_type": "table", "parent": "db1", "child": "t1"},
+        {"id": 2, "resource_type": "table", "parent": "db2", "child": "t2"},
+    ]
+    # The leftover scratch table must be gone.
+    assert "acl_resources_old" not in await db.table_names()
+
+    # Running startup again is idempotent: no error, no duplicate rows.
+    await datasette.invoke_startup()
+    rows_again = [
+        dict(r)
+        for r in (await db.execute("select * from acl_resources order by id"))
+    ]
+    assert rows_again == rows
 
 
 @pytest.mark.asyncio

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -630,3 +630,26 @@ async def test_table_actions(ds, should_work):
         assert has_link
     else:
         assert not has_link
+
+
+@pytest.mark.asyncio
+async def test_table_acl_page_actions_are_dynamic(ds, csrftoken):
+    # The table permissions page should offer the action set discovered from
+    # datasette.actions (every TableResource-scoped action), not a hardcoded
+    # subset. Core registers view-table and set-column-type beyond the original
+    # five, so their presence proves discovery is dynamic.
+    response = await ds.client.get(
+        "/db/t/-/acl",
+        cookies={"ds_actor": ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 200
+    for action in (
+        "insert-row",
+        "delete-row",
+        "update-row",
+        "alter-table",
+        "drop-table",
+        "view-table",
+        "set-column-type",
+    ):
+        assert action in response.text

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -553,8 +553,13 @@ async def test_table_actions(ds, should_work):
             ),
         },
     )
-    fragment = '<a href="/db/t/-/acl">Manage table permissions'
+    # 1.0a30 renders menu links with extra attrs (role/tabindex), so match the
+    # href + label rather than an exact anchor tag.
+    has_link = (
+        'href="/db/t/-/acl"' in response.text
+        and "Manage table permissions" in response.text
+    )
     if should_work:
-        assert fragment in response.text
+        assert has_link
     else:
-        assert fragment not in response.text
+        assert not has_link


### PR DESCRIPTION
Lands the `sharing-v2` ACL engine:

- Per-resource authorization via `can_manage` so document owners can manage grants without holding a global `datasette-acl` admin role.
- Picker API endpoints (actors/groups) for the share dialog, authorized per-resource.
- Identity forwarding on the internal `/-/acl/api/actors` → profiles proxy: `datasette.client.get(..., actor=...)` so the proxy isn't anonymous (previously returned empty). Includes a regression test.
- Adapted to datasette core 1.0a30 (header-based CSRF; `allowed`/`register_actions`).

Part of the cross-repo document-sharing unification. Depends on datasette-user-profiles (people search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)