### PR TITLE
6/6 Add ACL JSON API: read/mutate grants + actor/group pickers (per-resource authz)

### DIFF
--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -12,6 +12,8 @@ from datasette_acl.views.api import (
     grant_json,
     revoke_json,
     update_json,
+    groups_json,
+    actors_json,
 )
 from datasette_acl.roles import build_roles_registry
 from . import hookspecs
@@ -311,6 +313,7 @@ def permission_resources_sql(datasette, actor, action):
         # General-access (wildcard) principals always apply:
         #   '*'          -> anyone, including anonymous
         #   '_signed_in' -> any actor that has an id (only when signed in)
+        #   '_anonymous' -> only unauthenticated callers (no actor id)
         # Direct actor grants and group grants only apply when signed in.
         # NOTE: this must be a single SELECT statement with no leading CTE
         # (WITH ...). Datasette core inlines this SQL after a "UNION ALL" when
@@ -341,6 +344,7 @@ WHERE aa.name = :action
     a.actor_id = '*'
     OR (:actor_id IS NOT NULL AND a.actor_id = :actor_id)
     OR (:actor_id IS NOT NULL AND a.actor_id = '_signed_in')
+    OR (:actor_id IS NULL AND a.actor_id = '_anonymous')
     OR a.group_id IN (
         SELECT ag.group_id
         FROM acl_actor_groups ag
@@ -491,6 +495,10 @@ def register_routes():
             "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/update$",
             update_json,
         ),
+        # JSON API pickers (phase-02/05): the share dialog's group + actor
+        # autocomplete sources. Both gate on the global datasette-acl permission.
+        ("^/-/acl/api/groups$", groups_json),
+        ("^/-/acl/api/actors$", actors_json),
         # JSON API read (phase-02/03). The child segment is optional so
         # parent-only resource types resolve through the same route.
         (

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -7,7 +7,12 @@ from datasette_acl.utils import can_edit_permissions
 from datasette_acl.views.table_acls import manage_table_acls
 from datasette_acl.views.resource_acls import manage_resource_acls
 from datasette_acl.views.groups import manage_groups, manage_group
-from datasette_acl.views.api import resource_grants_json
+from datasette_acl.views.api import (
+    resource_grants_json,
+    grant_json,
+    revoke_json,
+    update_json,
+)
 from datasette_acl.roles import build_roles_registry
 from . import hookspecs
 import json
@@ -458,8 +463,36 @@ def register_routes():
             "^/-/acl/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)$",
             manage_resource_acls,
         ),
-        # JSON API (phase-02). The child segment is optional so parent-only
-        # resource types resolve through the same route.
+        # JSON API mutations (phase-02/04). Registered BEFORE the read routes so
+        # the trailing /grant|/revoke|/update verb isn't swallowed as a {child}
+        # path segment by the generic read route. The child segment is optional
+        # so parent-only resource types resolve through both variants.
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)/grant$",
+            grant_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/grant$",
+            grant_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)/revoke$",
+            revoke_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/revoke$",
+            revoke_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)/update$",
+            update_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/update$",
+            update_json,
+        ),
+        # JSON API read (phase-02/03). The child segment is optional so
+        # parent-only resource types resolve through the same route.
         (
             "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)$",
             resource_grants_json,

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -7,6 +7,7 @@ from datasette_acl.utils import can_edit_permissions
 from datasette_acl.views.table_acls import manage_table_acls
 from datasette_acl.views.resource_acls import manage_resource_acls
 from datasette_acl.views.groups import manage_groups, manage_group
+from datasette_acl.views.api import resource_grants_json
 from datasette_acl.roles import build_roles_registry
 from . import hookspecs
 import json
@@ -456,5 +457,15 @@ def register_routes():
         (
             "^/-/acl/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)$",
             manage_resource_acls,
+        ),
+        # JSON API (phase-02). The child segment is optional so parent-only
+        # resource types resolve through the same route.
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)$",
+            resource_grants_json,
+        ),
+        (
+            "^/-/acl/api/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)$",
+            resource_grants_json,
         ),
     ]

--- a/datasette_acl/roles.py
+++ b/datasette_acl/roles.py
@@ -83,10 +83,36 @@ def actions_for_role(roles: List[AclRole], name: str) -> Optional[List[str]]:
 def manage_actions(roles: List[AclRole]) -> Set[str]:
     """Union of actions across all ``manage=True`` roles for a resource type.
 
-    These are the actions that authorize re-sharing a resource (see task 04).
+    This is the full action bundle a manage role carries (e.g. Manager =
+    view+edit+manage). Use :func:`manage_only_actions` for the authorization
+    check — see its docstring for why the union is the wrong gate.
     """
     actions: Set[str] = set()
     for role in roles:
         if role.manage:
             actions.update(role.actions)
     return actions
+
+
+def manage_only_actions(roles: List[AclRole]) -> Set[str]:
+    """Actions that authorize re-sharing: those exclusive to ``manage`` roles.
+
+    A manage role typically *bundles* the lower roles' actions (Manager =
+    Viewer + Editor + ``manage``). Authorizing against the full bundle
+    (:func:`manage_actions`) would wrongly let any Viewer/Editor manage sharing,
+    since they too hold ``doc-view``. The action(s) that actually distinguish a
+    manager are those appearing only in ``manage=True`` roles and in no
+    non-manage role — typically a single ``*-manage`` action. Holding any one of
+    these is what grants re-share ability (task 04 §D).
+
+    Returns the empty set if no role is marked ``manage`` (callers then fall back
+    to the global ``datasette-acl`` permission).
+    """
+    manage_union: Set[str] = set()
+    non_manage_union: Set[str] = set()
+    for role in roles:
+        if role.manage:
+            manage_union.update(role.actions)
+        else:
+            non_manage_union.update(role.actions)
+    return manage_union - non_manage_union

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -14,16 +14,37 @@ to a name + member count from ``acl_groups`` / ``acl_actor_groups``. Wildcard
 principals (``*`` / ``_signed_in`` / ``_anonymous``) are flagged ``kind:"public"``
 and surface in the dialog's "General access" section.
 
-Per-resource authorization (the manage check) is formalized in task 04. Until
-then ``can_manage`` is computed here from either the global ``datasette-acl``
-permission OR the per-resource manage action (via the roles registry); the read
-endpoint is gated on ``can_manage``.
+Task 04 adds the *write* side — three JSON POST endpoints, each authorized by a
+**per-resource** manage check rather than a global flag:
+
+    POST /-/acl/api/resource/{resource_type}/{parent}/{child}/grant
+    POST .../revoke
+    POST .../update
+
+``can_manage`` (and its raising sibling ``_ensure_can_manage``) is the
+authoritative authz gate: an actor may manage sharing if EITHER they hold the
+global ``datasette-acl`` permission (admin) OR they are ``datasette.allowed`` a
+``manage=True`` role's action on *this specific resource* (i.e. they hold a
+Manager/Owner grant — which itself flows through the same acl machinery, so it
+composes with groups). A resource type that registers no ``manage`` role falls
+back to the global ``datasette-acl`` permission, so table-style resources still
+work.
+
+CSRF: datasette 1.0a30 replaced token-based asgi-csrf with the header-based
+``CrossOriginProtectionMiddleware`` (Sec-Fetch-Site + Origin). That core
+middleware rejects cross-origin browser writes before they reach these
+handlers, so the endpoints carry no server-side CSRF token logic of their own;
+the share component sends same-origin requests (and may set ``x-csrftoken`` for
+forward compat, which core ignores). Non-browser clients (the test client,
+curl) send neither header and pass through.
 """
+
+import json
 
 from datasette import Response, Forbidden
 
-from datasette_acl.grants import list_grants
-from datasette_acl.roles import role_for_actions, manage_actions
+from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.roles import role_for_actions, manage_only_actions
 from datasette_acl.utils import build_resource, resource_class_for, can_edit_permissions
 
 # Wildcard / "general access" principals. These are stored as actor_id values in
@@ -57,19 +78,30 @@ def _roles_payload(roles):
 async def can_manage(datasette, actor, resource_type, parent, child=None):
     """Whether ``actor`` may manage sharing for this resource.
 
-    Task 04 will own the authoritative per-resource manage check; this is the
-    forward-compatible version it will build on. An actor can manage if EITHER:
+    The authoritative per-resource manage check (task 04). An actor can manage
+    if EITHER:
 
