### PR TITLE
2/7 Use sqlite-migrate for internal schema

### DIFF
--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -7,80 +7,14 @@ from datasette.plugins import pm
 from datasette_acl.utils import can_edit_permissions
 from datasette_acl.views.table_acls import manage_table_acls
 from datasette_acl.views.groups import manage_groups, manage_group
+from datasette_acl.internal_migrations import internal_migrations
+from sqlite_utils import Database
 from . import hookspecs
 import json
 import sys
 import time
 
 pm.add_hookspecs(hookspecs)
-
-CREATE_TABLES_SQL = """
-create table if not exists acl_resources (
-    id integer primary key,
-    database text not null,
-    resource text,
-    unique(database, resource)
-);
-
-create table if not exists acl_actions (
-    id integer primary key,
-    name text not null unique
-);
-
--- new table for groups
-create table if not exists acl_groups (
-    id integer primary key,
-    name text not null unique,
-    deleted integer
-);
-
--- new table for actor-group relationships
-create table if not exists acl_actor_groups (
-    actor_id text,
-    group_id integer,
-    primary key (actor_id, group_id),
-    foreign key (group_id) references acl_groups(id)
-);
-
--- Group membership audit log
-create table if not exists acl_groups_audit (
-    id integer primary key,
-    timestamp text default (datetime('now')),
-    operation_by text,
-    operation text check (operation in ('added', 'removed', 'created', 'deleted')),
-    group_id integer,
-    actor_id text,
-    foreign key (group_id) references acl_groups(id)
-);
-
-create table if not exists acl (
-    acl_id integer primary key,
-    actor_id text,
-    group_id integer,
-    resource_id integer,
-    action_id integer,
-    foreign key (group_id) references acl_groups(id),
-    foreign key (resource_id) references acl_resources(id),
-    foreign key (action_id) references acl_actions(id),
-    check ((actor_id is null) != (group_id is null)),
-    unique(actor_id, group_id, resource_id, action_id)
-);
-
--- ACL audit log
-create table if not exists acl_audit (
-    id integer primary key,
-    timestamp text default (datetime('now')),
-    operation_by text,
-    operation text check (operation in ('added', 'removed')),
-    action_id integer,
-    resource_id integer,
-    group_id integer,
-    actor_id text,
-    foreign key (group_id) references acl_groups(id),
-    foreign key (resource_id) references acl_resources(id),
-    foreign key (action_id) references acl_actions(id)
-)
-"""
 
 EXPECTED_GROUPS_SQL = """
 with expected_groups as (
@@ -121,7 +55,11 @@ from actual_groups
 def startup(datasette):
     async def inner():
         db = datasette.get_internal_database()
-        await db.execute_write_script(CREATE_TABLES_SQL)
+
+        def apply_migrations(connection):
+            internal_migrations.apply(Database(connection))
+
+        await db.execute_write_fn(apply_migrations)
         # Ensure permissions are in the DB
         await db.execute_write_many(
             """

