### PR TITLE
1/7 Adapt test suite to datasette 1.0a30 (header-based CSRF)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,14 +38,3 @@ async def ds():
             await internal_db.execute_write(f"drop table {table}")
     for table in await db.table_names():
         await db.execute_write(f"drop table {table}")
-
-
-@pytest_asyncio.fixture
-async def csrftoken(ds):
-    csrf_token_response = await ds.client.get(
-        "/db/t/-/acl",
-        cookies={
-            "ds_actor": ds.client.actor_cookie({"id": "root"}),
-        },
-    )
-    return csrf_token_response.cookies["ds_csrftoken"]

--- a/tests/test_datasette_acl_valid_actors.py
+++ b/tests/test_datasette_acl_valid_actors.py
@@ -29,7 +29,7 @@ def register_plugin():
 
 
 @pytest.mark.asyncio
-async def test_datasette_acl_valid_actors(ds, csrftoken, register_plugin):
+async def test_datasette_acl_valid_actors(ds, register_plugin):
     plugins_response = await ds.client.get("/-/plugins.json")
     assert any(
         plugin
@@ -58,11 +58,9 @@ async def test_datasette_acl_valid_actors(ds, csrftoken, register_plugin):
             data={
                 "new_actor_id": actor_id,
                 "new_user_actions": "insert-row",
-                "csrftoken": csrftoken,
             },
             cookies={
                 "ds_actor": ds.client.actor_cookie({"id": "root"}),
-                "ds_csrftoken": csrftoken,
             },
         )
         assert response.status_code == 302