-      * they hold the global ``datasette-acl`` permission (admin), OR
-      * they are allowed the resource type's "manage" action on this specific
-        resource (i.e. they hold a ``manage=True`` role grant).
+      * they are ``datasette.allowed`` one of the resource type's *manage-only*
+        actions on this specific resource — i.e. they hold a ``manage=True``
+        role grant (Manager/Owner), which flows through the same acl machinery
+        and so composes with groups; OR
+      * the resource type registers no ``manage`` role, in which case we fall
+        back to the global ``datasette-acl`` permission so table-style resources
+        (which only have raw actions, no roles) still work.
+
+    The manage check authorizes against :func:`manage_only_actions` (the action
+    exclusive to manage roles, e.g. ``paper-manage``) rather than the full
+    Manager action bundle — otherwise any Viewer/Editor, who also holds
+    ``*-view``, would pass. The global ``datasette-acl`` admin always wins.
 
     Returns False (rather than raising) for unknown resource types.
     """
     if await can_edit_permissions(datasette, actor):
         return True
-    manage = manage_actions(_roles_for(datasette, resource_type))
+    manage = manage_only_actions(_roles_for(datasette, resource_type))
     if not manage:
+        # No manage role for this type: fall back to global admin (already
+        # checked above and was False), so non-admins cannot manage.
         return False
     try:
         resource = build_resource(datasette, resource_type, parent, child)
@@ -79,6 +111,18 @@ async def can_manage(datasette, actor, resource_type, parent, child=None):
         if await datasette.allowed(action=action, resource=resource, actor=actor):
             return True
     return False
+
+
+async def _ensure_can_manage(datasette, request, resource_type, parent, child=None):
+    """Raise ``Forbidden`` unless ``request.actor`` may manage this resource.
+
+    The authoritative per-resource authz gate for the mutation endpoints: it
+    delegates to :func:`can_manage` (global ``datasette-acl`` perm OR a
+    per-resource ``manage=True`` role action) and raises rather than returning a
+    bool so handlers can guard with a single ``await``.
+    """
+    if not await can_manage(datasette, request.actor, resource_type, parent, child):
+        raise Forbidden("Cannot manage sharing for this resource")
 
 
 def _kind_for(actor_id, enriched):
@@ -117,6 +161,79 @@ async def _group_info(datasette, group_ids):
         row["id"]: {"name": row["name"], "member_count": row["member_count"]}
         for row in rows.rows
     }
+
+
+async def _actor_grant_entry(datasette, roles, actor_id, actions):
+    """Build the enriched API entry for one actor-principal grant.
+
+    Resolves the granted action-set to its best role, enriches via core
+    ``actors_from_ids`` (skipped for wildcard principals), and tags ``kind``.
+    """
+    role = role_for_actions(roles, set(actions))
+    enriched = {}
+    if actor_id not in PUBLIC_PRINCIPALS:
+        enriched = (await datasette.actors_from_ids([actor_id])) or {}
+    info = enriched.get(actor_id) or {}
+    entry = {
+        "principal": "actor",
+        "id": actor_id,
+        "role": role.name if role else None,
+        "actions": sorted(actions),
+        "kind": _kind_for(actor_id, info),
+    }
+    for key in ("display_name", "email", "avatar_url"):
+        if info.get(key):
+            entry[key] = info[key]
+    return entry
+
+
+async def _group_grant_entry(datasette, roles, group_id, actions):
+    """Build the enriched API entry for one group-principal grant."""
+    role = role_for_actions(roles, set(actions))
+    info = (await _group_info(datasette, [group_id])).get(group_id, {})
+    return {
+        "principal": "group",
+        "id": str(group_id),
+        "role": role.name if role else None,
+        "actions": sorted(actions),
+        "kind": "group",
+        "display_name": info.get("name"),
+        "member_count": info.get("member_count", 0),
+    }
+
+
+def _principal_from_body(body):
+    """Extract ``(actor_id, group_id)`` from a request body, enforcing exactly one.
+
+    Returns ``(actor_id, group_id)`` with exactly one non-None. Raises
+    ``ValueError`` if neither or both are supplied (mirrors the acl CHECK
+    invariant) so handlers can translate it to a 400.
+    """
+    actor_id = body.get("actor_id")
+    group_id = body.get("group_id")
+    if (actor_id is None) == (group_id is None):
+        raise ValueError("Provide exactly one of actor_id or group_id")
+    return actor_id, group_id
+
+
+def _parse_json_body(request_body):
+    """Parse the raw POST body as a JSON object, or raise ``ValueError``."""
+    if not request_body:
+        return {}
+    try:
+        data = json.loads(request_body)
+    except json.JSONDecodeError:
+        raise ValueError("Request body must be valid JSON")
+    if not isinstance(data, dict):
+        raise ValueError("Request body must be a JSON object")
+    return data
+
+
+async def _enriched_grant(datasette, roles, actor_id, group_id, actions):
+    """Build the enriched grant entry for whichever principal was supplied."""
+    if actor_id is not None:
+        return await _actor_grant_entry(datasette, roles, actor_id, actions)
+    return await _group_grant_entry(datasette, roles, group_id, actions)
 
 
 async def resource_grants_json(request, datasette):
@@ -196,3 +313,134 @@ async def resource_grants_json(request, datasette):
             "grants": grants,
         }
     )
+
+
+class _ApiError(Exception):
+    """Carries an HTTP status + message for a JSON error response."""
+
+    def __init__(self, status, message):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+def _error_response(exc):
+    return Response.json({"ok": False, "error": exc.message}, status=exc.status)
+
+
+async def _begin_mutation(request, datasette):
+    """Shared preamble for the mutation endpoints.
+
+    Enforces POST, a known resource type, and the per-resource manage gate, then
+    parses the JSON body. Returns ``(resource_type, parent, child, roles,
+    body)``. Raises ``Forbidden`` (403) for the authz / unknown-type cases
+    (handled by core) and ``_ApiError`` for a bad method (405) or unparseable
+    body (400), which each handler catches and renders as a JSON error response.
+    """
+    if request.method != "POST":
+        raise _ApiError(405, "Method not allowed")
+    resource_type = request.url_vars["resource_type"]
+    parent = request.url_vars["parent"]
+    child = request.url_vars.get("child")
+    if resource_class_for(datasette, resource_type) is None:
+        raise Forbidden(f"Unknown resource type: {resource_type}")
+    # Per-resource authorization — the correctness fix over a global flag.
+    await _ensure_can_manage(datasette, request, resource_type, parent, child)
+    try:
+        body = _parse_json_body(await request.post_body())
+    except ValueError as exc:
+        raise _ApiError(400, str(exc))
+    roles = _roles_for(datasette, resource_type)
+    return resource_type, parent, child, roles, body
+
+
+async def grant_json(request, datasette):
+    """POST /-/acl/api/resource/{type}/{parent}/{child}/grant.
+
+    Body: ``{actor_id|group_id, role}`` or ``{actor_id|group_id, actions: [...]}``.
+    Upserts the grant (idempotent), audits, and returns the enriched grant.
+    """
+    try:
+        resource_type, parent, child, roles, body = await _begin_mutation(
+            request, datasette
+        )
+        actor_id, group_id = _principal_from_body(body)
+        by_actor = (request.actor or {}).get("id")
+        actions = await grant(
+            datasette,
+            resource_type,
+            parent,
+            child,
+            actor_id=actor_id,
+            group_id=group_id,
+            role=body.get("role"),
+            actions=body.get("actions"),
+            by_actor=by_actor,
+        )
+    except _ApiError as exc:
+        return _error_response(exc)
+    except ValueError as exc:
+        return _error_response(_ApiError(400, str(exc)))
+    entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
+    return Response.json({"ok": True, "grant": entry})
+
+
+async def revoke_json(request, datasette):
+    """POST /-/acl/api/resource/{type}/{parent}/{child}/revoke.
+
+    Body: ``{actor_id}`` or ``{group_id}``. Deletes all acl rows for that
+    principal on this resource, audits each removal, returns ``{ok: true}``.
+    """
+    try:
+        resource_type, parent, child, roles, body = await _begin_mutation(
+            request, datasette
+        )
+        actor_id, group_id = _principal_from_body(body)
+        by_actor = (request.actor or {}).get("id")
+        removed = await revoke(
+            datasette,
+            resource_type,
+            parent,
+            child,
+            actor_id=actor_id,
+            group_id=group_id,
+            by_actor=by_actor,
+        )
+    except _ApiError as exc:
+        return _error_response(exc)
+    except ValueError as exc:
+        return _error_response(_ApiError(400, str(exc)))
+    return Response.json({"ok": True, "removed": removed})
+
+
+async def update_json(request, datasette):
+    """POST /-/acl/api/resource/{type}/{parent}/{child}/update.
+
+    Body: ``{actor_id|group_id, role}``. Atomically swaps the principal's action
+    set to the new role, audits each change, and returns the enriched grant.
+    """
+    try:
+        resource_type, parent, child, roles, body = await _begin_mutation(
+            request, datasette
+        )
+        actor_id, group_id = _principal_from_body(body)
+        role = body.get("role")
+        if not role:
+            raise _ApiError(400, "update requires a role")
+        by_actor = (request.actor or {}).get("id")
+        actions = await update_role(
+            datasette,
+            resource_type,
+            parent,
+            child,
+            actor_id=actor_id,
+            group_id=group_id,
+            role=role,
+            by_actor=by_actor,
+        )
+    except _ApiError as exc:
+        return _error_response(exc)
+    except ValueError as exc:
+        return _error_response(_ApiError(400, str(exc)))
+    entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
+    return Response.json({"ok": True, "grant": entry})

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -402,20 +402,45 @@ async def grant_json(request, datasette):
 #     ``datasette_acl_valid_actors`` in Python, so the picker still works on an
 #     acl-only deployment (plan §C).
 #
-# Both gate on the global ``datasette-acl`` permission: listing every group /
-# directory actor is an admin-directory read, not a per-resource share read.
-# (The per-resource grant list endpoint above has its own per-resource gate.)
+# Authorization: the share dialog is driven by per-resource Managers (a doc
+# owner) who don't hold the global ``datasette-acl`` admin permission, so the
+# pickers accept OPTIONAL ``resource_type`` / ``parent`` / ``child`` query
+# params. When supplied, the request is authorized via the same per-resource
+# :func:`can_manage` gate the read + mutation endpoints use (global admin OR a
+# ``manage=True`` role action on that specific resource). When omitted, we fall
+# back to the global ``datasette-acl`` permission (back-compat for acl's own
+# admin pages). Neither passing → ``Forbidden``.
+
+
+async def _ensure_can_pick(datasette, request, message):
+    """Authorize a picker request.
+
+    If ``resource_type`` / ``parent`` (+ optional ``child``) query params are
+    present, authorize against the per-resource :func:`can_manage` gate.
+    Otherwise fall back to the global ``datasette-acl`` admin check. Raises
+    ``Forbidden(message)`` when neither passes.
+    """
+    resource_type = request.args.get("resource_type")
+    parent = request.args.get("parent")
+    if resource_type and parent:
+        child = request.args.get("child")
+        if await can_manage(datasette, request.actor, resource_type, parent, child):
+            return
+        raise Forbidden(message)
+    if await can_edit_permissions(datasette, request.actor):
+        return
+    raise Forbidden(message)
 
 
 async def groups_json(request, datasette):
-    """GET /-/acl/api/groups.
+    """GET /-/acl/api/groups[?resource_type=&parent=&child=].
 
     Returns ``{"groups": [{"id", "name", "member_count"}]}`` for every active
-    (non soft-deleted) group, with a member-count subquery. Gated by the global
-    ``datasette-acl`` permission.
+    (non soft-deleted) group, with a member-count subquery. Authorized per
+    :func:`_ensure_can_pick`: a per-resource Manager (when the resource is
+    supplied) or the global ``datasette-acl`` admin.
     """