--- a/datasette_acl/internal_migrations.py
+++ b/datasette_acl/internal_migrations.py
@@ -1,0 +1,83 @@
+"""Schema migrations for datasette-acl (sqlite-migrate).
+
+All ACL tables live in Datasette's internal database. Migrations are
+append-only: never edit an existing ``mNNN_`` function once it has shipped,
+add a new one instead. They are applied from the ``startup`` hook via
+:func:`datasette_acl.internal_migrations.internal_migrations.apply`.
+"""
+
+from sqlite_utils import Database
+from sqlite_migrate import Migrations
+
+internal_migrations = Migrations("datasette-acl.internal")
+
+
+@internal_migrations()
+def m001_initial(db: Database):
+    db.executescript("""
+    create table if not exists acl_resources (
+        id integer primary key,
+        database text not null,
+        resource text,
+        unique(database, resource)
+    );
+
+    create table if not exists acl_actions (
+        id integer primary key,
+        name text not null unique
+    );
+
+    -- new table for groups
+    create table if not exists acl_groups (
+        id integer primary key,
+        name text not null unique,
+        deleted integer
+    );
+
+    -- new table for actor-group relationships
+    create table if not exists acl_actor_groups (
+        actor_id text,
+        group_id integer,
+        primary key (actor_id, group_id),
+        foreign key (group_id) references acl_groups(id)
+    );
+
+    -- Group membership audit log
+    create table if not exists acl_groups_audit (
+        id integer primary key,
+        timestamp text default (datetime('now')),
+        operation_by text,
+        operation text check (operation in ('added', 'removed', 'created', 'deleted')),
+        group_id integer,
+        actor_id text,
+        foreign key (group_id) references acl_groups(id)
+    );
+
+    create table if not exists acl (
+        acl_id integer primary key,
+        actor_id text,
+        group_id integer,
+        resource_id integer,
+        action_id integer,
+        foreign key (group_id) references acl_groups(id),
+        foreign key (resource_id) references acl_resources(id),
+        foreign key (action_id) references acl_actions(id),
+        check ((actor_id is null) != (group_id is null)),
+        unique(actor_id, group_id, resource_id, action_id)
+    );
+
+    -- ACL audit log
+    create table if not exists acl_audit (
+        id integer primary key,
+        timestamp text default (datetime('now')),
+        operation_by text,
+        operation text check (operation in ('added', 'removed')),
+        action_id integer,
+        resource_id integer,
+        group_id integer,
+        actor_id text,
+        foreign key (group_id) references acl_groups(id),
+        foreign key (resource_id) references acl_resources(id),
+        foreign key (action_id) references acl_actions(id)
+    );
+    """)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ classifiers=[
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "datasette>=1.0a20"
+    "datasette>=1.0a20",
+    "sqlite-migrate==0.1b0"
 ]
 
 [dependency-groups]

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -7,3 +7,26 @@ async def test_can_startup_with_no_configuration():
     datasette = Datasette()
     await datasette.invoke_startup()
     assert (await datasette.client.get("/")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_startup_applies_internal_migrations():
+    # Startup should create the ACL tables via sqlite-migrate and record the
+    # applied migrations in the _sqlite_migrations tracking table.
+    datasette = Datasette(memory=True)
+    await datasette.invoke_startup()
+    db = datasette.get_internal_database()
+    tables = set(await db.table_names())
+    assert {"acl", "acl_resources", "acl_actions", "acl_groups"} <= tables
+    assert "_sqlite_migrations" in tables
+    applied = [
+        r["name"]
+        for r in await db.execute(
+            "select name from _sqlite_migrations where migration_set = ?",
+            ["datasette-acl.internal"],
+        )
+    ]
+    assert "m001_initial" in applied
+
+    # Re-running startup is idempotent.
+    await datasette.invoke_startup()


### PR DESCRIPTION
**Stack 2/7** of splitting #29 (sharing-v2). Stacked on #30 — review/merge that first. Base: `acl/1-test-compat`.

## Goal
Manage datasette-acl's internal database schema with the [sqlite-migrate](https://github.com/simonw/sqlite-migrate) library instead of running a `CREATE TABLE` script on every startup. Inserted into the stack so the resource-model change (next PR) can land as a real migration rather than a hand-rolled, feature-detecting `ALTER` in `startup()`.

## Changes
- `datasette_acl/internal_migrations.py` (new) — migration set `datasette-acl.internal`; `m001_initial` carries the existing schema verbatim.
- `datasette_acl/__init__.py` — `startup()` applies pending migrations via `internal_migrations.apply(Database(connection))` inside `execute_write_fn`, replacing `execute_write_script(CREATE_TABLES_SQL)`.
- `pyproject.toml` — add `sqlite-migrate==0.1b0`.

Mirrors the migration setup already used by `datasette-comments` and `datasette-aforms`.

## Tests
- `tests/test_startup.py` — assert startup applies migrations and records them in `_sqlite_migrations`; idempotent re-run.
- 16 passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