@@ -79,11 +77,9 @@ async def test_datasette_acl_valid_actors(ds, csrftoken, register_plugin):
             "/-/acl/groups/dev",
             data={
                 "add": actor_id,
-                "csrftoken": csrftoken,
             },
             cookies={
                 "ds_actor": ds.client.actor_cookie({"id": "root"}),
-                "ds_csrftoken": csrftoken,
             },
         )
         assert response.status_code == 302

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -40,7 +40,6 @@ ManageGroupTest = namedtuple(
 )
 async def test_manage_group_membership(
     ds,
-    csrftoken,
     description,
     setup_post_data,
     post_data,
@@ -52,20 +51,18 @@ async def test_manage_group_membership(
     if setup_post_data:
         setup_response = await ds.client.post(
             "/-/acl/groups/dev",
-            data={**setup_post_data, "csrftoken": csrftoken},
+            data={**setup_post_data},
             cookies={
                 "ds_actor": ds.client.actor_cookie({"id": "root"}),
-                "ds_csrftoken": csrftoken,
             },
         )
         assert setup_response.status_code == 302
 
     response = await ds.client.post(
         "/-/acl/groups/dev",
-        data={**post_data, "csrftoken": csrftoken},
+        data={**post_data},
         cookies={
             "ds_actor": ds.client.actor_cookie({"id": "root"}),
-            "ds_csrftoken": csrftoken,
         },
     )
     assert response.status_code == 302
@@ -87,17 +84,16 @@ async def test_manage_group_membership(
 
 
 @pytest.mark.asyncio
-async def test_cannot_edit_dynamic_group(ds, csrftoken):
+async def test_cannot_edit_dynamic_group(ds):
     db = ds.get_internal_database()
 
     # Adding to dev should work, adding to staff should fail
     for group in ("staff", "dev"):
         await ds.client.post(
             f"/-/acl/groups/{group}",
-            data={"add": "tony2", "csrftoken": csrftoken},
+            data={"add": "tony2"},
             cookies={
                 "ds_actor": ds.client.actor_cookie({"id": "root"}),
-                "ds_csrftoken": csrftoken,
             },
         )
     assert await get_group_members(db, "staff") == set()
@@ -147,16 +143,15 @@ async def test_deleted_group(ds):
 
 
 @pytest.mark.asyncio
-async def test_create_delete_group(ds, csrftoken):
+async def test_create_delete_group(ds):
     internal_db = ds.get_internal_database()
 
     # Create a group
     create_group_response = await ds.client.post(
         "/-/acl/groups",
-        data={"new_group": "sales", "csrftoken": csrftoken},
+        data={"new_group": "sales"},
         cookies={
             "ds_actor": ds.client.actor_cookie({"id": "root"}),
-            "ds_csrftoken": csrftoken,
         },
     )
     assert create_group_response.status_code == 302
@@ -182,10 +177,9 @@ async def test_create_delete_group(ds, csrftoken):
     for actor_id in ("sally", "sam", "paulo"):
         add_response = await ds.client.post(
             f"/-/acl/groups/sales",
-            data={"add": actor_id, "csrftoken": csrftoken},
+            data={"add": actor_id},
             cookies={
                 "ds_actor": ds.client.actor_cookie({"id": "root"}),
-                "ds_csrftoken": csrftoken,
             },
         )
         assert add_response.status_code == 302
@@ -198,7 +192,6 @@ async def test_create_delete_group(ds, csrftoken):
         f"/db/t/-/acl",
         cookies={
             "ds_actor": ds.client.actor_cookie({"id": "root"}),
-            "ds_csrftoken": csrftoken,
         },
     )
     assert "/groups/sales" in table_page1.text
@@ -206,20 +199,18 @@ async def test_create_delete_group(ds, csrftoken):
     # Add permissions for that group on that page, to test audit log later
     await ds.client.post(
         "/db/t/-/acl",
-        data={"group_permissions_sales": "insert-row", "csrftoken": csrftoken},
+        data={"group_permissions_sales": "insert-row"},
         cookies={
             "ds_actor": ds.client.actor_cookie({"id": "root"}),
-            "ds_csrftoken": csrftoken,
         },
     )
 
     # Deleting this group should first remove the members
     delete_group_response = await ds.client.post(
         "/-/acl/groups/sales",
-        data={"delete_group": "1", "csrftoken": csrftoken},
+        data={"delete_group": "1"},
         cookies={
             "ds_actor": ds.client.actor_cookie({"id": "root"}),
-            "ds_csrftoken": csrftoken,
         },
     )
     assert delete_group_response.status_code == 302
@@ -237,7 +228,6 @@ async def test_create_delete_group(ds, csrftoken):
         f"/db/t/-/acl",
         cookies={
             "ds_actor": ds.client.actor_cookie({"id": "root"}),
-            "ds_csrftoken": csrftoken,
         },
     )
     assert "/groups/sales" not in table_page2.text

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -242,7 +242,6 @@ ManageTableTest = namedtuple(
 )
 async def test_manage_table_permissions(
     ds,
-    csrftoken,
     description,
     setup_post_data,
     post_data,
@@ -262,10 +261,9 @@ async def test_manage_table_permissions(
     if setup_post_data:
         setup_response = await ds.client.post(
             "/db/t/-/acl",
-            data={**setup_post_data, "csrftoken": csrftoken},
+            data={**setup_post_data},
             cookies={
                 "ds_actor": ds.client.actor_cookie({"id": "root"}),
-                "ds_csrftoken": csrftoken,
             },
         )
         assert setup_response.status_code == 302
@@ -281,10 +279,9 @@ async def test_manage_table_permissions(
     # Use the /db/table/-/acl page to update permissions
     response = await ds.client.post(
         "/db/t/-/acl",
-        data={**post_data, "csrftoken": csrftoken},
+        data={**post_data},
         cookies={
             "ds_actor": ds.client.actor_cookie({"id": "root"}),
-            "ds_csrftoken": csrftoken,
         },
     )
     assert response.status_code == 302
@@ -553,8 +550,13 @@ async def test_table_actions(ds, should_work):
             ),
         },
     )
-    fragment = '<a href="/db/t/-/acl">Manage table permissions'
+    # 1.0a30 renders menu links with extra attrs (role/tabindex), so match the
+    # href + label rather than an exact anchor tag.
+    has_link = (
+        'href="/db/t/-/acl"' in response.text
+        and "Manage table permissions" in response.text
+    )
     if should_work:
-        assert fragment in response.text
+        assert has_link
     else:
-        assert fragment not in response.text
+        assert not has_link


### PR DESCRIPTION
**Stack 1/7** of splitting #29 (sharing-v2). Base: `main`.

## Goal
Make the existing suite pass against datasette core `1.0a30`, which replaced token-based `asgi-csrf` with the header-based `CrossOriginProtectionMiddleware`. Lands first to unblock the rest of the stack.

## Changes
- **Rip out the dead CSRF-token plumbing.** 1.0a30 has no `ds_csrftoken` cookie and the non-browser test client needs no token, so the `csrftoken` fixture and every `data={..., "csrftoken": ...}` form field / `"ds_csrftoken"` cookie are dead weight. Removed outright rather than fed a dummy value — mirrors [datasette-export-database@9021066](https://github.com/datasette/datasette-export-database/commit/902106636b8588e79bb7c6344ac7b30fb9bbe7b3).
- `tests/test_table_acls.py` — also loosen the table-action assertion that hard-coded the old `<a>` markup.

## Tests
Existing suite green under datasette `1.0a30` (15 passing on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
