### PR TITLE
4/7 Generic resource ACL admin view + dynamic action discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,41 @@ Permission can be granted for each of the above table actions. They can be assig
 
 An audit log tracks which permissions were added and removed, displayed at the bottom of the table permissions page.
 
+### Custom resource types
+
+`datasette-acl` is not limited to tables. It can store and resolve grants for *any* resource type defined by a plugin - documents, lists, workbooks, comment spaces, kanban boards and so on.
+
+There is no dedicated hook for this. A plugin makes its resource type manageable by `datasette-acl` simply by registering actions whose `resource_class` is a [Resource](https://docs.datasette.io/en/latest/internals.html) subclass:
+
+```python
+from datasette import hookimpl
+from datasette.permissions import Action, Resource
+
+
+class PaperDoc(Resource):
+    name = "paper-doc"
+
+
+@hookimpl
+def register_actions(datasette):
+    return [
+        Action(name="paper-view", description="View a doc", resource_class=PaperDoc),
+        Action(name="paper-edit", description="Edit a doc", resource_class=PaperDoc),
+    ]
+```
+
+`datasette-acl` discovers resource types from the actions registered across all plugins (`datasette.actions`). Both the action set offered on the table permissions page and the resource types managed by the generic admin page are derived dynamically from this - nothing is hardcoded.
+
+A generic admin page for any resource type lives at:
+
+```
+/-/acl/resource/<resource-type>/<parent>/<child>
+```
+
+For example `/-/acl/resource/paper-doc/workspace-1/doc-42`. The `<child>` segment is optional for parent-only resource types (`/-/acl/resource/<resource-type>/<parent>`). The page presents the same group/user grant interface and audit log as the table page, with checkboxes for exactly the actions registered for that resource type. Access to this admin page is gated on the `datasette-acl` permission described below.
+
+Grants made here flow through Datasette's permission system: once granted, `await datasette.allowed(actor=..., action="paper-edit", resource=PaperDoc("workspace-1", "doc-42"))` returns `True`.
+
 ### Controlling who can edit permissions
 
 Users with the new `datasette-acl` permission will have the ability to access a UI for setting permissions for users and groups on a table.

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -5,6 +5,7 @@ from datasette.utils import actor_matches_allow
 from datasette.plugins import pm
 from datasette_acl.utils import can_edit_permissions
 from datasette_acl.views.table_acls import manage_table_acls
+from datasette_acl.views.resource_acls import manage_resource_acls
 from datasette_acl.views.groups import manage_groups, manage_group
 from datasette_acl.internal_migrations import internal_migrations
 from sqlite_utils import Database
@@ -360,4 +361,14 @@ def register_routes():
         ("^/(?P<database>[^/]+)/(?P<table>[^/]+)/-/acl$", manage_table_acls),
         ("^/-/acl/groups$", manage_groups),
         ("^/-/acl/groups/(?P<name>[^/]+)$", manage_group),
+        # Generic per-resource-type admin page. The child segment is optional
+        # so parent-only resource types (e.g. a database) are also managed here.
+        (
+            "^/-/acl/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)/(?P<child>[^/]+)$",
+            manage_resource_acls,
+        ),
+        (
+            "^/-/acl/resource/(?P<resource_type>[^/]+)/(?P<parent>[^/]+)$",
+            manage_resource_acls,
+        ),
     ]

