### PR TITLE
6/7 Add grant/revoke/update helpers and resource builder

### DIFF
--- a/datasette_acl/grants.py
+++ b/datasette_acl/grants.py
@@ -1,0 +1,370 @@
+"""Reusable Python grant helpers for datasette-acl.
+
+acl historically had no public Python API: callers wanting to grant access had
+to write raw SQL into acl's tables. These helpers centralize the writes so other
+plugins (the JSON API in tasks 03-05, and consumer data-migrations in later
+phases) call functions instead of touching acl's schema directly.
+
+Every mutating helper:
+  * ensures the ``acl_resources`` row exists for ``(resource_type, parent, child)``,
+  * ensures the relevant ``acl_actions`` rows exist,
+  * writes the ``acl`` rows, and
+  * appends ``acl_audit`` entries (``operation_by`` = ``by_actor``).
+
+Principal invariant: exactly one of ``actor_id`` / ``group_id`` is set, matching
+the CHECK constraint on the ``acl`` table.
+"""
+
+from __future__ import annotations
+
+from typing import (
+    Iterable,
+    List,
+    Literal,
+    Optional,
+    Set,
+    TypedDict,
+    TYPE_CHECKING,
+)
+
+from datasette_acl.roles import AclRole, actions_for_role
+
+if TYPE_CHECKING:
+    from datasette.app import Datasette
+    from datasette.database import Database
+
+
+class Grant(TypedDict):
+    """One principal's grants on a resource, as returned by :func:`list_grants`."""
+
+    principal: Literal["actor", "group"]
+    actor_id: Optional[str]
+    group_id: Optional[int]
+    group_name: Optional[str]
+    actions: List[str]
+
+
+def _roles_for(datasette: Datasette, resource_type: str) -> List[AclRole]:
+    registry = getattr(datasette, "_acl_roles_registry", None) or {}
+    return registry.get(resource_type, [])
+
+
+def _resolve_actions(
+    datasette: Datasette,
+    resource_type: str,
+    role: Optional[str],
+    actions: Optional[Iterable[str]],
+) -> List[str]:
+    """Resolve the action list for a grant from either ``role`` or ``actions``.
+
+    Exactly one of ``role`` / ``actions`` must be provided. ``role`` is resolved
+    against the startup roles registry via :func:`actions_for_role`.
+    """
+    if (role is None) == (actions is None):
+        raise ValueError("Provide exactly one of role= or actions=")
+    if role is not None:
+        resolved = actions_for_role(_roles_for(datasette, resource_type), role)
+        if resolved is None:
+            raise ValueError(
+                f"Unknown role {role!r} for resource type {resource_type!r}"
+            )
+        return list(resolved)
+    # The guard above guarantees actions is not None when role is None.
+    assert actions is not None
+    return list(actions)
+
+
+def _check_principal(actor_id: Optional[str], group_id: Optional[int]) -> None:
+    """Enforce the acl CHECK invariant: exactly one of actor_id / group_id."""
+    if (actor_id is None) == (group_id is None):
+        raise ValueError("Provide exactly one of actor_id= or group_id=")
+
+
+async def _ensure_resource_id(
+    db: Database, resource_type: str, parent: str, child: Optional[str]
+) -> int:
+    # NOTE: the acl_resources UNIQUE(resource_type, parent, child) constraint
+    # treats NULL children as distinct in SQLite, so a bare INSERT OR IGNORE for
+    # a parent-only resource (child IS NULL) would create a duplicate row on
+    # every call. Select first and only insert when absent; return the lowest
+    # existing id so repeated calls are stable.
+    select_sql = (
+        "SELECT id FROM acl_resources "
+        "WHERE resource_type = ? AND parent = ? AND child IS ? "
+        "ORDER BY id LIMIT 1"
+    )
+    existing = await db.execute(select_sql, [resource_type, parent, child])
+    if existing.rows:
+        return existing.rows[0][0]
+    await db.execute_write(
+        "INSERT INTO acl_resources (resource_type, parent, child) VALUES (?, ?, ?)",
+        [resource_type, parent, child],
+    )
+    return (
+        await db.execute(select_sql, [resource_type, parent, child])
+    ).single_value()
+
+
+async def _ensure_actions(db: Database, actions: Iterable[str]) -> None:
+    if actions:
+        await db.execute_write_many(
+            "INSERT OR IGNORE INTO acl_actions (name) VALUES (:name)",
+            [{"name": name} for name in actions],
+        )
+
+
+async def _current_actions(
+    db: Database, resource_id: int, actor_id: Optional[str], group_id: Optional[int]
+) -> Set[str]:
+    """Return the set of action names currently granted to a principal."""
+    if actor_id is not None:
+        where = "acl.actor_id = :actor_id AND acl.group_id IS NULL"
+    else:
+        where = "acl.group_id = :group_id AND acl.actor_id IS NULL"
+    rows = await db.execute(
+        f"""
+        SELECT acl_actions.name AS name
+        FROM acl
+        JOIN acl_actions ON acl.action_id = acl_actions.id
+        WHERE acl.resource_id = :resource_id AND {where}
+        """,
+        {"resource_id": resource_id, "actor_id": actor_id, "group_id": group_id},
+    )
+    return {row["name"] for row in rows.rows}
+
+
+async def _insert_grant(
+    db: Database,
+    resource_id: int,
+    actor_id: Optional[str],
+    group_id: Optional[int],
+    action_name: str,
+    by_actor: Optional[str],
+) -> None:
+    await db.execute_write(
+        """
+        INSERT OR IGNORE INTO acl (actor_id, group_id, resource_id, action_id)
+        VALUES (
+            :actor_id,
+            :group_id,
+            :resource_id,
+            (SELECT id FROM acl_actions WHERE name = :action_name)
+        )
+        """,
+        {
+            "actor_id": actor_id,
+            "group_id": group_id,
+            "resource_id": resource_id,
+            "action_name": action_name,
+        },
+    )
+    await _audit(db, "added", resource_id, actor_id, group_id, action_name, by_actor)
+
+
+async def _delete_grant(
+    db: Database,
+    resource_id: int,
+    actor_id: Optional[str],
+    group_id: Optional[int],
+    action_name: str,
+    by_actor: Optional[str],
+) -> None:
+    if actor_id is not None:
+        principal_where = "actor_id = :actor_id AND group_id IS NULL"
+    else:
+        principal_where = "group_id = :group_id AND actor_id IS NULL"
+    await db.execute_write(
+        f"""
+        DELETE FROM acl
+        WHERE {principal_where}
+          AND resource_id = :resource_id
+          AND action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
+        """,
+        {
+            "actor_id": actor_id,
+            "group_id": group_id,
+            "resource_id": resource_id,
+            "action_name": action_name,
+        },
+    )
+    await _audit(db, "removed", resource_id, actor_id, group_id, action_name, by_actor)
+
+
+async def _audit(
+    db: Database,
+    operation: Literal["added", "removed"],
+    resource_id: int,
+    actor_id: Optional[str],
+    group_id: Optional[int],
+    action_name: str,
+    by_actor: Optional[str],
+) -> None:
+    await db.execute_write(
+        """
+        INSERT INTO acl_audit (
+            operation, actor_id, group_id, resource_id, action_id, operation_by
+        ) VALUES (
+            :operation,
+            :actor_id,
+            :group_id,
+            :resource_id,
+            (SELECT id FROM acl_actions WHERE name = :action_name),
+            :operation_by
+        )
+        """,
+        {
+            "operation": operation,
+            "actor_id": actor_id,
+            "group_id": group_id,
+            "resource_id": resource_id,
+            "action_name": action_name,
+            "operation_by": by_actor,
+        },
+    )
+
+
+async def grant(
+    datasette: Datasette,
+    resource_type: str,
+    parent: str,
+    child: Optional[str] = None,
+    *,
+    actor_id: Optional[str] = None,
+    group_id: Optional[int] = None,
+    role: Optional[str] = None,
+    actions: Optional[Iterable[str]] = None,
+    by_actor: Optional[str] = None,
+) -> List[str]:
+    """Grant a principal access to a resource, by role or by raw actions.
+
+    Exactly one of ``actor_id`` / ``group_id`` and exactly one of ``role`` /
+    ``actions`` must be supplied. Only actions not already granted are inserted
+    (idempotent). Returns the list of action names now held by the principal.
+    """
+    _check_principal(actor_id, group_id)
+    resolved = _resolve_actions(datasette, resource_type, role, actions)
+    db = datasette.get_internal_database()
+    resource_id = await _ensure_resource_id(db, resource_type, parent, child)
+    await _ensure_actions(db, resolved)
+    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    for action_name in resolved:
+        if action_name not in existing:
+            await _insert_grant(
+                db, resource_id, actor_id, group_id, action_name, by_actor
+            )
+    return sorted(existing | set(resolved))
+
+
+async def revoke(
+    datasette: Datasette,
+    resource_type: str,
+    parent: str,
+    child: Optional[str] = None,
+    *,
+    actor_id: Optional[str] = None,
+    group_id: Optional[int] = None,
+    by_actor: Optional[str] = None,
+) -> List[str]:
+    """Remove all acl rows for a principal on a resource. Audits each removal.
+
+    Returns the list of action names that were removed.
+    """
+    _check_principal(actor_id, group_id)
+    db = datasette.get_internal_database()
+    resource_id = await _ensure_resource_id(db, resource_type, parent, child)
+    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    for action_name in sorted(existing):
+        await _delete_grant(
+            db, resource_id, actor_id, group_id, action_name, by_actor
+        )
+    return sorted(existing)
+
+
+async def update_role(
+    datasette: Datasette,
+    resource_type: str,
+    parent: str,
+    child: Optional[str] = None,
+    *,
+    actor_id: Optional[str] = None,
+    group_id: Optional[int] = None,
+    role: str,
+    by_actor: Optional[str] = None,
+) -> List[str]:
+    """Atomically swap a principal's action set on a resource to ``role``.
+
+    Removes any currently-granted actions that are not in the new role, then
+    adds any missing ones. Audits each change. Returns the new action list.
+    """
+    _check_principal(actor_id, group_id)
+    resolved = set(_resolve_actions(datasette, resource_type, role, None))
+    db = datasette.get_internal_database()
+    resource_id = await _ensure_resource_id(db, resource_type, parent, child)
+    await _ensure_actions(db, resolved)
+    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    for action_name in sorted(existing - resolved):
+        await _delete_grant(
+            db, resource_id, actor_id, group_id, action_name, by_actor
+        )
+    for action_name in sorted(resolved - existing):
+        await _insert_grant(
+            db, resource_id, actor_id, group_id, action_name, by_actor
+        )
+    return sorted(resolved)
+
+
+async def list_grants(
+    datasette: Datasette,
+    resource_type: str,
+    parent: str,
+    child: Optional[str] = None,
+) -> List[Grant]:
+    """Return the grants on a resource as a list of dicts.
+
+    Each dict is ``{"principal": "actor"|"group", "actor_id", "group_id",
+    "group_name", "actions": [...]}`` with actions sorted. Group grants whose
+    group is soft-deleted are omitted. The list is ordered by principal then id.
+    """
+    db = datasette.get_internal_database()
+    resource_id = await _ensure_resource_id(db, resource_type, parent, child)
+    rows = await db.execute(
+        """
+        SELECT
+            acl.actor_id AS actor_id,
+            acl.group_id AS group_id,
+            acl_groups.name AS group_name,
+            acl_actions.name AS action_name
+        FROM acl
+        JOIN acl_actions ON acl.action_id = acl_actions.id
+        LEFT JOIN acl_groups ON acl.group_id = acl_groups.id
+        WHERE acl.resource_id = :resource_id
+          AND (acl.group_id IS NULL OR acl_groups.deleted IS NULL)
+        """,
+        {"resource_id": resource_id},
+    )
+    grants = {}
+    for row in rows.rows:
+        if row["actor_id"] is not None:
+            key = ("actor", row["actor_id"], None, None)
+        else:
+            key = ("group", None, row["group_id"], row["group_name"])
+        grants.setdefault(key, set()).add(row["action_name"])
+    out: List[Grant] = []
+    for (_principal, actor_id, group_id, group_name), action_set in grants.items():
+        out.append(
+            {
+                "principal": "actor" if actor_id is not None else "group",
+                "actor_id": actor_id,
+                "group_id": group_id,
+                "group_name": group_name,
+                "actions": sorted(action_set),
+            }
+        )
+    out.sort(
+        key=lambda g: (
+            g["principal"],
+            g["actor_id"] or "",
+            g["group_id"] or 0,
+        )
+    )
+    return out