-    if not await can_edit_permissions(datasette, request.actor):
-        raise Forbidden("Cannot list groups")
+    await _ensure_can_pick(datasette, request, "Cannot list groups")
     db = datasette.get_internal_database()
     rows = await db.execute(
         """
@@ -490,15 +515,16 @@ async def _valid_actors_fallback(datasette, q):
 
 
 async def actors_json(request, datasette):
-    """GET /-/acl/api/actors?q=&kind=.
+    """GET /-/acl/api/actors?q=&kind=[&resource_type=&parent=&child=].
 
     Thin actor-autocomplete proxy. Delegates to the user-profiles search API
     when available, else falls back to ``datasette_acl_valid_actors`` filtered by
     ``q`` in Python. Returns ``{"results": [{"id", "display_name", "avatar_url",
-    "kind", ...}]}``. Gated by the global ``datasette-acl`` permission.
+    "kind", ...}]}``. Authorized per :func:`_ensure_can_pick`: a per-resource
+    Manager (when the resource is supplied) or the global ``datasette-acl``
+    admin.
     """
-    if not await can_edit_permissions(datasette, request.actor):
-        raise Forbidden("Cannot search actors")
+    await _ensure_can_pick(datasette, request, "Cannot search actors")
     q = (request.args.get("q") or "").strip()
     kind = request.args.get("kind")
     results = await _profiles_search(datasette, q, kind)

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -462,7 +462,7 @@ async def groups_json(request, datasette):
     return Response.json({"groups": groups})
 
 
-async def _profiles_search(datasette, q, kind):
+async def _profiles_search(datasette, q, kind, actor):
     """Delegate the actor search to user-profiles' search API, if installed.
 
     Issues an internal request to ``GET /-/profiles/api/search`` (carrying the
@@ -470,6 +470,13 @@ async def _profiles_search(datasette, q, kind):
     is not installed / the route is absent (so the caller falls back). Any error
     response (e.g. 403) is treated as "no results" rather than propagated, since
     this is an autocomplete helper.
+
+    ``actor`` is the caller's actor. The internal ``datasette.client`` request is
+    otherwise anonymous, so profiles' ``profile_access`` gate would 403 it and we
+    would silently return no results. We forward the caller's identity via the
+    ``actor=`` kwarg, which signs a ``ds_actor`` cookie for the internal request,
+    so the gate evaluates against the real caller (just as the share dialog's
+    direct browser call does).
     """
     params = {}
     if q:
@@ -478,7 +485,9 @@ async def _profiles_search(datasette, q, kind):
         params["kind"] = kind
     try:
         response = await datasette.client.get(
-            datasette.urls.path("/-/profiles/api/search"), params=params
+            datasette.urls.path("/-/profiles/api/search"),
+            params=params,
+            actor=actor,
         )
     except Exception:
         return None
@@ -527,7 +536,7 @@ async def actors_json(request, datasette):
     await _ensure_can_pick(datasette, request, "Cannot search actors")
     q = (request.args.get("q") or "").strip()
     kind = request.args.get("kind")
-    results = await _profiles_search(datasette, q, kind)
+    results = await _profiles_search(datasette, q, kind, request.actor)
     if results is None:
         results = await _valid_actors_fallback(datasette, q)
     return Response.json({"results": results})

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -45,7 +45,12 @@ from datasette import Response, Forbidden
 
 from datasette_acl.grants import grant, revoke, update_role, list_grants
 from datasette_acl.roles import role_for_actions, manage_only_actions
-from datasette_acl.utils import build_resource, resource_class_for, can_edit_permissions
+from datasette_acl.utils import (
+    build_resource,
+    resource_class_for,
+    can_edit_permissions,
+    get_acl_valid_actors,
+)
 
 # Wildcard / "general access" principals. These are stored as actor_id values in
 # acl rows but represent classes of actor rather than a specific person, so the
@@ -383,6 +388,123 @@ async def grant_json(request, datasette):
         return _error_response(_ApiError(400, str(exc)))
     entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
     return Response.json({"ok": True, "grant": entry})
+
+
+# --- pickers ---------------------------------------------------------------
+#
+# The share dialog needs to populate the "add a person / group" boxes. Two
+# decoupled endpoints back that:
+#
+#   GET /-/acl/api/groups          -> the group picker, drawn from acl_groups.
+#   GET /-/acl/api/actors?q=&kind= -> the actor picker. The dialog MAY call the
+#     user-profiles search API directly; this endpoint is the decoupled fallback
+#     that delegates to profiles when installed and otherwise filters acl's own
+#     ``datasette_acl_valid_actors`` in Python, so the picker still works on an
+#     acl-only deployment (plan §C).
+#
+# Both gate on the global ``datasette-acl`` permission: listing every group /
+# directory actor is an admin-directory read, not a per-resource share read.
+# (The per-resource grant list endpoint above has its own per-resource gate.)
+
+
+async def groups_json(request, datasette):
+    """GET /-/acl/api/groups.
+
+    Returns ``{"groups": [{"id", "name", "member_count"}]}`` for every active
+    (non soft-deleted) group, with a member-count subquery. Gated by the global
+    ``datasette-acl`` permission.
+    """
+    if not await can_edit_permissions(datasette, request.actor):
+        raise Forbidden("Cannot list groups")
+    db = datasette.get_internal_database()
+    rows = await db.execute(
+        """
+        SELECT
+            acl_groups.id AS id,
+            acl_groups.name AS name,
+            count(acl_actor_groups.actor_id) AS member_count
+        FROM acl_groups
+        LEFT JOIN acl_actor_groups ON acl_groups.id = acl_actor_groups.group_id
+        WHERE acl_groups.deleted IS NULL
+        GROUP BY acl_groups.id, acl_groups.name
+        ORDER BY acl_groups.name
+        """
+    )
+    groups = [
+        {"id": row["id"], "name": row["name"], "member_count": row["member_count"]}
+        for row in rows.rows
+    ]
+    return Response.json({"groups": groups})
+
+
+async def _profiles_search(datasette, q, kind):
+    """Delegate the actor search to user-profiles' search API, if installed.
+
+    Issues an internal request to ``GET /-/profiles/api/search`` (carrying the
+    same query). Returns the parsed ``results`` list, or ``None`` when profiles
+    is not installed / the route is absent (so the caller falls back). Any error
+    response (e.g. 403) is treated as "no results" rather than propagated, since
+    this is an autocomplete helper.
+    """
+    params = {}
+    if q:
+        params["q"] = q
+    if kind:
+        params["kind"] = kind
+    try:
+        response = await datasette.client.get(
+            datasette.urls.path("/-/profiles/api/search"), params=params
+        )
+    except Exception:
+        return None
+    if response.status_code == 404:
+        return None
+    if response.status_code != 200:
+        return []
+    try:
+        data = response.json()
+    except Exception:
+        return []
+    return data.get("results", [])
+
+
+async def _valid_actors_fallback(datasette, q):
+    """Filter ``datasette_acl_valid_actors`` by ``q`` (substring, case-insensitive).
+
+    The acl-only fallback when user-profiles is not installed. ``valid_actors``
+    yields ``(id, display)`` pairs with no avatar/email, so the entries are
+    minimal: ``{"id", "display_name", "kind": "user"}``.
+    """
+    actors = await get_acl_valid_actors(datasette)
+    needle = (q or "").lower()
+    results = []
+    for actor_id, display in actors:
+        if needle and needle not in actor_id.lower() and needle not in (
+            display or ""
+        ).lower():
+            continue
+        results.append(
+            {"id": actor_id, "display_name": display, "kind": "user"}
+        )
+    return results
+
+
+async def actors_json(request, datasette):
+    """GET /-/acl/api/actors?q=&kind=.
+
+    Thin actor-autocomplete proxy. Delegates to the user-profiles search API
+    when available, else falls back to ``datasette_acl_valid_actors`` filtered by
+    ``q`` in Python. Returns ``{"results": [{"id", "display_name", "avatar_url",
+    "kind", ...}]}``. Gated by the global ``datasette-acl`` permission.
+    """
+    if not await can_edit_permissions(datasette, request.actor):
+        raise Forbidden("Cannot search actors")
+    q = (request.args.get("q") or "").strip()
+    kind = request.args.get("kind")
+    results = await _profiles_search(datasette, q, kind)
+    if results is None:
+        results = await _valid_actors_fallback(datasette, q)
+    return Response.json({"results": results})
 
 
 async def revoke_json(request, datasette):

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -1,0 +1,198 @@
+"""JSON API for datasette-acl (the share component's backend).
+
+acl was form-POST only; this is the first JSON endpoint. Task 03 adds the
+*read* side:
+
+    GET /-/acl/api/resource/{resource_type}/{parent}/{child}
+
+returning the share state for one resource — the dialog's main read. Grants are
+grouped by principal, each principal's granted action-set is resolved to a
+friendly role, and actor grants are enriched with display name / email / avatar
+via core ``datasette.actors_from_ids`` (owned by user-profiles in phase-03;
+degrades to ``{"id": id}`` when profiles is not installed). Group grants resolve
+to a name + member count from ``acl_groups`` / ``acl_actor_groups``. Wildcard
+principals (``*`` / ``_signed_in`` / ``_anonymous``) are flagged ``kind:"public"``
+and surface in the dialog's "General access" section.
+
+Per-resource authorization (the manage check) is formalized in task 04. Until
+then ``can_manage`` is computed here from either the global ``datasette-acl``
+permission OR the per-resource manage action (via the roles registry); the read
+endpoint is gated on ``can_manage``.
+"""
+
+from datasette import Response, Forbidden
+
+from datasette_acl.grants import list_grants
+from datasette_acl.roles import role_for_actions, manage_actions
+from datasette_acl.utils import build_resource, resource_class_for, can_edit_permissions
+
+# Wildcard / "general access" principals. These are stored as actor_id values in
+# acl rows but represent classes of actor rather than a specific person, so the
+# UI renders them in a separate "General access" section.
+PUBLIC_PRINCIPALS = {"*", "_signed_in", "_anonymous"}
+
+
+def _roles_for(datasette, resource_type):
+    registry = getattr(datasette, "_acl_roles_registry", None) or {}
+    return registry.get(resource_type, [])
+
+
+def _roles_payload(roles):
+    """Serialize the roles registry for a resource type to the API shape."""
+    payload = []
+    for role in roles:
+        entry = {
+            "name": role.name,
+            "actions": list(role.actions),
+            "rank": role.rank,
+        }
+        if role.manage:
+            entry["manage"] = True
+        if role.description:
+            entry["description"] = role.description
+        payload.append(entry)
+    return payload
+
+
+async def can_manage(datasette, actor, resource_type, parent, child=None):
+    """Whether ``actor`` may manage sharing for this resource.
+
+    Task 04 will own the authoritative per-resource manage check; this is the
+    forward-compatible version it will build on. An actor can manage if EITHER:
+
+      * they hold the global ``datasette-acl`` permission (admin), OR
+      * they are allowed the resource type's "manage" action on this specific
+        resource (i.e. they hold a ``manage=True`` role grant).
+
+    Returns False (rather than raising) for unknown resource types.
+    """
+    if await can_edit_permissions(datasette, actor):
+        return True
+    manage = manage_actions(_roles_for(datasette, resource_type))
+    if not manage:
+        return False
+    try:
+        resource = build_resource(datasette, resource_type, parent, child)
+    except ValueError:
+        return False
+    for action in manage:
+        if await datasette.allowed(action=action, resource=resource, actor=actor):
+            return True
+    return False
+
+
+def _kind_for(actor_id, enriched):
+    """Resolve the ``kind`` for an actor-principal grant.
+
+    Wildcard principals are ``public``. Otherwise prefer a ``kind`` supplied by
+    the actor-resolution layer (profiles / agents); default to ``user``.
+    """
+    if actor_id in PUBLIC_PRINCIPALS:
+        return "public"
+    if enriched and enriched.get("kind"):
+        return enriched["kind"]
+    return "user"
+
+
+async def _group_info(datasette, group_ids):
+    """Return ``{group_id: {"name", "member_count"}}`` for the given ids."""
+    if not group_ids:
+        return {}
+    db = datasette.get_internal_database()
+    placeholders = ", ".join("?" for _ in group_ids)
+    rows = await db.execute(
+        f"""
+        SELECT
+            acl_groups.id AS id,
+            acl_groups.name AS name,
+            count(acl_actor_groups.actor_id) AS member_count
+        FROM acl_groups
+        LEFT JOIN acl_actor_groups ON acl_groups.id = acl_actor_groups.group_id
+        WHERE acl_groups.id IN ({placeholders})
+        GROUP BY acl_groups.id, acl_groups.name
+        """,
+        list(group_ids),
+    )
+    return {
+        row["id"]: {"name": row["name"], "member_count": row["member_count"]}
+        for row in rows.rows
+    }
+
+
+async def resource_grants_json(request, datasette):
+    """GET /-/acl/api/resource/{resource_type}/{parent}/{child}.
+
+    The child segment is optional so parent-only resource types also resolve.
+    """
+    resource_type = request.url_vars["resource_type"]
+    parent = request.url_vars["parent"]
+    child = request.url_vars.get("child")
+
+    if resource_class_for(datasette, resource_type) is None:
+        raise Forbidden(f"Unknown resource type: {resource_type}")
+
+    # Gate: for v1 the full grant list is readable only by managers.
+    actor_can_manage = await can_manage(
+        datasette, request.actor, resource_type, parent, child
+    )
+    if not actor_can_manage:
+        raise Forbidden("Cannot manage sharing for this resource")
+
+    roles = _roles_for(datasette, resource_type)
+    raw_grants = await list_grants(datasette, resource_type, parent, child)
+
+    # Enrich actor grants in one batch via core actors_from_ids. Wildcard
+    # principals are not real actors; we never look them up.
+    actor_ids = [
+        g["actor_id"]
+        for g in raw_grants
+        if g["principal"] == "actor" and g["actor_id"] not in PUBLIC_PRINCIPALS
+    ]
+    enriched = {}
+    if actor_ids:
+        enriched = await datasette.actors_from_ids(actor_ids) or {}
+
+    group_ids = [g["group_id"] for g in raw_grants if g["principal"] == "group"]
+    group_info = await _group_info(datasette, group_ids)
+
+    grants = []
+    for g in raw_grants:
+        role = role_for_actions(roles, set(g["actions"]))
+        if g["principal"] == "actor":
+            actor_id = g["actor_id"]
+            entry = {
+                "principal": "actor",
+                "id": actor_id,
+                "role": role.name if role else None,
+                "actions": g["actions"],
+                "kind": _kind_for(actor_id, enriched.get(actor_id)),
+            }
+            info = enriched.get(actor_id) or {}
+            for key in ("display_name", "email", "avatar_url"):
+                if info.get(key):
+                    entry[key] = info[key]
+            grants.append(entry)
+        else:
+            info = group_info.get(g["group_id"], {})
+            grants.append(
+                {
+                    "principal": "group",
+                    "id": str(g["group_id"]),
+                    "role": role.name if role else None,
+                    "actions": g["actions"],
+                    "kind": "group",
+                    "display_name": info.get("name", g["group_name"]),
+                    "member_count": info.get("member_count", 0),
+                }
+            )
+
+    return Response.json(
+        {
+            "resource_type": resource_type,
+            "parent": parent,
+            "child": child,
+            "can_manage": actor_can_manage,
+            "roles": _roles_payload(roles),
+            "grants": grants,
+        }
+    )

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -1,0 +1,458 @@
+"""Tests for the JSON mutation endpoints (task 04):
+
+    POST /-/acl/api/resource/{resource_type}/{parent}/{child}/grant
+    POST .../revoke
+    POST .../update
+
+Covers the grant/revoke/update happy paths (they mutate acl + write audit rows
+and return the expected JSON), per-resource authorization (a non-manager gets
+403; granting them the Manager role — directly or via a group — then lets them
+manage), and the datasette 1.0a30 header-based CSRF behavior (a cross-origin
+browser POST is rejected; a same-origin / non-browser POST is accepted).
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+from datasette_acl.grants import grant, list_grants
+from datasette_acl.roles import AclRole
+import pytest
+import pytest_asyncio
+
+
+class DocResource(Resource):
+    """Parent-only mock resource type used by these tests."""
+
+    name = "mock-doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT '42' AS parent, NULL AS child"
+
+
+DOC_ROLES = [
+    AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    AclRole(
+        "mock-doc",
+        "Manager",
+        ["doc-view", "doc-edit", "doc-manage"],
+        rank=3,
+        manage=True,
+    ),
+]
+
+FAKE_ACTORS = {
+    "alice": {
+        "id": "alice",
+        "display_name": "Alice Garcia",
+        "email": "alice@example.com",
+        "avatar_url": "/-/profile/pic/alice",
+        "kind": "user",
+    },
+}
+
+
+class ApiMutationPlugin:
+    __name__ = "ApiMutationPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(
+                name="doc-manage", description="Manage", resource_class=DocResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(DOC_ROLES)
+
+    @hookimpl
+    def actors_from_ids(self, datasette, actor_ids):
+        return {
+            actor_id: FAKE_ACTORS.get(actor_id, {"id": actor_id})
+            for actor_id in actor_ids
+        }
+
+
+@pytest_asyncio.fixture
+async def api_ds():
+    plugin = ApiMutationPlugin()
+    pm.register(plugin, name="api-mutation-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        await datasette.get_internal_database().execute_write(
+            "INSERT INTO acl_groups (name) VALUES ('staff')"
+        )
+        yield datasette
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="api-mutation-plugin")
+
+
+def _cookie(datasette, actor_id):
+    return {"ds_actor": datasette.client.actor_cookie({"id": actor_id})}
+
+
+def _root_cookie(datasette):
+    return _cookie(datasette, "root")
+
+
+async def _group_id(datasette, name):
+    return (
+        await datasette.get_internal_database().execute(
+            "SELECT id FROM acl_groups WHERE name = ?", [name]
+        )
+    ).single_value()
+
+
+async def _audit_rows(datasette):
+    rows = await datasette.get_internal_database().execute(
+        "SELECT operation, actor_id, group_id, operation_by FROM acl_audit ORDER BY id"
+    )
+    return [dict(r) for r in rows.rows]
+
+
+async def _post(datasette, path, json=None, cookies=None, headers=None):
+    return await datasette.client.post(
+        path,
+        json=json if json is not None else {},
+        cookies=cookies or {},
+        headers=headers or {},
+    )
+
+
+GRANT_URL = "/-/acl/api/resource/mock-doc/42/grant"
+REVOKE_URL = "/-/acl/api/resource/mock-doc/42/revoke"
+UPDATE_URL = "/-/acl/api/resource/mock-doc/42/update"
+
+
+# --- happy paths ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grant_by_role(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Editor"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert data["grant"]["id"] == "bob"
+    assert data["grant"]["role"] == "Editor"
+    assert data["grant"]["actions"] == ["doc-edit", "doc-view"]
+    assert data["grant"]["kind"] == "user"
+
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    bob = [g for g in grants if g["actor_id"] == "bob"][0]
+    assert bob["actions"] == ["doc-edit", "doc-view"]
+
+    audit = await _audit_rows(api_ds)
+    added = [r for r in audit if r["operation"] == "added" and r["actor_id"] == "bob"]
+    assert len(added) == 2
+    assert all(r["operation_by"] == "root" for r in added)
+
+
+@pytest.mark.asyncio
+async def test_grant_by_actions(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "carol", "actions": ["doc-view"]},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grant"]["role"] == "Viewer"
+    assert data["grant"]["actions"] == ["doc-view"]
+
+
+@pytest.mark.asyncio
+async def test_grant_enriched_display(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "alice", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    grant_entry = response.json()["grant"]
+    assert grant_entry["display_name"] == "Alice Garcia"
+    assert grant_entry["email"] == "alice@example.com"
+    assert grant_entry["avatar_url"] == "/-/profile/pic/alice"
+
+
+@pytest.mark.asyncio
+async def test_grant_group(api_ds):
+    gid = await _group_id(api_ds, "staff")
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"group_id": gid, "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    data = response.json()
+    assert data["grant"]["principal"] == "group"
+    assert data["grant"]["id"] == str(gid)
+    assert data["grant"]["role"] == "Viewer"
+    assert data["grant"]["kind"] == "group"
+    assert data["grant"]["display_name"] == "staff"
+
+
+@pytest.mark.asyncio
+async def test_grant_wildcard_principal(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "_signed_in", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    data = response.json()
+    assert data["grant"]["id"] == "_signed_in"
+    assert data["grant"]["kind"] == "public"
+    assert "display_name" not in data["grant"]
+
+
+@pytest.mark.asyncio
+async def test_update_swaps_role(api_ds):
+    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    response = await _post(
+        api_ds,
+        UPDATE_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grant"]["role"] == "Viewer"
+    assert data["grant"]["actions"] == ["doc-view"]
+
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    bob = [g for g in grants if g["actor_id"] == "bob"][0]
+    assert bob["actions"] == ["doc-view"]
+
+    audit = await _audit_rows(api_ds)
+    removed = [r for r in audit if r["operation"] == "removed" and r["actor_id"] == "bob"]
+    # Manager -> Viewer drops doc-edit and doc-manage.
+    assert {r["operation_by"] for r in removed} == {"root"}
+    assert len(removed) == 2
+
+
+@pytest.mark.asyncio
+async def test_revoke_removes_all(api_ds):
+    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    response = await _post(
+        api_ds,
+        REVOKE_URL,
+        json={"actor_id": "bob"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["ok"] is True
+    assert sorted(data["removed"]) == ["doc-edit", "doc-manage", "doc-view"]
+
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    assert [g for g in grants if g["actor_id"] == "bob"] == []
+
+    audit = await _audit_rows(api_ds)
+    removed = [r for r in audit if r["operation"] == "removed" and r["actor_id"] == "bob"]
+    assert len(removed) == 3
+    assert all(r["operation_by"] == "root" for r in removed)
+
+
+@pytest.mark.asyncio
+async def test_revoke_group(api_ds):
+    gid = await _group_id(api_ds, "staff")
+    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    response = await _post(
+        api_ds,
+        REVOKE_URL,
+        json={"group_id": gid},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    assert grants == []
+
+
+# --- per-resource authorization -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_manager_cannot_grant(api_ds):
+    # mallory has no manage action and is not the global admin.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_cookie(api_ds, "mallory"),
+    )
+    assert response.status_code == 403
+    # Nothing was written.
+    assert await list_grants(api_ds, "mock-doc", "42") == []
+
+
+@pytest.mark.asyncio
+async def test_anonymous_cannot_grant(api_ds):
+    response = await _post(api_ds, GRANT_URL, json={"actor_id": "bob", "role": "Viewer"})
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_manager_role_grants_manage_ability(api_ds):
+    # Granting mallory the Manager role (which includes doc-manage) lets her
+    # re-share, without the global datasette-acl permission.
+    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root")
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_cookie(api_ds, "mallory"),
+    )
+    assert response.status_code == 200
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    assert any(g["actor_id"] == "bob" for g in grants)
+
+
+@pytest.mark.asyncio
+async def test_non_manager_role_cannot_grant(api_ds):
+    # Editor is not a manage role, so it must NOT confer re-share ability.
+    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Editor", by_actor="root")
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_cookie(api_ds, "mallory"),
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_group_manager_role_grants_manage_ability(api_ds):
+    # mallory is in the staff group; the staff group holds the Manager role.
+    gid = await _group_id(api_ds, "staff")
+    db = api_ds.get_internal_database()
+    await db.execute_write(
+        "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
+        ["mallory", gid],
+    )
+    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Manager", by_actor="root")
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_cookie(api_ds, "mallory"),
+    )
+    assert response.status_code == 200
+    grants = await list_grants(api_ds, "mock-doc", "42")
+    assert any(g["actor_id"] == "bob" for g in grants)
+
+
+@pytest.mark.asyncio
+async def test_unknown_resource_type(api_ds):
+    response = await _post(
+        api_ds,
+        "/-/acl/api/resource/nope/42/grant",
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 403
+
+
+# --- bad input ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grant_requires_exactly_one_principal(api_ds):
+    # Neither principal.
+    response = await _post(
+        api_ds, GRANT_URL, json={"role": "Viewer"}, cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 400
+    assert response.json()["ok"] is False
+    # Both principals.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "group_id": 1, "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_grant_unknown_role(api_ds):
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Nope"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_requires_role(api_ds):
+    response = await _post(
+        api_ds, UPDATE_URL, json={"actor_id": "bob"}, cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_on_mutation_route_not_allowed(api_ds):
+    response = await api_ds.client.get(GRANT_URL, cookies=_root_cookie(api_ds))
+    assert response.status_code == 405
+
+
+# --- CSRF (datasette 1.0a30 header-based protection) ----------------------
+
+
+@pytest.mark.asyncio
+async def test_csrf_cross_origin_browser_post_rejected(api_ds):
+    # A browser cross-origin POST sends an Origin that does not match Host and
+    # no Sec-Fetch-Site=same-origin; core's CrossOriginProtectionMiddleware
+    # rejects it before our handler runs.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+        headers={"origin": "https://evil.example.com"},
+    )
+    assert response.status_code == 403
+    # The grant did not happen.
+    assert await list_grants(api_ds, "mock-doc", "42") == []
+
+
+@pytest.mark.asyncio
+async def test_csrf_same_origin_post_accepted(api_ds):
+    # Sec-Fetch-Site: same-origin is the signal a same-origin browser fetch
+    # sends; core lets it through. (The non-browser test client with no headers
+    # is already exercised by the happy-path tests above.)
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "bob", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+        headers={"sec-fetch-site": "same-origin"},
+    )
+    assert response.status_code == 200
+    assert response.json()["ok"] is True

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -236,6 +236,73 @@ async def test_actors_delegates_q_to_profiles(profiles_ds):
     assert [r["id"] for r in results] == ["evan"]
 
 
+# --- actors picker: the proxy forwards the caller's identity ---------------
+#
+# The actor picker proxies to profiles' search API via an internal
+# ``datasette.client`` request. That request is anonymous by default, so a
+# profiles ``profile_access`` gate would 403 it and the proxy would silently
+# return no results. The fix forwards ``request.actor`` on the internal call.
+# This fake search route enforces the same identity gate so the test fails if
+# the caller's actor is not forwarded.
+
+
+async def _gated_profiles_search(request, datasette):
+    """Stand-in for profiles' search API that enforces a ``profile_access`` gate.
+
+    Returns 403 unless the (forwarded) caller is the actor that holds access.
+    """
+    if not (request.actor and request.actor.get("id") == "root"):
+        return Response.json({"error": "forbidden"}, status=403)
+    return await _fake_profiles_search(request, datasette)
+
+
+class GatedProfilesPlugin:
+    __name__ = "GatedProfilesPlugin"
+
+    @hookimpl
+    def register_routes(self):
+        return [("^/-/profiles/api/search$", _gated_profiles_search)]
+
+    @hookimpl
+    def datasette_acl_valid_actors(self, datasette):
+        # If the gated delegation returns 403, the proxy must NOT silently fall
+        # back to these — it returns an empty list. So these never appear.
+        return [{"id": "fallback-leak", "display": "Fallback Leak"}]
+
+
+@pytest_asyncio.fixture
+async def gated_profiles_ds():
+    pm.register(GatedProfilesPlugin(), name="gated-profiles-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        yield datasette
+        db = datasette.get_internal_database()
+        for table in await db.table_names():
+            if table.startswith("acl"):
+                await db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="gated-profiles-plugin")
+
+
+@pytest.mark.asyncio
+async def test_actors_forwards_actor_to_gated_profiles(gated_profiles_ds):
+    # root passes the proxy's own datasette-acl admin gate AND the downstream
+    # profiles profile_access gate — but only if the internal request carries
+    # root's identity. This is the regression test for the identity-forwarding
+    # bug: an anonymous internal call would 403 and return an empty list.
+    response = await gated_profiles_ds.client.get(
+        "/-/acl/api/actors", cookies=_root_cookie(gated_profiles_ds)
+    )
+    assert response.status_code == 200
+    ids = {r["id"] for r in response.json()["results"]}
+    assert ids == {"dora", "evan"}
+    # The fallback was not consulted (the gated delegation succeeded).
+    assert "fallback-leak" not in ids
+
+
 # --- per-resource authorization (the share-dialog Manager) -----------------
 #
 # The share dialog is driven by per-resource Managers (a doc owner) who do NOT

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -1,0 +1,229 @@
+"""Tests for the picker endpoints (task 05):
+
+    GET /-/acl/api/groups
+    GET /-/acl/api/actors?q=&kind=
+
+The group picker draws from ``acl_groups`` (active groups + member counts). The
+actor picker is a thin proxy: it delegates to the user-profiles search API
+(``GET /-/profiles/api/search``) when installed, and otherwise falls back to
+``datasette_acl_valid_actors`` filtered by ``q`` in Python. Both endpoints gate
+on the global ``datasette-acl`` permission. Wildcard / public principals
+(``*``, ``_signed_in``, ``_anonymous``) need no write path — they are plain
+``actor_id`` strings — so they are exercised through the grant helpers in
+``test_custom_resources.py`` rather than here.
+"""
+
+from datasette import hookimpl
+from datasette import Response
+from datasette.app import Datasette
+from datasette.plugins import pm
+import pytest
+import pytest_asyncio
+
+
+def _root_cookie(datasette):
+    return {"ds_actor": datasette.client.actor_cookie({"id": "root"})}
+
+
+# --- groups picker --------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def groups_ds():
+    datasette = Datasette(config={"permissions": {"datasette-acl": {"id": "root"}}})
+    await datasette.invoke_startup()
+    db = datasette.get_internal_database()
+    await db.execute_write("INSERT INTO acl_groups (name) VALUES ('staff')")
+    await db.execute_write("INSERT INTO acl_groups (name) VALUES ('admins')")
+    # A soft-deleted group must not appear in the picker.
+    await db.execute_write(
+        "INSERT INTO acl_groups (name, deleted) VALUES ('old', 1)"
+    )
+    # Members so member_count is exercised.
+    staff_id = (
+        await db.execute("SELECT id FROM acl_groups WHERE name = 'staff'")
+    ).single_value()
+    for actor_id in ("a", "b"):
+        await db.execute_write(
+            "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
+            [actor_id, staff_id],
+        )
+    yield datasette
+    for table in await db.table_names():
+        if table.startswith("acl"):
+            await db.execute_write(f"drop table {table}")
+
+
+@pytest.mark.asyncio
+async def test_groups_requires_permission(groups_ds):
+    response = await groups_ds.client.get("/-/acl/api/groups")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_groups_lists_active_with_counts(groups_ds):
+    response = await groups_ds.client.get(
+        "/-/acl/api/groups", cookies=_root_cookie(groups_ds)
+    )
+    assert response.status_code == 200
+    groups = {g["name"]: g for g in response.json()["groups"]}
+    # Soft-deleted group excluded.
+    assert set(groups) == {"staff", "admins"}
+    assert groups["staff"]["member_count"] == 2
+    assert groups["admins"]["member_count"] == 0
+    # ids are present and integers.
+    assert isinstance(groups["staff"]["id"], int)
+
+
+# --- actors picker: fallback (no profiles) --------------------------------
+
+
+class ValidActorsPlugin:
+    __name__ = "ValidActorsPlugin"
+
+    @hookimpl
+    def datasette_acl_valid_actors(self, datasette):
+        return [
+            {"id": "alice", "display": "Alice Garcia"},
+            {"id": "bob", "display": "Bob Lee"},
+            {"id": "carol", "display": "Carol"},
+        ]
+
+
+@pytest_asyncio.fixture
+async def fallback_ds():
+    pm.register(ValidActorsPlugin(), name="valid-actors-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        yield datasette
+        db = datasette.get_internal_database()
+        for table in await db.table_names():
+            if table.startswith("acl"):
+                await db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="valid-actors-plugin")
+
+
+@pytest.mark.asyncio
+async def test_actors_requires_permission(fallback_ds):
+    response = await fallback_ds.client.get("/-/acl/api/actors")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_actors_fallback_returns_valid_actors(fallback_ds):
+    response = await fallback_ds.client.get(
+        "/-/acl/api/actors", cookies=_root_cookie(fallback_ds)
+    )
+    assert response.status_code == 200
+    results = response.json()["results"]
+    ids = {r["id"] for r in results}
+    assert ids == {"alice", "bob", "carol"}
+    alice = next(r for r in results if r["id"] == "alice")
+    assert alice["display_name"] == "Alice Garcia"
+    assert alice["kind"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_actors_fallback_filters_by_q(fallback_ds):
+    # q matches against id OR display_name, case-insensitively.
+    response = await fallback_ds.client.get(
+        "/-/acl/api/actors?q=garcia", cookies=_root_cookie(fallback_ds)
+    )
+    results = response.json()["results"]
+    assert [r["id"] for r in results] == ["alice"]
+
+    response = await fallback_ds.client.get(
+        "/-/acl/api/actors?q=BO", cookies=_root_cookie(fallback_ds)
+    )
+    results = response.json()["results"]
+    assert [r["id"] for r in results] == ["bob"]
+
+
+# --- actors picker: delegates to profiles search API ----------------------
+
+
+async def _fake_profiles_search(request, datasette):
+    """Stand-in for user-profiles' GET /-/profiles/api/search."""
+    q = (request.args.get("q") or "").strip().lower()
+    directory = [
+        {
+            "id": "dora",
+            "display_name": "Dora Profile",
+            "email": "dora@example.com",
+            "avatar_url": "/-/profile/pic/dora",
+            "kind": "user",
+        },
+        {
+            "id": "evan",
+            "display_name": "Evan Profile",
+            "email": "evan@example.com",
+            "avatar_url": "/-/profile/pic/evan",
+            "kind": "user",
+        },
+    ]
+    if q:
+        directory = [
+            r
+            for r in directory
+            if q in r["id"].lower() or q in r["display_name"].lower()
+        ]
+    return Response.json({"results": directory})
+
+
+class FakeProfilesPlugin:
+    __name__ = "FakeProfilesPlugin"
+
+    @hookimpl
+    def register_routes(self):
+        return [("^/-/profiles/api/search$", _fake_profiles_search)]
+
+    @hookimpl
+    def datasette_acl_valid_actors(self, datasette):
+        # If delegation works, these must NOT appear in the results.
+        return [{"id": "should-not-appear", "display": "Fallback Only"}]
+
+
+@pytest_asyncio.fixture
+async def profiles_ds():
+    pm.register(FakeProfilesPlugin(), name="fake-profiles-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        yield datasette
+        db = datasette.get_internal_database()
+        for table in await db.table_names():
+            if table.startswith("acl"):
+                await db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="fake-profiles-plugin")
+
+
+@pytest.mark.asyncio
+async def test_actors_delegates_to_profiles(profiles_ds):
+    response = await profiles_ds.client.get(
+        "/-/acl/api/actors", cookies=_root_cookie(profiles_ds)
+    )
+    assert response.status_code == 200
+    results = response.json()["results"]
+    ids = {r["id"] for r in results}
+    # Profiles results used; the valid_actors fallback was NOT consulted.
+    assert ids == {"dora", "evan"}
+    assert "should-not-appear" not in ids
+    dora = next(r for r in results if r["id"] == "dora")
+    assert dora["email"] == "dora@example.com"
+    assert dora["avatar_url"] == "/-/profile/pic/dora"
+
+
+@pytest.mark.asyncio
+async def test_actors_delegates_q_to_profiles(profiles_ds):
+    response = await profiles_ds.client.get(
+        "/-/acl/api/actors?q=evan", cookies=_root_cookie(profiles_ds)
+    )
+    results = response.json()["results"]
+    assert [r["id"] for r in results] == ["evan"]

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -16,13 +16,20 @@ on the global ``datasette-acl`` permission. Wildcard / public principals
 from datasette import hookimpl
 from datasette import Response
 from datasette.app import Datasette
+from datasette.permissions import Action, Resource
 from datasette.plugins import pm
+from datasette_acl.grants import grant
+from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
 
 
 def _root_cookie(datasette):
     return {"ds_actor": datasette.client.actor_cookie({"id": "root"})}
+
+
+def _cookie(datasette, actor_id):
+    return {"ds_actor": datasette.client.actor_cookie({"id": actor_id})}
 
 
 # --- groups picker --------------------------------------------------------
@@ -227,3 +234,149 @@ async def test_actors_delegates_q_to_profiles(profiles_ds):
     )
     results = response.json()["results"]
     assert [r["id"] for r in results] == ["evan"]