--- a/datasette_acl/templates/manage_resource_acls.html
+++ b/datasette_acl/templates/manage_resource_acls.html
@@ -1,0 +1,171 @@
+{% extends "base.html" %}
+
+{% block title %}Permissions for {{ resource_type }}: {{ parent }}{% if child %}/{{ child }}{% endif %}{% endblock %}
+
+{% block extra_head %}
+<script src="{{ urls.static_plugins("datasette-acl", "choices-9.0.1.min.js") }}"></script>
+<link rel="stylesheet" href="{{ urls.static_plugins("datasette-acl", "choices-9.0.1.min.css") }}">
+<style>
+#needs-save-message {
+  color: rgb(249, 114, 114);
+  font-weight: bold;
+  margin-top: 10px;
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  padding-left: 0.8em;
+}
+#needs-save-message.visible {
+  opacity: 1;
+}
+table.audit {
+  border-collapse: collapse;
+}
+table.audit td {
+  border-top: 1px solid #aaa;
+  border-right: 1px solid #eee;
+  padding: 4px;
+  vertical-align: top;
+}
+</style>
+{% endblock %}
+
+{% block content %}
+<h1>Permissions for {{ resource_type }}: {{ parent }}{% if child %}/{{ child }}{% endif %}</h1>
+
+<form action="{{ request.path }}" method="post">
+  {% if groups %}
+  <h3>Groups</h3>
+  {% for group in groups %}
+    <div style="margin-bottom: 1em">
+      <label style="display: block" for="id_group_permissions_{{ group }}"><a href="{{ urls.path("/-/acl/groups/" + group) }}">{{ group }}</a> ({{ group_sizes[group] }})</label>
+      <select multiple name="group_permissions_{{ group }}" id="id_group_permissions_{{ group }}">
+        {% for action in actions %}
+          <option value="{{ action }}" {% if group_permissions and group_permissions.get(group, {}).get(action) %}selected{% endif %}>{{ action }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  {% endfor %}
+{% endif %}
+
+<h3>Users</h3>
+{% for user in user_permissions %}
+  <div>
+    {{ user }}
+    <select multiple name="user_permissions_{{ user }}">
+      {% for action in actions %}
+        <option value="{{ action }}" {% if user_permissions and user_permissions.get(user, {}).get(action) %}selected{% endif %}>{{ action }}</option>
+      {% endfor %}
+    </select>
+  </div>
+{% endfor %}
+
+<div style="margin-top: 2em">
+  <label for="id_new_actor_id" style="display: block; font-size: 0.8em">Other user:</label>
+  {% if valid_actors %}
+    <select id="id_new_actor_id" name="new_actor_id">
+      <option></option>
+      {% for actor in valid_actors %}
+        <option value="{{ actor[0] }}">{{ actor[1] }}</option>
+      {% endfor %}
+    </select>
+  {% else %}
+    <input data-1p-ignore placeholder="User ID" style="width: 8em" id="id_new_actor_id" name="new_actor_id">
+  {% endif %}
+</div>
+
+<div>
+  <label for="id_new_user_actions" style="display: block; font-size: 0.8em">Permissions for the additional user:</label>
+  <select multiple name="new_user_actions" id="id_new_user_actions">
+    {% for action in actions %}
+      <option value="{{ action }}">{{ action }}</option>
+    {% endfor %}
+  </select>
+</div>
+
+<p style="margin-top: 1em">
+  <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+  <input type="submit" value="Save changes" class="core">
+  <span id="needs-save-message"></span>
+</p>
+</form>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const selects = document.querySelectorAll('select');
+    selects.forEach(select => {
+        new Choices(select, {
+            removeItemButton: true,
+            containerOuter: 'choices'
+        });
+    });
+});
+</script>
+
+{% if audit_log %}
+<h2>Audit history</h2>
+<table class="audit">
+  <thead>
+    <tr>
+      <th>Date and time</th>
+      <th>Operation by</th>
+      <th>Operation</th>
+      <th>Group</th>
+      <th>User</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for entry in audit_log %}
+      <tr>
+        <td>{{ entry.timestamp }}</td>
+        <td>{{ entry.operation_by }}</td>
+        <td>{{ entry.operation }}</td>
+        <td>{{ entry.group_name or '' }}</td>
+        <td>{{ entry.actor_id or '' }}</td>
+        <td>{{ entry.action_name }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+<script>
+// "You have unsaved changes" message
+const initialState = {};
+const checkboxes = document.querySelectorAll('table input[type="checkbox"]');
+const messageElement = document.getElementById("needs-save-message");
+
+function updateInitialState() {
+  checkboxes.forEach((checkbox) => {
+    initialState[checkbox.name] = checkbox.checked;
+  });
+}
+
+function hasStateChanged() {
+  return Array.from(checkboxes).some(
+    (checkbox) => initialState[checkbox.name] !== checkbox.checked,
+  );
+}
+
+function updateMessage() {
+  if (hasStateChanged()) {
+    messageElement.textContent = "You have unsaved changes";
+    messageElement.classList.add("visible");
+  } else {
+    messageElement.classList.remove("visible");
+    setTimeout(() => {
+      if (!hasStateChanged()) {
+        messageElement.textContent = "";
+      }
+    }, 500);
+  }
+}
+
+updateInitialState();
+
+checkboxes.forEach((checkbox) => {
+  checkbox.addEventListener("change", updateMessage);
+});
+</script>
+
+{% endblock %}

--- a/datasette_acl/utils.py
+++ b/datasette_acl/utils.py
@@ -1,10 +1,44 @@
+from __future__ import annotations
+
 from datasette.plugins import pm
 from datasette.utils import await_me_maybe
-from typing import List, Tuple
+from typing import List, Optional, Tuple, Type, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datasette.app import Datasette
+    from datasette.permissions import Resource
 
 
 async def can_edit_permissions(datasette, actor):
     return await datasette.allowed(actor=actor, action="datasette-acl")
+
+
+def resource_class_for(
+    datasette: Datasette, resource_type: str
+) -> Optional[Type[Resource]]:
+    """Return the Resource subclass whose .name == resource_type, or None.
+
+    Resource types are discovered from registered actions (datasette.actions),
+    so any plugin that registers actions with a resource_class is manageable by
+    acl without a dedicated hook.
+    """
+    for action in datasette.actions.values():
+        rc = action.resource_class
+        if rc is not None and rc.name == resource_type:
+            return rc
+    return None
+
+
+def actions_for_resource_type(
+    datasette: Datasette, resource_type: str
+) -> List[str]:
+    """Action names whose resource_class.name == resource_type, in registration order."""
+    return [
+        action.name
+        for action in datasette.actions.values()
+        if action.resource_class is not None
+        and action.resource_class.name == resource_type
+    ]
 
 
 def generate_changes_message(changes_made, noun):

--- a/datasette_acl/views/resource_acls.py
+++ b/datasette_acl/views/resource_acls.py
@@ -1,47 +1,51 @@
 from datasette import Response, Forbidden
-from datasette.utils import MultiParams
 from datasette_acl.utils import (
     actions_for_resource_type,
     can_edit_permissions,
     generate_changes_message,
     get_acl_valid_actors,
+    resource_class_for,
     validate_actor_id,
 )
+from datasette.utils import MultiParams
 from urllib.parse import parse_qs
 
 
-def table_actions_list(datasette):
-    """Action names scoped to the 'table' resource type.
-
-    Discovered dynamically from datasette.actions rather than hardcoded, so any
-    plugin that registers table-scoped actions is managed here automatically.
-    """
-    return actions_for_resource_type(datasette, "table")
-
-
-async def manage_table_acls(request, datasette):
+async def manage_resource_acls(request, datasette):
+    # Admin page: gated on the global datasette-acl permission. Per-resource
+    # authorization (who may manage a specific resource) arrives with the JSON
+    # API in phase-02.
     if not await can_edit_permissions(datasette, request.actor):
         raise Forbidden("You do not have permission to edit permissions")
-    table = request.url_vars["table"]
-    database = request.url_vars["database"]
-    actions = table_actions_list(datasette)
+
+    resource_type = request.url_vars["resource_type"]
+    parent = request.url_vars["parent"]
+    child = request.url_vars.get("child")
+
+    # The resource type must correspond to a known, action-bearing resource
+    # class, otherwise there is nothing to manage.
+    if resource_class_for(datasette, resource_type) is None:
+        raise Forbidden(f"Unknown resource type: {resource_type}")
+
+    actions = actions_for_resource_type(datasette, resource_type)
+
     internal_db = datasette.get_internal_database()
     groups = [
         g["name"]
-        for g in await datasette.get_internal_database().execute(
+        for g in await internal_db.execute(
             "select name from acl_groups where deleted is null"
         )
     ]
 
-    # Ensure we have a resource_id for this table
+    # Ensure we have a resource_id for this resource
     await internal_db.execute_write(
-        "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES ('table', ?, ?);",
-        [database, table],
+        "INSERT OR IGNORE INTO acl_resources (resource_type, parent, child) VALUES (?, ?, ?);",
+        [resource_type, parent, child],
     )
     resource_id = (
         await internal_db.execute(
-            "SELECT id FROM acl_resources WHERE resource_type = 'table' AND parent = ? AND child = ?",
-            [database, table],
+            "SELECT id FROM acl_resources WHERE resource_type = ? AND parent = ? AND child IS ?",
+            [resource_type, parent, child],
         )
     ).single_value()
 
@@ -66,7 +70,6 @@ async def manage_table_acls(request, datasette):
         action_name = row["action_name"]
         if group_name:
             current_group_permissions.setdefault(group_name, {})[action_name] = True
-            current_group_permissions[group_name][action_name] = True
         else:
             assert actor_id
             current_user_permissions.setdefault(actor_id, {})[action_name] = True
@@ -88,7 +91,6 @@ async def manage_table_acls(request, datasette):
                 )
                 if new_value != current_value:
                     if new_value:
-                        # They added it, add the record
                         await internal_db.execute_write(
                             """
                             INSERT INTO acl (actor_id, group_id, resource_id, action_id)
@@ -108,11 +110,10 @@ async def manage_table_acls(request, datasette):
                         operation = "added"
                         group_changes_made["added"].append((group_name, action_name))
                     else:
-                        # They removed it
                         await internal_db.execute_write(
                             """
                             delete from acl where
-                                actor_id is null and 
+                                actor_id is null and
                                 group_id = (SELECT id FROM acl_groups WHERE name = :group_name)
                                 and resource_id = :resource_id
                                 and action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
@@ -154,7 +155,6 @@ async def manage_table_acls(request, datasette):
         user_changes_made = {"added": [], "removed": []}
         for actor_id in list(current_user_permissions) + [None]:
             if actor_id is None:
-                # This is the special case for new_user_{{ action }}
                 actor_id = (post_vars.get("new_actor_id") or "").strip()
                 if not actor_id:
                     continue
@@ -176,7 +176,6 @@ async def manage_table_acls(request, datasette):
                 )
                 if new_value != current_value:
                     if new_value:
-                        # They added the permission
                         await internal_db.execute_write(
                             """
                             insert into acl (actor_id, group_id, resource_id, action_id)
@@ -196,7 +195,6 @@ async def manage_table_acls(request, datasette):
                         operation = "added"
                         user_changes_made["added"].append((actor_id, action_name))
                     else:
-                        # They removed the permission
                         await internal_db.execute_write(
                             """
                             delete from acl where
@@ -269,7 +267,6 @@ async def manage_table_acls(request, datasette):
         [resource_id],
     )
 
-    # group_sizes dictionary for displaying their sizes
     group_sizes = {
         row["name"]: row["size"]
         for row in await internal_db.execute(
@@ -291,10 +288,11 @@ async def manage_table_acls(request, datasette):
 
     return Response.html(
         await datasette.render_template(
-            "manage_table_acls.html",
+            "manage_resource_acls.html",
             {
-                "database_name": request.url_vars["database"],
-                "table_name": request.url_vars["table"],
+                "resource_type": resource_type,
+                "parent": parent,
+                "child": child,
                 "actions": actions,
                 "groups": groups,
                 "group_sizes": group_sizes,

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -39,6 +39,11 @@ class WidgetPlugin:
                 description="View a widget",
                 resource_class=WidgetResource,
             ),
+            Action(
+                name="widget-edit",
+                description="Edit a widget",
+                resource_class=WidgetResource,
+            ),
         ]
 
 
@@ -236,4 +241,128 @@ async def test_anonymous_wildcard_grant(widget_ds):
     )
     assert await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+
+
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_lists_dynamic_actions(widget_ds):
+    # The generic admin page renders the action set discovered for this resource
+    # type (widget-view, widget-edit), not a hardcoded table list.
+    response = await widget_ds.client.get(
+        "/-/acl/resource/widget/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 200
+    assert "Permissions for widget: shelf/gadget" in response.text
+    assert "widget-view" in response.text
+    assert "widget-edit" in response.text
+    # Table-only actions must not appear for a widget resource
+    assert "insert-row" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_requires_permission(widget_ds):
+    response = await widget_ds.client.get(
+        "/-/acl/resource/widget/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "other"})},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_unknown_type(widget_ds):
+    response = await widget_ds.client.get(
+        "/-/acl/resource/nope/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_grants_via_post(widget_ds):
+    actor = {"id": "alice"}
+    resource = WidgetResource("shelf", "gadget")
+    # No grant yet
+    assert not await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=actor
+    )
+    # Grant widget-edit to alice through the generic admin POST
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={
+            "new_actor_id": "alice",
+            "new_user_actions": "widget-edit",
+        },
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+
+    # The acl row exists for the right (resource_type, parent, child)
+    internal_db = widget_ds.get_internal_database()
+    rows = [
+        dict(r)
+        for r in (
+            await internal_db.execute(
+                """
+                select
+                  acl.actor_id,
+                  acl_actions.name as action_name,
+                  acl_resources.resource_type,
+                  acl_resources.parent,
+                  acl_resources.child
+                from acl
+                join acl_actions on acl.action_id = acl_actions.id
+                join acl_resources on acl.resource_id = acl_resources.id
+                """
+            )
+        )
+    ]
+    assert rows == [
+        {
+            "actor_id": "alice",
+            "action_name": "widget-edit",
+            "resource_type": "widget",
+            "parent": "shelf",
+            "child": "gadget",
+        }
+    ]
+
+    # And datasette.allowed reflects the new grant
+    assert await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=actor
+    )
+    # The other action is still denied
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=actor
+    )
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_revokes_via_post(widget_ds):
+    actor = {"id": "alice"}
+    resource = WidgetResource("shelf", "gadget")
+    await _grant_actor(
+        widget_ds,
+        actor_id="alice",
+        resource_type="widget",
+        parent="shelf",
+        child="gadget",
+        action="widget-edit",
+    )
+    assert await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=actor
+    )
+    # POST with the existing user's checkbox unchecked removes the grant
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={
+            "user_permissions_alice": "",
+        },
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+    assert not await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=actor
     )

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -628,3 +628,26 @@ async def test_table_actions(ds, should_work):
         assert has_link
     else:
         assert not has_link
+
+
+@pytest.mark.asyncio
+async def test_table_acl_page_actions_are_dynamic(ds):
+    # The table permissions page should offer the action set discovered from
+    # datasette.actions (every TableResource-scoped action), not a hardcoded
+    # subset. Core registers view-table and set-column-type beyond the original
+    # five, so their presence proves discovery is dynamic.
+    response = await ds.client.get(
+        "/db/t/-/acl",
+        cookies={"ds_actor": ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 200
+    for action in (
+        "insert-row",
+        "delete-row",
+        "update-row",
+        "alter-table",
+        "drop-table",
+        "view-table",
+        "set-column-type",
+    ):
+        assert action in response.text


### PR DESCRIPTION
**Stack 4/7** of splitting #29 (sharing-v2). Stacked on #37 — review/merge that first. Supersedes #32 (closed in the renumber).

## Goal
An HTML admin UI to manage grants for **any** resource type, with actions discovered dynamically (not hardcoded to table actions). The human-facing counterpart to the generalized model in #37.

## Changes
- `datasette_acl/views/resource_acls.py` (new) — generic resource ACL management view.
- `datasette_acl/templates/manage_resource_acls.html` (new).
- `datasette_acl/utils.py` — dynamic action discovery.
- `datasette_acl/views/table_acls.py`, `datasette_acl/__init__.py` — route registration.
- `README.md` — docs.

## Tests
- `tests/test_custom_resources.py`, `tests/test_table_acls.py` — admin-view + discovery cases.
- 29 passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