--- a/datasette_acl/utils.py
+++ b/datasette_acl/utils.py
@@ -41,6 +41,36 @@ def actions_for_resource_type(
     ]
 
 
+def build_resource(
+    datasette: Datasette,
+    resource_type: str,
+    parent: str,
+    child: Optional[str] = None,
+) -> Resource:
+    """Build a core ``Resource`` instance for ``(resource_type, parent, child)``.
+
+    The acl JSON API and consumer data-migrations receive resources as strings
+    but ``datasette.allowed()`` needs a ``Resource`` instance. We discover the
+    resource class from the registered actions (see ``resource_class_for``) and
+    construct it.
+
+    Constructor convention: ``Resource.__init__(parent, child)`` accepts both
+    positionally. A 2-level resource type (``parent_class`` set, e.g. a table
+    inside a database) is built as ``rc(parent, child)``; a parent-only type
+    (``parent_class is None``) is built as ``rc(parent)``. Consumers whose
+    constructors do not follow this positional convention should add a
+    ``from_parent_child`` classmethod (none do today).
+
+    Raises ``ValueError`` if ``resource_type`` is unknown.
+    """
+    rc = resource_class_for(datasette, resource_type)
+    if rc is None:
+        raise ValueError(f"Unknown resource type: {resource_type}")
+    if rc.parent_class is not None:
+        return rc(parent, child)
+    return rc(parent)
+
+
 def generate_changes_message(changes_made, noun):
     messages = []
     for action, changes in changes_made.items():

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -1,0 +1,355 @@
+"""Tests for the Python grant helpers (grants.py) and build_resource (utils.py).
+
+These back the JSON API (tasks 03-05) and consumer data-migrations: grant by
+role / by raw actions, revoke, atomic update_role, audit rows, the actor/group
+CHECK invariant, and building a core Resource for 2-level and parent-only types.
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.roles import AclRole
+from datasette_acl.utils import build_resource
+import pytest
+import pytest_asyncio
+
+
+class DocResource(Resource):
+    """Parent-only resource type (no parent_class)."""
+
+    name = "doc"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT '42' AS parent, NULL AS child"
+
+
+class FolderResource(Resource):
+    name = "folder"
+    parent_class = None
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT 'home' AS parent, NULL AS child"
+
+
+class FileResource(Resource):
+    """Two-level resource type: a file inside a folder."""
+
+    name = "file"
+    parent_class = FolderResource
+
+    def __init__(self, parent, child=None):
+        super().__init__(parent=parent, child=child)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return "SELECT 'home' AS parent, 'notes.txt' AS child"
+
+
+DOC_ROLES = [
+    AclRole("doc", "Viewer", ["doc-view"], rank=1),
+    AclRole("doc", "Editor", ["doc-view", "doc-edit"], rank=2),
+    AclRole(
+        "doc", "Manager", ["doc-view", "doc-edit", "doc-manage"], rank=3, manage=True
+    ),
+]
+
+
+class GrantsPlugin:
+    __name__ = "GrantsPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(name="doc-view", description="View", resource_class=DocResource),
+            Action(name="doc-edit", description="Edit", resource_class=DocResource),
+            Action(name="doc-manage", description="Manage", resource_class=DocResource),
+            Action(
+                name="file-view", description="View file", resource_class=FileResource
+            ),
+        ]
+
+    @hookimpl
+    def datasette_acl_roles(self, datasette):
+        return list(DOC_ROLES)
+
+
+@pytest_asyncio.fixture
+async def grants_ds():
+    pm.register(GrantsPlugin(), name="grants-plugin")
+    try:
+        datasette = Datasette(config={"permissions": {"datasette-acl": {"id": "root"}}})
+        await datasette.invoke_startup()
+        # A group to grant to
+        await datasette.get_internal_database().execute_write(
+            "INSERT INTO acl_groups (name) VALUES ('staff')"
+        )
+        yield datasette
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="grants-plugin")
+
+
+async def _actions_for(datasette, actor_id):
+    """Read the action names granted to actor_id on the doc/42 resource."""
+    rows = await datasette.get_internal_database().execute(
+        """
+        SELECT acl_actions.name AS name
+        FROM acl
+        JOIN acl_actions ON acl.action_id = acl_actions.id
+        JOIN acl_resources ON acl.resource_id = acl_resources.id
+        WHERE acl.actor_id = :actor_id
+          AND acl_resources.resource_type = 'doc'
+          AND acl_resources.parent = '42'
+        """,
+        {"actor_id": actor_id},
+    )
+    return sorted(row["name"] for row in rows.rows)
+
+
+async def _group_id(datasette, name):
+    return (
+        await datasette.get_internal_database().execute(
+            "SELECT id FROM acl_groups WHERE name = ?", [name]
+        )
+    ).single_value()
+
+
+async def _audit_ops(datasette):
+    rows = await datasette.get_internal_database().execute(
+        """
+        SELECT acl_audit.operation, acl_audit.actor_id, acl_audit.group_id,
+               acl_actions.name AS action_name, acl_audit.operation_by
+        FROM acl_audit
+        JOIN acl_actions ON acl_audit.action_id = acl_actions.id
+        ORDER BY acl_audit.id
+        """
+    )
+    return [dict(r) for r in rows.rows]
+
+
+# --- build_resource -------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_resource_parent_only(grants_ds):
+    resource = build_resource(grants_ds, "doc", "42")
+    assert isinstance(resource, DocResource)
+    assert resource.parent == "42"
+    assert resource.child is None
+
+
+@pytest.mark.asyncio
+async def test_build_resource_two_level(grants_ds):
+    resource = build_resource(grants_ds, "file", "home", "notes.txt")
+    assert isinstance(resource, FileResource)
+    assert resource.parent == "home"
+    assert resource.child == "notes.txt"
+
+
+@pytest.mark.asyncio
+async def test_build_resource_unknown_type(grants_ds):
+    with pytest.raises(ValueError):
+        build_resource(grants_ds, "nope", "x")
+
+
+# --- grant ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_grant_by_role(grants_ds):
+    result = await grant(
+        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+    )
+    assert result == ["doc-edit", "doc-view"]
+    assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
+    # datasette.allowed reflects it
+    assert await grants_ds.allowed(
+        action="doc-edit", resource=DocResource("42"), actor={"id": "alice"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_grant_by_raw_actions(grants_ds):
+    result = await grant(
+        grants_ds, "doc", "42", actor_id="bob", actions=["doc-view"], by_actor="root"
+    )
+    assert result == ["doc-view"]
+    assert await _actions_for(grants_ds, "bob") == ["doc-view"]
+
+
+@pytest.mark.asyncio
+async def test_grant_is_idempotent(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    # Granting again with overlap only inserts the new action
+    result = await grant(
+        grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root"
+    )
+    assert result == ["doc-edit", "doc-manage", "doc-view"]
+    assert await _actions_for(grants_ds, "alice") == [
+        "doc-edit",
+        "doc-manage",
+        "doc-view",
+    ]
+    # Only one row per action despite the overlap
+    count = (
+        await grants_ds.get_internal_database().execute(
+            "SELECT count(*) FROM acl WHERE actor_id = 'alice'"
+        )
+    ).single_value()
+    assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_grant_to_group(grants_ds):
+    gid = await _group_id(grants_ds, "staff")
+    result = await grant(
+        grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root"
+    )
+    assert result == ["doc-view"]
+    grants = await list_grants(grants_ds, "doc", "42")
+    assert grants == [
+        {
+            "principal": "group",
+            "actor_id": None,
+            "group_id": gid,
+            "group_name": "staff",
+            "actions": ["doc-view"],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_grant_unknown_role_raises(grants_ds):
+    with pytest.raises(ValueError):
+        await grant(grants_ds, "doc", "42", actor_id="alice", role="Nope")
+
+
+@pytest.mark.asyncio
+async def test_grant_requires_exactly_one_principal(grants_ds):
+    with pytest.raises(ValueError):
+        await grant(grants_ds, "doc", "42", role="Viewer")
+    gid = await _group_id(grants_ds, "staff")
+    with pytest.raises(ValueError):
+        await grant(grants_ds, "doc", "42", actor_id="a", group_id=gid, role="Viewer")
+
+
+@pytest.mark.asyncio
+async def test_grant_requires_exactly_one_of_role_or_actions(grants_ds):
+    with pytest.raises(ValueError):
+        await grant(grants_ds, "doc", "42", actor_id="a")
+    with pytest.raises(ValueError):
+        await grant(
+            grants_ds, "doc", "42", actor_id="a", role="Viewer", actions=["doc-view"]
+        )
+
+
+# --- revoke ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_revoke_removes_all_rows(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    removed = await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    assert removed == ["doc-edit", "doc-manage", "doc-view"]
+    assert await _actions_for(grants_ds, "alice") == []
+
+
+@pytest.mark.asyncio
+async def test_revoke_only_targets_principal(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(grants_ds, "doc", "42", actor_id="bob", role="Viewer", by_actor="root")
+    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    assert await _actions_for(grants_ds, "alice") == []
+    assert await _actions_for(grants_ds, "bob") == ["doc-view"]
+
+
+# --- update_role ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_role_swaps_atomically(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    result = await update_role(
+        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root"
+    )
+    assert result == ["doc-view"]
+    # Only doc-view remains: doc-edit and doc-manage removed
+    assert await _actions_for(grants_ds, "alice") == ["doc-view"]
+
+
+@pytest.mark.asyncio
+async def test_update_role_upgrades(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    result = await update_role(
+        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+    )
+    assert result == ["doc-edit", "doc-view"]
+    assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
+
+
+# --- audit ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_rows_written(grants_ds):
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await update_role(
+        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="admin"
+    )
+    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    ops = await _audit_ops(grants_ds)
+    # grant Editor: +doc-view +doc-edit; update to Viewer: -doc-edit;
+    # revoke: -doc-view
+    summary = [(o["operation"], o["action_name"], o["operation_by"]) for o in ops]
+    assert ("added", "doc-view", "root") in summary
+    assert ("added", "doc-edit", "root") in summary
+    assert ("removed", "doc-edit", "admin") in summary
+    assert ("removed", "doc-view", "root") in summary
+    # All audit rows recorded the actor principal, no group
+    assert all(o["actor_id"] == "alice" and o["group_id"] is None for o in ops)
+
+
+# --- list_grants ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_grants_actor_and_group(grants_ds):
+    gid = await _group_id(grants_ds, "staff")
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    grants = await list_grants(grants_ds, "doc", "42")
+    assert grants == [
+        {
+            "principal": "actor",
+            "actor_id": "alice",
+            "group_id": None,
+            "group_name": None,
+            "actions": ["doc-edit", "doc-view"],
+        },
+        {
+            "principal": "group",
+            "actor_id": None,
+            "group_id": gid,
+            "group_name": "staff",
+            "actions": ["doc-view"],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_grants_empty(grants_ds):
+    assert await list_grants(grants_ds, "doc", "42") == []


### PR DESCRIPTION
**Stack 6/7** of splitting #29 (sharing-v2). Stacked on #39 — review/merge that first. Supersedes #34 (closed in the renumber).

## Goal
A Python-level helper layer (`grants.py`) other plugins call to grant/revoke/update grants and ensure resource rows exist, with role→action resolution.

## Changes
- `datasette_acl/grants.py` (new) — `grant`, `revoke`, `update_role`, `list_grants`, `_ensure_resource_id`.
- `datasette_acl/utils.py` — resource builder additions.

Imports `roles.actions_for_role` (#39) and uses the generalized `(resource_type, parent, child)` model (#37).

## Tests
- `tests/test_grants.py` (new, 17) — grant/revoke/update round-trips, role resolution, NULL-child parent-only resources (no duplicate rows under SQLite's NULL-distinct UNIQUE), idempotency.
- 52 passing on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