+
+
+# --- per-resource authorization (the share-dialog Manager) -----------------
+#
+# The share dialog is driven by per-resource Managers (a doc owner) who do NOT
+# hold the global ``datasette-acl`` permission. They authorize the pickers by
+# passing the dialog's resource (resource_type / parent / child); the endpoints
+# then run the same per-resource ``can_manage`` gate the read + mutation
+# endpoints use. Omitting the resource still requires global admin.
+
+
+class DocResource(Resource):
+    """Parent-only mock resource type for the per-resource picker tests."""
+
+    name = "mock-doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT '42' AS parent, NULL AS child"
+
+
+DOC_ROLES = [
+    AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    AclRole(
+        "mock-doc",
+        "Manager",
+        ["doc-view", "doc-edit", "doc-manage"],
+        rank=3,
+        manage=True,
+    ),
+]
+
+
+class DocPickerPlugin:
+    __name__ = "DocPickerPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(
+                name="doc-manage", description="Manage", resource_class=DocResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(DOC_ROLES)
+
+
+@pytest_asyncio.fixture
+async def resource_ds():
+    pm.register(DocPickerPlugin(), name="doc-picker-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        db = datasette.get_internal_database()
+        await db.execute_write("INSERT INTO acl_groups (name) VALUES ('staff')")
+        # bruce is a per-resource Manager (no global admin).
+        await grant(
+            datasette, "mock-doc", "42", actor_id="bruce", role="Manager",
+            by_actor="root",
+        )
+        yield datasette
+        for table in await db.table_names():
+            if table.startswith("acl"):
+                await db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="doc-picker-plugin")
+
+
+_RES = "resource_type=mock-doc&parent=42"
+
+
+@pytest.mark.asyncio
+async def test_manager_can_use_groups_picker_with_resource(resource_ds):
+    # bruce is not a global admin but manages mock-doc/42, so passing the
+    # resource lets him list groups.
+    response = await resource_ds.client.get(
+        f"/-/acl/api/groups?{_RES}", cookies=_cookie(resource_ds, "bruce")
+    )
+    assert response.status_code == 200
+    names = {g["name"] for g in response.json()["groups"]}
+    assert "staff" in names
+
+
+@pytest.mark.asyncio
+async def test_manager_can_use_actors_picker_with_resource(resource_ds):
+    response = await resource_ds.client.get(
+        f"/-/acl/api/actors?{_RES}", cookies=_cookie(resource_ds, "bruce")
+    )
+    assert response.status_code == 200
+    assert "results" in response.json()
+
+
+@pytest.mark.asyncio
+async def test_non_manager_cannot_use_pickers_with_resource(resource_ds):
+    # mallory holds no manage action on the resource and is not global admin.
+    for path in (
+        f"/-/acl/api/groups?{_RES}",
+        f"/-/acl/api/actors?{_RES}",
+    ):
+        response = await resource_ds.client.get(
+            path, cookies=_cookie(resource_ds, "mallory")
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_anonymous_cannot_use_pickers_with_resource(resource_ds):
+    for path in (
+        f"/-/acl/api/groups?{_RES}",
+        f"/-/acl/api/actors?{_RES}",
+    ):
+        response = await resource_ds.client.get(path)
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_manager_without_resource_still_requires_global_admin(resource_ds):
+    # Without the resource params, the global-admin fallback applies, so a
+    # per-resource Manager who lacks global admin is rejected (existing behavior).
+    for path in ("/-/acl/api/groups", "/-/acl/api/actors"):
+        response = await resource_ds.client.get(
+            path, cookies=_cookie(resource_ds, "bruce")
+        )
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_global_admin_still_works_without_resource(resource_ds):
+    # root holds the global datasette-acl permission → pickers work with no
+    # resource params (back-compat).
+    for path in ("/-/acl/api/groups", "/-/acl/api/actors"):
+        response = await resource_ds.client.get(
+            path, cookies=_root_cookie(resource_ds)
+        )
+        assert response.status_code == 200

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -1,0 +1,264 @@
+"""Tests for the JSON read endpoint (task 03):
+
+    GET /-/acl/api/resource/{resource_type}/{parent}/{child}
+
+Seeds actor / group / wildcard grants on a mock resource and asserts the JSON
+shape: grants grouped by principal with a resolved role, actor enrichment from a
+fake ``actors_from_ids`` test plugin (display name / email / avatar / kind),
+group ``member_count``, wildcard principals flagged ``kind:"public"``, and the
+``roles`` registry + ``can_manage`` flag.
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+from datasette_acl.grants import grant
+from datasette_acl.roles import AclRole
+import pytest
+import pytest_asyncio
+
+
+class DocResource(Resource):
+    """Parent-only mock resource type used by these tests."""
+
+    name = "mock-doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT '42' AS parent, NULL AS child"
+
+
+DOC_ROLES = [
+    AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    AclRole(
+        "mock-doc",
+        "Manager",
+        ["doc-view", "doc-edit", "doc-manage"],
+        rank=3,
+        manage=True,
+    ),
+]
+
+# Fake directory the test plugin's actors_from_ids resolves against. Includes a
+# user and an agent (with kind) so enrichment + kind passthrough are exercised.
+FAKE_ACTORS = {
+    "alice": {
+        "id": "alice",
+        "display_name": "Alice Garcia",
+        "email": "alice@example.com",
+        "avatar_url": "/-/profile/pic/alice",
+        "kind": "user",
+    },
+    "agent:researcher": {
+        "id": "agent:researcher",
+        "display_name": "Researcher",
+        "avatar_url": "/-/agent/pic/researcher",
+        "kind": "agent",
+    },
+}
+
+
+class ApiDocPlugin:
+    __name__ = "ApiDocPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(
+                name="doc-manage", description="Manage", resource_class=DocResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(DOC_ROLES)
+
+    @hookimpl
+    def actors_from_ids(self, datasette, actor_ids):
+        # Resolve known ids; unknown ids fall back to {"id": id} (mirrors the
+        # core default so the endpoint still returns a usable grant).
+        return {
+            actor_id: FAKE_ACTORS.get(actor_id, {"id": actor_id})
+            for actor_id in actor_ids
+        }
+
+
+@pytest_asyncio.fixture
+async def api_ds():
+    plugin = ApiDocPlugin()
+    pm.register(plugin, name="api-doc-plugin")
+    try:
+        datasette = Datasette(
+            config={"permissions": {"datasette-acl": {"id": "root"}}}
+        )
+        await datasette.invoke_startup()
+        await datasette.get_internal_database().execute_write(
+            "INSERT INTO acl_groups (name) VALUES ('staff')"
+        )
+        yield datasette
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="api-doc-plugin")
+
+
+async def _group_id(datasette, name):
+    return (
+        await datasette.get_internal_database().execute(
+            "SELECT id FROM acl_groups WHERE name = ?", [name]
+        )
+    ).single_value()
+
+
+def _root_cookie(datasette):
+    return {"ds_actor": datasette.client.actor_cookie({"id": "root"})}
+
+
+async def _get(datasette, path, cookies=None):
+    return await datasette.client.get(path, cookies=cookies or {})
+
+
+# --- gating ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_requires_manage(api_ds):
+    # Anonymous / non-manager is forbidden.
+    response = await _get(api_ds, "/-/acl/api/resource/mock-doc/42")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_read_unknown_resource_type(api_ds):
+    response = await _get(
+        api_ds, "/-/acl/api/resource/nope/42", cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_per_resource_manager_can_read(api_ds):
+    # Grant alice the Manager role (which includes the manage action) and prove
+    # she can read the endpoint without the global datasette-acl permission.
+    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    cookies = {"ds_actor": api_ds.client.actor_cookie({"id": "alice"})}
+    response = await _get(api_ds, "/-/acl/api/resource/mock-doc/42", cookies=cookies)
+    assert response.status_code == 200
+    assert response.json()["can_manage"] is True
+
+
+# --- shape ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_full_shape(api_ds):
+    gid = await _group_id(api_ds, "staff")
+    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    await grant(
+        api_ds, "mock-doc", "42", actor_id="agent:researcher", role="Editor", by_actor="root"
+    )
+    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        api_ds, "mock-doc", "42", actor_id="_signed_in", role="Viewer", by_actor="root"
+    )
+
+    response = await _get(
+        api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["resource_type"] == "mock-doc"
+    assert data["parent"] == "42"
+    assert data["child"] is None
+    assert data["can_manage"] is True
+
+    # roles registry surfaced, in rank order, manage flag preserved.
+    assert [r["name"] for r in data["roles"]] == ["Viewer", "Editor", "Manager"]
+    assert data["roles"][-1]["manage"] is True
+    assert data["roles"][0]["actions"] == ["doc-view"]
+
+    grants = {(g["principal"], g["id"]): g for g in data["grants"]}
+
+    # Actor grant enriched + role resolved.
+    alice = grants[("actor", "alice")]
+    assert alice["role"] == "Manager"
+    assert alice["kind"] == "user"
+    assert alice["display_name"] == "Alice Garcia"
+    assert alice["email"] == "alice@example.com"
+    assert alice["avatar_url"] == "/-/profile/pic/alice"
+
+    # Agent: kind passthrough from actors_from_ids.
+    agent = grants[("actor", "agent:researcher")]
+    assert agent["role"] == "Editor"
+    assert agent["kind"] == "agent"
+    assert agent["display_name"] == "Researcher"
+
+    # Group grant: name + member_count + kind group.
+    group = grants[("group", str(gid))]
+    assert group["role"] == "Viewer"
+    assert group["kind"] == "group"
+    assert group["display_name"] == "staff"
+    assert group["member_count"] == 0
+
+    # Wildcard principal flagged public.
+    wildcard = grants[("actor", "_signed_in")]
+    assert wildcard["role"] == "Viewer"
+    assert wildcard["kind"] == "public"
+    # No enrichment looked up for a wildcard principal.
+    assert "display_name" not in wildcard
+
+
+@pytest.mark.asyncio
+async def test_group_member_count(api_ds):
+    gid = await _group_id(api_ds, "staff")
+    db = api_ds.get_internal_database()
+    for actor_id in ("a", "b", "c"):
+        await db.execute_write(
+            "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
+            [actor_id, gid],
+        )
+    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    response = await _get(
+        api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
+    )
+    group = response.json()["grants"][0]
+    assert group["principal"] == "group"
+    assert group["member_count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_read_empty_resource(api_ds):
+    response = await _get(
+        api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["grants"] == []
+    # roles + can_manage still present.
+    assert data["can_manage"] is True
+    assert len(data["roles"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_unknown_actor_falls_back(api_ds):
+    # An actor with no directory entry still resolves (kind user, no names).
+    await grant(api_ds, "mock-doc", "42", actor_id="ghost", role="Viewer", by_actor="root")
+    response = await _get(
+        api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
+    )
+    ghost = response.json()["grants"][0]
+    assert ghost["id"] == "ghost"
+    assert ghost["role"] == "Viewer"
+    assert ghost["kind"] == "user"
+    assert "display_name" not in ghost

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -195,7 +195,7 @@ async def test_signed_in_wildcard_grant(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_anonymous_wildcard_grant(widget_ds):
+async def test_star_wildcard_grant(widget_ds):
     # Grant '*' => literally anyone, including anonymous
     await _grant_actor(widget_ds, "*", "widget", "shelf", "gadget", "widget-view")
     resource = WidgetResource("shelf", "gadget")
@@ -207,6 +207,20 @@ async def test_anonymous_wildcard_grant(widget_ds):
     )
 
 
+@pytest.mark.asyncio
+async def test_anonymous_wildcard_grant(widget_ds):
+    # Grant '_anonymous' => only unauthenticated callers; a signed-in actor is not
+    # matched by this grant.
+    await _grant_actor(
+        widget_ds, "_anonymous", "widget", "shelf", "gadget", "widget-view"
+    )
+    resource = WidgetResource("shelf", "gadget")
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -12,6 +12,7 @@ from datasette_acl.roles import (
     role_for_actions,
     actions_for_role,
     manage_actions,
+    manage_only_actions,
 )
 import pytest
 import pytest_asyncio
@@ -127,3 +128,19 @@ def test_manage_actions_empty_when_no_manage_role():
         AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
     ]
     assert manage_actions(roles) == set()
+
+
+def test_manage_only_actions_excludes_shared_actions():
+    # The manage gate must authorize against only the action(s) exclusive to a
+    # manage role; the bundled view/edit actions must NOT count (otherwise any
+    # Viewer/Editor would pass the manage check).
+    roles = list(MOCK_ROLES)
+    assert manage_only_actions(roles) == {"doc-manage"}
+
+
+def test_manage_only_actions_empty_when_no_manage_role():
+    roles = [
+        AclRole("mock-doc", "Viewer", ["doc-view"], rank=1),
+        AclRole("mock-doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    ]
+    assert manage_only_actions(roles) == set()


### PR DESCRIPTION
**Stack 6/6** of splitting #29 (sharing-v2). Stacked on #34 — review/merge that first.

## Goal
The REST surface the share dialog consumes — read grants, mutate grants, and search actors/groups — all authorized **per-resource** via `can_manage`, so a document owner can manage grants without holding a global `datasette-acl` admin role.

## Changes (5 commits)
- `GET /-/acl/api/resource` — read grants for a resource.
- Grant/revoke/update JSON endpoints with per-resource authorization.
- Group/actor picker endpoints + `*` / `_signed_in` / `_anonymous` wildcard principals.
- Pickers accept per-resource manage authz.
- Forward caller actor on the internal `/-/acl/api/actors` → profiles proxy via `datasette.client.get(..., actor=...)` (previously anonymous → returned empty). Includes a regression test.

Imports `grants.py` (#34) and `roles.py` (#33); uses `utils.py` discovery (#32).

## Tests
- `tests/test_api_read.py` (7), `tests/test_api_mutations.py` (20), `tests/test_api_pickers.py` (14), plus mutation cases in `tests/test_roles.py`.
- 95 passing on this branch (full suite — this is the stack tip).

## Note
This branch tip reproduces the original `asg017/sharing-v2` (PR #29) exactly, minus two intentional drops: the two `PLAN-*.md` design docs, and the dead datasette-<1.0a30 CSRF-token plumbing (see #30). No source/behavior drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)