### PR TITLE
General access principals: first-class principal types + resource page section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ venv
 .vscode
 dist
 build
+tmp.db
+internal.db
+uv.lock

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,41 @@
+# datasette-acl — dev recipes
+#
+# `just dev` loads the widgets sample plugin (tests/sample-plugin) +
+# datasette-debug-gotham. Visit http://localhost:5172/-/widgets, "log in" as a
+# character via the gotham actor switcher, create a widget (you become its
+# Manager), then share/restrict it from /-/acl/resource/widget/widgets/<id>.
+#
+# The gotham actors carry a `newsroom` attribute; the dynamic-groups config
+# below turns it into daily-planet / gotham-gazette groups so group grants can
+# be exercised too. `root` (via the --root sign-in link) holds the global
+# datasette-acl admin permission.
+
+dev *flags:
+  DATASETTE_SECRET=abc123 uv run \
+    --prerelease=allow \
+    --with-editable . \
+    --with datasette-debug-gotham \
+    datasette \
+    --root \
+    --plugins-dir tests/sample-plugin \
+    --template-dir tests/sample-plugin/templates \
+    -s permissions.datasette-acl.id root \
+    -s plugins.datasette-acl.dynamic-groups.daily-planet.newsroom daily-planet \
+    -s plugins.datasette-acl.dynamic-groups.gotham-gazette.newsroom gotham-gazette \
+    tmp.db --create \
+    --internal internal.db \
+    -p 5172 \
+    {{flags}}
+
+# Same as `dev`, but restarts datasette when .py/.html files change.
+dev-with-hmr *flags:
+  watchexec \
+    --stop-signal SIGKILL \
+    -e py,html \
+    --ignore '*.db' \
+    --restart \
+    --clear -- \
+    just dev {{flags}}
+
+test *options:
+  uv run pytest {{options}}

--- a/Justfile
+++ b/Justfile
@@ -22,20 +22,10 @@ dev *flags:
     -s permissions.datasette-acl.id root \
     -s plugins.datasette-acl.dynamic-groups.daily-planet.newsroom daily-planet \
     -s plugins.datasette-acl.dynamic-groups.gotham-gazette.newsroom gotham-gazette \
-    tmp.db --create \
+    tmp.db internal.db --create \
     --internal internal.db \
     -p 5172 \
     {{flags}}
-
-# Same as `dev`, but restarts datasette when .py/.html files change.
-dev-with-hmr *flags:
-  watchexec \
-    --stop-signal SIGKILL \
-    -e py,html \
-    --ignore '*.db' \
-    --restart \
-    --clear -- \
-    just dev {{flags}}
 
 test *options:
   uv run pytest {{options}}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This plugin is under active development. It supports configuring [permissions](h
 - `alter-table`
 - `drop-table`
 
-Grants can target individual users, [user groups](#user-groups), or [general-access wildcard principals](#principals-and-general-access) like `_signed_in`.
+Grants can target individual users, [user groups](#user-groups), or [general-access audiences](#principals-and-general-access) like "any signed-in user".
 
 Permissions are saved in the internal database. This means you should run Datasette with the `--internal path/to/internal.db` option, otherwise your permissions will be reset every time you restart Datasette.
 
@@ -35,7 +35,7 @@ The interface for configuring table permissions lives at `/database-name/table-n
 
 Permission can be granted for each of the above table actions. They can be assigned to both groups and individual users, who can be added using their `actor["id"]`.
 
-The table page does not (yet) offer the **General access** section found on the generic resource page — to grant a table action to a wildcard principal such as `_signed_in`, use the [JSON API](docs/json-api.md) or the [Python helpers](#python-api-for-managing-grants). See [Principals and general access](#principals-and-general-access).
+The table page does not (yet) offer the **General access** section found on the generic resource page — to grant a table action to a public audience such as "any signed-in user", use the [JSON API](docs/json-api.md) or the [Python helpers](#python-api-for-managing-grants). See [Principals and general access](#principals-and-general-access).
 
 An audit log tracks which permissions were added and removed, displayed at the bottom of the table permissions page.
 
@@ -78,21 +78,19 @@ Grants made here flow through Datasette's permission system: once granted, `awai
 
 ### Principals and general access
 
-Every grant names exactly one **principal**, and every stored grant records which kind it is in an explicit `principal_type` column:
+Every grant names exactly one **principal**, recorded in the `principal_type` column on each stored grant. There are five kinds — two identified by an id, and three public audiences identified by the type alone:
 
-- **`actor`** — an individual user, identified by their `actor["id"]`.
-- **`group`** — a [user group](#user-groups); the grant applies to all of its members.
-- **`public`** — one of three wildcard principals that match a *class* of caller rather than a specific person:
+| `principal_type` | Grants to | Identified by |
+| --- | --- | --- |
+| `actor` | An individual user | `actor_id` |
+| `group` | All members of a [user group](#user-groups) | `group_id` |
+| `everyone` | Anyone, signed in or not | — |
+| `authenticated` | Any signed-in actor | — |
+| `anonymous` | Signed-out (anonymous) visitors only | — |
 
-| Wildcard | Grants to |
-| --- | --- |
-| `*` | Anyone, signed in or not |
-| `_signed_in` | Any authenticated actor |
-| `_anonymous` | Signed-out (anonymous) visitors only |
+The generic resource admin page presents the three audiences as its **General access** section (labelled "Anyone (signed in or not)", "Any signed-in user" and "Signed-out (anonymous) visitors only"), and the audit log's Principal column shows the same labels. Audiences can also be granted programmatically by passing the `principal_type` to the [JSON API](docs/json-api.md) or the [Python helpers](#python-api-for-managing-grants).
 
-The generic resource admin page presents the wildcards as its **General access** section (labelled "Anyone (signed in or not)", "Any signed-in user" and "Signed-out (anonymous) visitors only"), and the audit log's Principal column shows the same labels. The wildcards can also be granted programmatically by passing the wildcard string as the `actor_id` to the [JSON API](docs/json-api.md) or the [Python helpers](#python-api-for-managing-grants).
-
-Because `principal_type` is stored explicitly, wildcard grants are distinguished from real users at the storage layer, not by string comparison. Permission checks match on `(principal_type, id)` pairs: a signed-in user whose id happens to be `_anonymous` can never inherit grants intended for signed-out visitors, and revoking a wildcard grant can never delete a like-named user's grant. Two things remain convention rather than enforcement: audit history rows written before the `principal_type` migration display wildcard-looking ids without knowing which they were, and any third-party code writing raw SQL into the `acl` table must now supply the `principal_type` column itself (use the [Python API](#python-api-for-managing-grants) instead).
+Because an audience grant stores no id at all, there is no reserved actor-id namespace: permission checks match audiences on `principal_type` alone and actors on their literal id, so no user id — however unusual — can collide with a general-access grant. One note for third-party code writing raw SQL into the `acl` table: the `principal_type` column is NOT NULL and CHECK-constrained, so such writers must supply it themselves (use the [Python API](#python-api-for-managing-grants) instead).
 
 ### Declaring roles
 
@@ -245,18 +243,14 @@ def datasette_acl_valid_actors(datasette):
 
 `datasette_acl.grants` provides async helpers so other plugins can read and modify grants without writing raw SQL against the ACL tables. Each call resolves the `(resource_type, parent, child)` resource, writes the `acl` rows, and appends audit entries attributed to `by_actor`.
 
-Provide exactly one principal (`actor_id=` or `group_id=`), and for `grant()` exactly one of `role=` or `actions=`.
-
-An `actor_id` that is one of the [wildcard principals](#principals-and-general-access) (`*`, `_signed_in`, `_anonymous`) is stored as a `public` grant by default. Pass `principal_type="actor"` to `grant()`, `update_role()` or `revoke()` to override that inference and target a real user whose id collides with a wildcard; `principal_type="public"` asserts the id must be a wildcard (anything else raises `ValueError`):
+Provide exactly one principal — `actor_id=`, `group_id=`, or a [public audience](#principals-and-general-access) as `principal_type=` — and for `grant()` exactly one of `role=` or `actions=`:
 
 ```python
-# Stored as a public grant: any signed-in user becomes a Viewer
-await grant(datasette, "doc", "doc1", actor_id="_signed_in", role="Viewer")
-# Explicit override: a real user whose id is literally "_signed_in"
-await grant(datasette, "doc", "doc1", actor_id="_signed_in", role="Viewer", principal_type="actor")
+# Any signed-in user becomes a Viewer
+await grant(datasette, "doc", "doc1", principal_type="authenticated", role="Viewer")
+# A specific user becomes an Editor
+await grant(datasette, "doc", "doc1", actor_id="alice", role="Editor")
 ```
-
-The two grants above are independent rows — revoking one never touches the other.
 
 ```python
 from datasette_acl.grants import grant, revoke, update_role, list_grants
@@ -281,7 +275,7 @@ await update_role(datasette, "doc", "doc1", actor_id="alice", role="Viewer")
 await revoke(datasette, "table", "mydb", "mytable", actor_id="alice")
 ```
 
-`list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`, where `principal` is `"actor"`, `"group"` or `"public"`):
+`list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`, where `principal` is the stored `principal_type`; audience grants carry no id):
 
 ```python
 grants = await list_grants(datasette, "table", "mydb", "mytable")

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ For example `/-/acl/resource/playlist/workspace-1/playlist-42`. The `<child>` se
 
 The page also has a **General access** section for exposing a resource without naming individual users, using the wildcard principals: `*` grants an action to anyone (signed in or not), `_signed_in` to any authenticated actor, and `_anonymous` to signed-out visitors only.
 
+Every stored grant carries an explicit `principal_type` column — `actor`, `group` or `public` — so wildcard grants are distinguished from real users at the storage layer, not by string comparison. Permission checks match on `(principal_type, id)` pairs: a signed-in user whose id happens to be `_anonymous` can never inherit grants intended for signed-out visitors, and revoking a wildcard grant can never delete a like-named user's grant. Two things remain convention rather than enforcement: audit history rows written before the `principal_type` migration display wildcard-looking ids without knowing which they were, and any third-party code writing raw SQL into the `acl` table must now supply the `principal_type` column itself (use the [Python API](#python-api-for-managing-grants) instead).
+
 Grants made here flow through Datasette's permission system: once granted, `await datasette.allowed(actor=..., action="playlist-edit", resource=Playlist("workspace-1", "playlist-42"))` returns `True`.
 
 ### Declaring roles
@@ -225,6 +227,8 @@ def datasette_acl_valid_actors(datasette):
 
 Provide exactly one principal (`actor_id=` or `group_id=`), and for `grant()` exactly one of `role=` or `actions=`.
 
+An `actor_id` that is one of the wildcard principals (`*`, `_signed_in`, `_anonymous`) is stored as a `public` grant by default. Pass `principal_type="actor"` to `grant()`, `update_role()` or `revoke()` to override that inference and target a real user whose id collides with a wildcard; `principal_type="public"` asserts the id must be a wildcard (anything else raises `ValueError`).
+
 ```python
 from datasette_acl.grants import grant, revoke, update_role, list_grants
 ```
@@ -248,7 +252,7 @@ await update_role(datasette, "doc", "doc1", actor_id="alice", role="Viewer")
 await revoke(datasette, "table", "mydb", "mytable", actor_id="alice")
 ```
 
-`list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`):
+`list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`, where `principal` is `"actor"`, `"group"` or `"public"`):
 
 ```python
 grants = await list_grants(datasette, "table", "mydb", "mytable")

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Every grant names exactly one **principal**, recorded in the `principal_type` co
 | `authenticated` | Any signed-in actor | — |
 | `anonymous` | Signed-out (anonymous) visitors only | — |
 
-The generic resource admin page presents the three audiences as its **General access** section (labelled "Anyone (signed in or not)", "Any signed-in user" and "Signed-out (anonymous) visitors only"), and the audit log's Principal column shows the same labels. Audiences can also be granted programmatically by passing the `principal_type` to the [JSON API](docs/json-api.md) or the [Python helpers](#python-api-for-managing-grants).
+The generic resource admin page presents the three audiences as its **General access** section (labelled "Anyone (signed in or not)", "Any signed-in user" and "Signed-out (anonymous) visitors only"), and the audit log's Principal column shows the same labels. Audiences can also be granted programmatically: pass `principal_type` to the [JSON API](docs/json-api.md), or an audience `Principal` (e.g. `Principal.authenticated()`) to the [Python helpers](#python-api-for-managing-grants).
 
 Because an audience grant stores no id at all, there is no reserved actor-id namespace: permission checks match audiences on `principal_type` alone and actors on their literal id, so no user id — however unusual — can collide with a general-access grant. One note for third-party code writing raw SQL into the `acl` table: the `principal_type` column is NOT NULL and CHECK-constrained, so such writers must supply it themselves (use the [Python API](#python-api-for-managing-grants) instead).
 
@@ -243,36 +243,34 @@ def datasette_acl_valid_actors(datasette):
 
 `datasette_acl.grants` provides async helpers so other plugins can read and modify grants without writing raw SQL against the ACL tables. Each call resolves the `(resource_type, parent, child)` resource, writes the `acl` rows, and appends audit entries attributed to `by_actor`.
 
-Provide exactly one principal — `actor_id=`, `group_id=`, or a [public audience](#principals-and-general-access) as `principal_type=` — and for `grant()` exactly one of `role=` or `actions=`:
+The principal — who a grant targets — is a `Principal` value object, built via one of its constructors: `Principal.actor(id)`, `Principal.group(id)`, or a [public audience](#principals-and-general-access) `Principal.everyone()` / `Principal.authenticated()` / `Principal.anonymous()`. Pass it as `principal=`, and for `grant()` supply exactly one of `role=` or `actions=`:
 
 ```python
+from datasette_acl.grants import grant, revoke, update_role, list_grants, Principal
+
 # Any signed-in user becomes a Viewer
-await grant(datasette, "doc", "doc1", principal_type="authenticated", role="Viewer")
+await grant(datasette, "doc", "doc1", principal=Principal.authenticated(), role="Viewer")
 # A specific user becomes an Editor
-await grant(datasette, "doc", "doc1", actor_id="alice", role="Editor")
-```
-
-```python
-from datasette_acl.grants import grant, revoke, update_role, list_grants
+await grant(datasette, "doc", "doc1", principal=Principal.actor("alice"), role="Editor")
 ```
 
 `grant(...)` — give a principal access, by raw actions or by a role (idempotent). Returns the actions now held. Role names come from the `datasette_acl_roles` hook:
 
 ```python
-await grant(datasette, "table", "mydb", "mytable", actor_id="alice", actions=["insert-row"])
-await grant(datasette, "table", "mydb", "mytable", group_id=3, actions=["insert-row"], by_actor="root")
+await grant(datasette, "table", "mydb", "mytable", principal=Principal.actor("alice"), actions=["insert-row"])
+await grant(datasette, "table", "mydb", "mytable", principal=Principal.group(3), actions=["insert-row"], by_actor="root")
 ```
 
 `update_role(...)` — atomically swap a principal's actions to exactly those of a registered `role`. Returns the new actions:
 
 ```python
-await update_role(datasette, "doc", "doc1", actor_id="alice", role="Viewer")
+await update_role(datasette, "doc", "doc1", principal=Principal.actor("alice"), role="Viewer")
 ```
 
 `revoke(...)` — remove all of a principal's grants on a resource. Returns the actions that were removed:
 
 ```python
-await revoke(datasette, "table", "mydb", "mytable", actor_id="alice")
+await revoke(datasette, "table", "mydb", "mytable", principal=Principal.actor("alice"))
 ```
 
 `list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`, where `principal` is the stored `principal_type`; audience grants carry no id):

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ datasette install datasette-acl
 ```
 ## Usage
 
-This plugin is under active development. It currently only supports configuring [permissions](https://docs.datasette.io/en/latest/authentication.html#permissions) for individual tables, controlling the following:
+This plugin is under active development. It supports configuring [permissions](https://docs.datasette.io/en/latest/authentication.html#permissions) for individual tables — controlling the following actions — as well as for [any custom resource type](#custom-resource-types) registered by a plugin:
 
 - `insert-row`
 - `delete-row`
 - `update-row`
 - `alter-table`
 - `drop-table`
+
+Grants can target individual users, [user groups](#user-groups), or [general-access wildcard principals](#principals-and-general-access) like `_signed_in`.
 
 Permissions are saved in the internal database. This means you should run Datasette with the `--internal path/to/internal.db` option, otherwise your permissions will be reset every time you restart Datasette.
 
@@ -32,6 +34,8 @@ A JSON HTTP API for reading and managing per-resource grants programmatically is
 The interface for configuring table permissions lives at `/database-name/table-name/-/acl`. It can be accessed from the table actions menu on the table page.
 
 Permission can be granted for each of the above table actions. They can be assigned to both groups and individual users, who can be added using their `actor["id"]`.
+
+The table page does not (yet) offer the **General access** section found on the generic resource page — to grant a table action to a wildcard principal such as `_signed_in`, use the [JSON API](docs/json-api.md) or the [Python helpers](#python-api-for-managing-grants). See [Principals and general access](#principals-and-general-access).
 
 An audit log tracks which permissions were added and removed, displayed at the bottom of the table permissions page.
 
@@ -68,11 +72,27 @@ A generic admin page for any resource type lives at:
 
 For example `/-/acl/resource/playlist/workspace-1/playlist-42`. The `<child>` segment is optional for parent-only resource types (`/-/acl/resource/<resource-type>/<parent>`). The page presents the same group/user grant interface and audit log as the table page, with checkboxes for exactly the actions registered for that resource type. Access to this admin page is gated on the `datasette-acl` permission described below.
 
-The page also has a **General access** section for exposing a resource without naming individual users, using the wildcard principals: `*` grants an action to anyone (signed in or not), `_signed_in` to any authenticated actor, and `_anonymous` to signed-out visitors only.
-
-Every stored grant carries an explicit `principal_type` column — `actor`, `group` or `public` — so wildcard grants are distinguished from real users at the storage layer, not by string comparison. Permission checks match on `(principal_type, id)` pairs: a signed-in user whose id happens to be `_anonymous` can never inherit grants intended for signed-out visitors, and revoking a wildcard grant can never delete a like-named user's grant. Two things remain convention rather than enforcement: audit history rows written before the `principal_type` migration display wildcard-looking ids without knowing which they were, and any third-party code writing raw SQL into the `acl` table must now supply the `principal_type` column itself (use the [Python API](#python-api-for-managing-grants) instead).
+The page also has a **General access** section for exposing a resource without naming individual users — see [Principals and general access](#principals-and-general-access) below.
 
 Grants made here flow through Datasette's permission system: once granted, `await datasette.allowed(actor=..., action="playlist-edit", resource=Playlist("workspace-1", "playlist-42"))` returns `True`.
+
+### Principals and general access
+
+Every grant names exactly one **principal**, and every stored grant records which kind it is in an explicit `principal_type` column:
+
+- **`actor`** — an individual user, identified by their `actor["id"]`.
+- **`group`** — a [user group](#user-groups); the grant applies to all of its members.
+- **`public`** — one of three wildcard principals that match a *class* of caller rather than a specific person:
+
+| Wildcard | Grants to |
+| --- | --- |
+| `*` | Anyone, signed in or not |
+| `_signed_in` | Any authenticated actor |
+| `_anonymous` | Signed-out (anonymous) visitors only |
+
+The generic resource admin page presents the wildcards as its **General access** section (labelled "Anyone (signed in or not)", "Any signed-in user" and "Signed-out (anonymous) visitors only"), and the audit log's Principal column shows the same labels. The wildcards can also be granted programmatically by passing the wildcard string as the `actor_id` to the [JSON API](docs/json-api.md) or the [Python helpers](#python-api-for-managing-grants).
+
+Because `principal_type` is stored explicitly, wildcard grants are distinguished from real users at the storage layer, not by string comparison. Permission checks match on `(principal_type, id)` pairs: a signed-in user whose id happens to be `_anonymous` can never inherit grants intended for signed-out visitors, and revoking a wildcard grant can never delete a like-named user's grant. Two things remain convention rather than enforcement: audit history rows written before the `principal_type` migration display wildcard-looking ids without knowing which they were, and any third-party code writing raw SQL into the `acl` table must now supply the `principal_type` column itself (use the [Python API](#python-api-for-managing-grants) instead).
 
 ### Declaring roles
 
@@ -227,7 +247,16 @@ def datasette_acl_valid_actors(datasette):
 
 Provide exactly one principal (`actor_id=` or `group_id=`), and for `grant()` exactly one of `role=` or `actions=`.
 
-An `actor_id` that is one of the wildcard principals (`*`, `_signed_in`, `_anonymous`) is stored as a `public` grant by default. Pass `principal_type="actor"` to `grant()`, `update_role()` or `revoke()` to override that inference and target a real user whose id collides with a wildcard; `principal_type="public"` asserts the id must be a wildcard (anything else raises `ValueError`).
+An `actor_id` that is one of the [wildcard principals](#principals-and-general-access) (`*`, `_signed_in`, `_anonymous`) is stored as a `public` grant by default. Pass `principal_type="actor"` to `grant()`, `update_role()` or `revoke()` to override that inference and target a real user whose id collides with a wildcard; `principal_type="public"` asserts the id must be a wildcard (anything else raises `ValueError`):
+
+```python
+# Stored as a public grant: any signed-in user becomes a Viewer
+await grant(datasette, "doc", "doc1", actor_id="_signed_in", role="Viewer")
+# Explicit override: a real user whose id is literally "_signed_in"
+await grant(datasette, "doc", "doc1", actor_id="_signed_in", role="Viewer", principal_type="actor")
+```
+
+The two grants above are independent rows — revoking one never touches the other.
 
 ```python
 from datasette_acl.grants import grant, revoke, update_role, list_grants

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ A generic admin page for any resource type lives at:
 
 For example `/-/acl/resource/playlist/workspace-1/playlist-42`. The `<child>` segment is optional for parent-only resource types (`/-/acl/resource/<resource-type>/<parent>`). The page presents the same group/user grant interface and audit log as the table page, with checkboxes for exactly the actions registered for that resource type. Access to this admin page is gated on the `datasette-acl` permission described below.
 
+The page also has a **General access** section for exposing a resource without naming individual users, using the wildcard principals: `*` grants an action to anyone (signed in or not), `_signed_in` to any authenticated actor, and `_anonymous` to signed-out visitors only.
+
 Grants made here flow through Datasette's permission system: once granted, `await datasette.allowed(actor=..., action="playlist-edit", resource=Playlist("workspace-1", "playlist-42"))` returns `True`.
 
 ### Declaring roles

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -225,17 +225,15 @@ def permission_resources_sql(datasette, actor, action):
             await update_dynamic_groups(
                 datasette, actor, skip_cache=hasattr(sys, "_pytest_running")
             )
-        # General-access (wildcard) principals are stored with
-        # principal_type = 'public':
-        #   '*'          -> anyone, including anonymous
-        #   '_signed_in' -> any actor that has an id (only when signed in)
-        #   '_anonymous' -> only unauthenticated callers (no actor id)
-        # Direct actor grants and group grants only apply when signed in.
-        # Every branch is constrained by principal_type, so a signed-in caller
-        # whose actor id is literally '_anonymous' matches only rows stored as
-        # ('actor', '_anonymous') -- never the anonymous wildcard. Before
-        # principal_type, the direct-grant branch matched wildcard rows by bare
-        # string comparison and leaked '_anonymous' grants to such a caller.
+        # A grant's audience is named entirely by principal_type:
+        #   'actor'         -> the one actor whose id matches (signed in only)
+        #   'group'         -> members of the group (signed in only)
+        #   'everyone'      -> anyone, including anonymous
+        #   'authenticated' -> any caller that has an actor id
+        #   'anonymous'     -> only unauthenticated callers (no actor id)
+        # Public-audience rows store no id at all, so no reserved actor-id
+        # namespace exists: an actor's grants are only ever the 'actor' rows
+        # matching their literal id, whatever that id is.
         # NOTE: this must be a single SELECT statement with no leading CTE
         # (WITH ...). Datasette core inlines this SQL after a "UNION ALL" when
         # building its anon_rules block for include_is_private queries, and a
@@ -251,7 +249,9 @@ SELECT
         CASE
             WHEN a.principal_type = 'group'
                 THEN 'group:' || g.name
-            ELSE a.principal_type || ':' || a.actor_id
+            WHEN a.principal_type = 'actor'
+                THEN 'actor:' || a.actor_id
+            ELSE a.principal_type
         END,
         ', '
     ) AS reason
@@ -262,13 +262,11 @@ LEFT JOIN acl_groups g ON a.group_id = g.id
 WHERE aa.name = :action
   AND ar.resource_type = :resource_type
   AND (
-    (a.principal_type = 'public' AND a.actor_id = '*')
+    a.principal_type = 'everyone'
     OR (:actor_id IS NOT NULL
         AND a.principal_type = 'actor' AND a.actor_id = :actor_id)
-    OR (:actor_id IS NOT NULL
-        AND a.principal_type = 'public' AND a.actor_id = '_signed_in')
-    OR (:actor_id IS NULL
-        AND a.principal_type = 'public' AND a.actor_id = '_anonymous')
+    OR (:actor_id IS NOT NULL AND a.principal_type = 'authenticated')
+    OR (:actor_id IS NULL AND a.principal_type = 'anonymous')
     OR (a.principal_type = 'group' AND a.group_id IN (
         SELECT ag.group_id
         FROM acl_actor_groups ag

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -225,11 +225,17 @@ def permission_resources_sql(datasette, actor, action):
             await update_dynamic_groups(
                 datasette, actor, skip_cache=hasattr(sys, "_pytest_running")
             )
-        # General-access (wildcard) principals always apply:
+        # General-access (wildcard) principals are stored with
+        # principal_type = 'public':
         #   '*'          -> anyone, including anonymous
         #   '_signed_in' -> any actor that has an id (only when signed in)
         #   '_anonymous' -> only unauthenticated callers (no actor id)
         # Direct actor grants and group grants only apply when signed in.
+        # Every branch is constrained by principal_type, so a signed-in caller
+        # whose actor id is literally '_anonymous' matches only rows stored as
+        # ('actor', '_anonymous') -- never the anonymous wildcard. Before
+        # principal_type, the direct-grant branch matched wildcard rows by bare
+        # string comparison and leaked '_anonymous' grants to such a caller.
         # NOTE: this must be a single SELECT statement with no leading CTE
         # (WITH ...). Datasette core inlines this SQL after a "UNION ALL" when
         # building its anon_rules block for include_is_private queries, and a
@@ -243,9 +249,9 @@ SELECT
     1 AS allow,
     'datasette-acl: ' || GROUP_CONCAT(
         CASE
-            WHEN a.actor_id IS NOT NULL
-                THEN 'actor:' || a.actor_id
-            ELSE 'group:' || g.name
+            WHEN a.principal_type = 'group'
+                THEN 'group:' || g.name
+            ELSE a.principal_type || ':' || a.actor_id
         END,
         ', '
     ) AS reason
@@ -256,18 +262,21 @@ LEFT JOIN acl_groups g ON a.group_id = g.id
 WHERE aa.name = :action
   AND ar.resource_type = :resource_type
   AND (
-    a.actor_id = '*'
-    OR (:actor_id IS NOT NULL AND a.actor_id = :actor_id)
-    OR (:actor_id IS NOT NULL AND a.actor_id = '_signed_in')
-    OR (:actor_id IS NULL AND a.actor_id = '_anonymous')
-    OR a.group_id IN (
+    (a.principal_type = 'public' AND a.actor_id = '*')
+    OR (:actor_id IS NOT NULL
+        AND a.principal_type = 'actor' AND a.actor_id = :actor_id)
+    OR (:actor_id IS NOT NULL
+        AND a.principal_type = 'public' AND a.actor_id = '_signed_in')
+    OR (:actor_id IS NULL
+        AND a.principal_type = 'public' AND a.actor_id = '_anonymous')
+    OR (a.principal_type = 'group' AND a.group_id IN (
         SELECT ag.group_id
         FROM acl_actor_groups ag
         JOIN acl_groups ig ON ag.group_id = ig.id
         WHERE :actor_id IS NOT NULL
           AND ag.actor_id = :actor_id
           AND ig.deleted IS NULL
-    )
+    ))
   )
   AND (a.group_id IS NULL OR g.deleted IS NULL)
 GROUP BY ar.parent, ar.child
@@ -335,8 +344,9 @@ def track_event(datasette, event):
         )
         await db.execute_write_many(
             """
-            INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+            INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
             VALUES (
+                'actor',
                 :actor_id,
                 null,
                 :resource_id,

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -16,7 +16,6 @@ from datasette_acl.views.api import (
     groups_json,
     actors_json,
 )
-from datasette_acl.roles import build_roles_registry
 from sqlite_utils import Database
 from . import hookspecs
 import json
@@ -84,11 +83,6 @@ def startup(datasette):
                 "insert or ignore into acl_groups (name) values (:name)",
                 [{"name": name} for name in groups.keys()],
             )
-        # Collect friendly roles declared by plugins via datasette_acl_roles
-        # into a registry keyed by resource_type and stash it on datasette.
-        # Re-gathering is cheap; we do it once at startup.
-        datasette._acl_roles_registry = await build_roles_registry(datasette)
-
     return inner
 
 

--- a/datasette_acl/grants.py
+++ b/datasette_acl/grants.py
@@ -11,17 +11,18 @@ Every mutating helper:
   * writes the ``acl`` rows, and
   * appends ``acl_audit`` entries (``operation_by`` = ``by_actor``).
 
-Principal invariant: a grant targets exactly one principal -- an actor
-(``actor_id=``), a group (``group_id=``), or a public audience
-(``principal_type=`` one of ``'everyone'`` / ``'authenticated'`` /
-``'anonymous'``, with no id at all) -- matching the CHECK constraint on the
-``acl`` table. :func:`principal_type_for` is the single place that resolves
-and validates the combination.
+Principal invariant: a grant targets exactly one principal -- an actor, a
+group, or a public audience -- matching the CHECK constraint on the ``acl``
+table. The :class:`Principal` value object is the single place that resolves
+and validates the combination; every helper takes one ``principal`` rather
+than threading ``(principal_type, actor_id, group_id)`` around by hand.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import (
+    Dict,
     Iterable,
     List,
     Literal,
@@ -40,6 +41,127 @@ if TYPE_CHECKING:
 
 
 PrincipalType = Literal["actor", "group", "everyone", "authenticated", "anonymous"]
+
+
+@dataclass(frozen=True)
+class Principal:
+    """A grant's target: an actor, a group, or a public audience.
+
+    Build one via the classmethods rather than the raw constructor so the
+    "exactly one principal" invariant (which mirrors the ``acl`` CHECK
+    constraint) is enforced in a single place::
+
+        Principal.actor("alice")
+        Principal.group(7)
+        Principal.everyone()        # / .authenticated() / .anonymous()
+        Principal.public("everyone")
+
+    :meth:`from_parts` resolves the looser ``(actor_id, group_id,
+    principal_type)`` combination that arrives from a request body, validating
+    it the same way. :meth:`where_sql` / :meth:`sql_params` produce the
+    principal-matching SQL fragment shared by every read/write helper.
+    """
+
+    principal_type: PrincipalType
+    actor_id: Optional[str] = None
+    group_id: Optional[int] = None
+
+    @classmethod
+    def actor(cls, actor_id: str) -> "Principal":
+        if actor_id is None:
+            raise ValueError("actor principal requires an actor_id")
+        return cls("actor", actor_id=actor_id)
+
+    @classmethod
+    def group(cls, group_id: int) -> "Principal":
+        if group_id is None:
+            raise ValueError("group principal requires a group_id")
+        return cls("group", group_id=group_id)
+
+    @classmethod
+    def public(cls, principal_type: str) -> "Principal":
+        if principal_type not in PUBLIC_PRINCIPAL_TYPES:
+            raise ValueError(
+                f"Unknown public principal_type {principal_type!r}; expected "
+                f"one of {', '.join(sorted(PUBLIC_PRINCIPAL_TYPES))}"
+            )
+        return cls(principal_type)
+
+    @classmethod
+    def everyone(cls) -> "Principal":
+        return cls("everyone")
+
+    @classmethod
+    def authenticated(cls) -> "Principal":
+        return cls("authenticated")
+
+    @classmethod
+    def anonymous(cls) -> "Principal":
+        return cls("anonymous")
+
+    @classmethod
+    def from_parts(
+        cls,
+        actor_id: Optional[str],
+        group_id: Optional[int],
+        principal_type: Optional[str] = None,
+    ) -> "Principal":
+        """Resolve a principal from a loose ``(actor_id, group_id, type)`` set.
+
+        A principal is exactly one of: an actor (``actor_id``), a group
+        (``group_id``), or a public audience (``principal_type`` in
+        ``PUBLIC_PRINCIPAL_TYPES``, with neither id). ``principal_type`` may
+        also redundantly name ``'actor'`` / ``'group'`` alongside the matching
+        id. Raises ``ValueError`` for any other combination, mirroring the
+        acl table's CHECK constraint.
+        """
+        if principal_type in PUBLIC_PRINCIPAL_TYPES:
+            if actor_id is not None or group_id is not None:
+                raise ValueError(
+                    f"principal_type {principal_type!r} cannot be combined "
+                    "with actor_id= or group_id="
+                )
+            return cls(principal_type)
+        if (actor_id is None) == (group_id is None):
+            raise ValueError(
+                "Provide exactly one principal: actor_id=, group_id=, or a "
+                f"public principal_type ({', '.join(PUBLIC_PRINCIPAL_TYPES)})"
+            )
+        if group_id is not None:
+            if principal_type not in (None, "group"):
+                raise ValueError(
+                    f"principal_type {principal_type!r} cannot be used "
+                    "with group_id="
+                )
+            return cls("group", group_id=group_id)
+        if principal_type not in (None, "actor"):
+            raise ValueError(
+                f"principal_type {principal_type!r} cannot be used "
+                "with actor_id="
+            )
+        return cls("actor", actor_id=actor_id)
+
+    def where_sql(self, alias: Optional[str] = None) -> str:
+        """SQL fragment matching this principal's acl rows.
+
+        ``alias`` qualifies the column references (e.g. ``"acl"`` for a joined
+        query); omit it for a single-table statement. Pair with
+        :meth:`sql_params` for the bind values.
+        """
+        col = f"{alias}." if alias else ""
+        if self.principal_type == "actor":
+            return f"{col}principal_type = 'actor' AND {col}actor_id = :actor_id"
+        if self.principal_type == "group":
+            return f"{col}principal_type = 'group' AND {col}group_id = :group_id"
+        # Public audience: the type alone identifies the principal.
+        return f"{col}principal_type = :principal_type"
+
+    def sql_params(self) -> Dict[str, object]:
+        return {
+            "principal_type": self.principal_type,
+            "actor_id": self.actor_id,
+            "group_id": self.group_id,
+        }
 
 
 class Grant(TypedDict):
@@ -93,45 +215,6 @@ def _resolve_actions(
     return requested
 
 
-def principal_type_for(
-    actor_id: Optional[str],
-    group_id: Optional[int],
-    principal_type: Optional[str] = None,
-) -> PrincipalType:
-    """Resolve and validate the ``principal_type`` for a grant's principal.
-
-    A principal is exactly one of: an actor (``actor_id=``), a group
-    (``group_id=``), or a public audience (``principal_type=`` one of
-    ``PUBLIC_PRINCIPAL_TYPES``, with neither id). ``principal_type`` may also
-    redundantly name ``'actor'`` / ``'group'`` alongside the matching id.
-    Raises ``ValueError`` for any other combination, mirroring the acl table's
-    CHECK constraint.
-    """
-    if principal_type in PUBLIC_PRINCIPAL_TYPES:
-        if actor_id is not None or group_id is not None:
-            raise ValueError(
-                f"principal_type {principal_type!r} cannot be combined with "
-                "actor_id= or group_id="
-            )
-        return principal_type
-    if (actor_id is None) == (group_id is None):
-        raise ValueError(
-            "Provide exactly one principal: actor_id=, group_id=, or a "
-            f"public principal_type ({', '.join(PUBLIC_PRINCIPAL_TYPES)})"
-        )
-    if group_id is not None:
-        if principal_type not in (None, "group"):
-            raise ValueError(
-                f"principal_type {principal_type!r} cannot be used with group_id="
-            )
-        return "group"
-    if principal_type not in (None, "actor"):
-        raise ValueError(
-            f"principal_type {principal_type!r} cannot be used with actor_id="
-        )
-    return "actor"
-
-
 async def _ensure_resource_id(
     db: Database, resource_type: str, parent: str, child: Optional[str]
 ) -> int:
@@ -168,31 +251,17 @@ async def _ensure_actions(db: Database, actions: Iterable[str]) -> None:
 async def _current_actions(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
 ) -> Set[str]:
     """Return the set of action names currently granted to a principal."""
-    if principal_type == "actor":
-        where = "acl.principal_type = 'actor' AND acl.actor_id = :actor_id"
-    elif principal_type == "group":
-        where = "acl.principal_type = 'group' AND acl.group_id = :group_id"
-    else:
-        # Public audience: the type alone identifies the principal.
-        where = "acl.principal_type = :principal_type"
     rows = await db.execute(
         f"""
         SELECT acl_actions.name AS name
         FROM acl
         JOIN acl_actions ON acl.action_id = acl_actions.id
-        WHERE acl.resource_id = :resource_id AND {where}
+        WHERE acl.resource_id = :resource_id AND {principal.where_sql("acl")}
         """,
-        {
-            "resource_id": resource_id,
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
-        },
+        {"resource_id": resource_id, **principal.sql_params()},
     )
     return {row["name"] for row in rows.rows}
 
@@ -200,9 +269,7 @@ async def _current_actions(
 async def _insert_grant(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
@@ -220,68 +287,42 @@ async def _insert_grant(
         )
         """,
         {
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(
-        db, "added", resource_id, principal_type, actor_id, group_id, action_name, by_actor
-    )
+    await _audit(db, "added", resource_id, principal, action_name, by_actor)
 
 
 async def _delete_grant(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
-    if principal_type == "actor":
-        principal_where = "principal_type = 'actor' AND actor_id = :actor_id"
-    elif principal_type == "group":
-        principal_where = "principal_type = 'group' AND group_id = :group_id"
-    else:
-        # Public audience: the type alone identifies the principal.
-        principal_where = "principal_type = :principal_type"
     await db.execute_write(
         f"""
         DELETE FROM acl
-        WHERE {principal_where}
+        WHERE {principal.where_sql()}
           AND resource_id = :resource_id
           AND action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
         """,
         {
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(
-        db,
-        "removed",
-        resource_id,
-        principal_type,
-        actor_id,
-        group_id,
-        action_name,
-        by_actor,
-    )
+    await _audit(db, "removed", resource_id, principal, action_name, by_actor)
 
 
 async def _audit(
     db: Database,
     operation: Literal["added", "removed"],
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
@@ -302,9 +343,7 @@ async def _audit(
         """,
         {
             "operation": operation,
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
             "operation_by": by_actor,
@@ -318,33 +357,27 @@ async def grant(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     role: Optional[str] = None,
     actions: Optional[Iterable[str]] = None,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Grant a principal access to a resource, by role or by raw actions.
 
-    The principal is exactly one of ``actor_id=``, ``group_id=``, or a public
-    audience passed as ``principal_type=`` (``'everyone'`` /
-    ``'authenticated'`` / ``'anonymous'``, with neither id). Exactly one of
-    ``role`` / ``actions`` must be supplied. Only actions not already granted
-    are inserted (idempotent). Returns the list of action names now held by
-    the principal.
+    ``principal`` is a :class:`Principal` (``Principal.actor(...)`` /
+    ``.group(...)`` / ``.everyone()`` / etc). Exactly one of ``role`` /
+    ``actions`` must be supplied. Only actions not already granted are
+    inserted (idempotent). Returns the list of action names now held by the
+    principal.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = _resolve_actions(datasette, resource_type, role, actions)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in resolved:
         if action_name not in existing:
-            await _insert_grant(
-                db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-            )
+            await _insert_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(existing | set(resolved))
 
 
@@ -354,24 +387,19 @@ async def revoke(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Remove all acl rows for a principal on a resource. Audits each removal.
 
     The principal is specified as in :func:`grant`. Returns the list of action
     names that were removed.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in sorted(existing):
-        await _delete_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _delete_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(existing)
 
 
@@ -381,11 +409,9 @@ async def update_role(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     role: str,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Atomically swap a principal's action set on a resource to ``role``.
 
@@ -393,20 +419,15 @@ async def update_role(
     granted actions that are not in the new role, then adds any missing ones.
     Audits each change. Returns the new action list.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = set(_resolve_actions(datasette, resource_type, role, None))
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in sorted(existing - resolved):
-        await _delete_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _delete_grant(db, resource_id, principal, action_name, by_actor)
     for action_name in sorted(resolved - existing):
-        await _insert_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _insert_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(resolved)
 
 

--- a/datasette_acl/grants.py
+++ b/datasette_acl/grants.py
@@ -12,7 +12,11 @@ Every mutating helper:
   * appends ``acl_audit`` entries (``operation_by`` = ``by_actor``).
 
 Principal invariant: exactly one of ``actor_id`` / ``group_id`` is set, matching
-the CHECK constraint on the ``acl`` table.
+the CHECK constraint on the ``acl`` table. Every stored row also carries an
+explicit ``principal_type`` (``'actor'`` / ``'group'`` / ``'public'``);
+:func:`principal_type_for` is the single place that resolves it, defaulting to
+inference from ``PUBLIC_PRINCIPALS`` membership for callers that do not pass
+``principal_type=`` explicitly.
 """
 
 from __future__ import annotations
@@ -28,17 +32,20 @@ from typing import (
 )
 
 from datasette_acl.roles import actions_for_role, roles_for
-from datasette_acl.utils import actions_for_resource_type
+from datasette_acl.utils import PUBLIC_PRINCIPALS, actions_for_resource_type
 
 if TYPE_CHECKING:
     from datasette.app import Datasette
     from datasette.database import Database
 
 
+PrincipalType = Literal["actor", "group", "public"]
+
+
 class Grant(TypedDict):
     """One principal's grants on a resource, as returned by :func:`list_grants`."""
 
-    principal: Literal["actor", "group"]
+    principal: PrincipalType
     actor_id: Optional[str]
     group_id: Optional[int]
     group_name: Optional[str]
@@ -81,10 +88,44 @@ def _resolve_actions(
     return requested
 
 
-def _check_principal(actor_id: Optional[str], group_id: Optional[int]) -> None:
-    """Enforce the acl CHECK invariant: exactly one of actor_id / group_id."""
+def principal_type_for(
+    actor_id: Optional[str],
+    group_id: Optional[int],
+    principal_type: Optional[str] = None,
+) -> PrincipalType:
+    """Resolve the ``principal_type`` for a grant's principal.
+
+    Enforces the acl CHECK invariant (exactly one of ``actor_id`` /
+    ``group_id``). ``group_id`` always means ``'group'``. For actor ids, an
+    explicit ``principal_type`` of ``'actor'`` or ``'public'`` is honored
+    (``'public'`` ids are validated against ``PUBLIC_PRINCIPALS``); when it is
+    None the type is **inferred** from ``PUBLIC_PRINCIPALS`` membership. That
+    inference is the back-compat default for callers that say
+    ``actor_id="*"`` -- it lives only here; storage is always explicit and
+    enforcement never infers. Callers that know the type should pass it.
+    """
     if (actor_id is None) == (group_id is None):
         raise ValueError("Provide exactly one of actor_id= or group_id=")
+    if group_id is not None:
+        if principal_type not in (None, "group"):
+            raise ValueError(
+                f"principal_type {principal_type!r} cannot be used with group_id="
+            )
+        return "group"
+    if principal_type is None:
+        return "public" if actor_id in PUBLIC_PRINCIPALS else "actor"
+    if principal_type == "actor":
+        return "actor"
+    if principal_type == "public":
+        if actor_id not in PUBLIC_PRINCIPALS:
+            raise ValueError(
+                f"principal_type 'public' requires actor_id to be one of "
+                f"{sorted(PUBLIC_PRINCIPALS)!r}, not {actor_id!r}"
+            )
+        return "public"
+    if principal_type == "group":
+        raise ValueError("principal_type 'group' requires group_id=, not actor_id=")
+    raise ValueError(f"Invalid principal_type: {principal_type!r}")
 
 
 async def _ensure_resource_id(
@@ -121,11 +162,15 @@ async def _ensure_actions(db: Database, actions: Iterable[str]) -> None:
 
 
 async def _current_actions(
-    db: Database, resource_id: int, actor_id: Optional[str], group_id: Optional[int]
+    db: Database,
+    resource_id: int,
+    principal_type: PrincipalType,
+    actor_id: Optional[str],
+    group_id: Optional[int],
 ) -> Set[str]:
     """Return the set of action names currently granted to a principal."""
     if actor_id is not None:
-        where = "acl.actor_id = :actor_id AND acl.group_id IS NULL"
+        where = "acl.principal_type = :principal_type AND acl.actor_id = :actor_id"
     else:
         where = "acl.group_id = :group_id AND acl.actor_id IS NULL"
     rows = await db.execute(
@@ -135,7 +180,12 @@ async def _current_actions(
         JOIN acl_actions ON acl.action_id = acl_actions.id
         WHERE acl.resource_id = :resource_id AND {where}
         """,
-        {"resource_id": resource_id, "actor_id": actor_id, "group_id": group_id},
+        {
+            "resource_id": resource_id,
+            "principal_type": principal_type,
+            "actor_id": actor_id,
+            "group_id": group_id,
+        },
     )
     return {row["name"] for row in rows.rows}
 
@@ -143,6 +193,7 @@ async def _current_actions(
 async def _insert_grant(
     db: Database,
     resource_id: int,
+    principal_type: PrincipalType,
     actor_id: Optional[str],
     group_id: Optional[int],
     action_name: str,
@@ -150,8 +201,11 @@ async def _insert_grant(
 ) -> None:
     await db.execute_write(
         """
-        INSERT OR IGNORE INTO acl (actor_id, group_id, resource_id, action_id)
+        INSERT OR IGNORE INTO acl (
+            principal_type, actor_id, group_id, resource_id, action_id
+        )
         VALUES (
+            :principal_type,
             :actor_id,
             :group_id,
             :resource_id,
@@ -159,25 +213,34 @@ async def _insert_grant(
         )
         """,
         {
+            "principal_type": principal_type,
             "actor_id": actor_id,
             "group_id": group_id,
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(db, "added", resource_id, actor_id, group_id, action_name, by_actor)
+    await _audit(
+        db, "added", resource_id, principal_type, actor_id, group_id, action_name, by_actor
+    )
 
 
 async def _delete_grant(
     db: Database,
     resource_id: int,
+    principal_type: PrincipalType,
     actor_id: Optional[str],
     group_id: Optional[int],
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
+    # Constrain actor deletes by (principal_type, actor_id) so revoking the
+    # '_signed_in' wildcard can never delete a like-named user's grant, and
+    # vice versa.
     if actor_id is not None:
-        principal_where = "actor_id = :actor_id AND group_id IS NULL"
+        principal_where = (
+            "principal_type = :principal_type AND actor_id = :actor_id"
+        )
     else:
         principal_where = "group_id = :group_id AND actor_id IS NULL"
     await db.execute_write(
@@ -188,19 +251,30 @@ async def _delete_grant(
           AND action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
         """,
         {
+            "principal_type": principal_type,
             "actor_id": actor_id,
             "group_id": group_id,
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(db, "removed", resource_id, actor_id, group_id, action_name, by_actor)
+    await _audit(
+        db,
+        "removed",
+        resource_id,
+        principal_type,
+        actor_id,
+        group_id,
+        action_name,
+        by_actor,
+    )
 
 
 async def _audit(
     db: Database,
     operation: Literal["added", "removed"],
     resource_id: int,
+    principal_type: PrincipalType,
     actor_id: Optional[str],
     group_id: Optional[int],
     action_name: str,
@@ -209,9 +283,11 @@ async def _audit(
     await db.execute_write(
         """
         INSERT INTO acl_audit (
-            operation, actor_id, group_id, resource_id, action_id, operation_by
+            operation, principal_type, actor_id, group_id, resource_id,
+            action_id, operation_by
         ) VALUES (
             :operation,
+            :principal_type,
             :actor_id,
             :group_id,
             :resource_id,
@@ -221,6 +297,7 @@ async def _audit(
         """,
         {
             "operation": operation,
+            "principal_type": principal_type,
             "actor_id": actor_id,
             "group_id": group_id,
             "resource_id": resource_id,
@@ -241,23 +318,28 @@ async def grant(
     role: Optional[str] = None,
     actions: Optional[Iterable[str]] = None,
     by_actor: Optional[str] = None,
+    principal_type: Optional[Literal["actor", "public"]] = None,
 ) -> List[str]:
     """Grant a principal access to a resource, by role or by raw actions.
 
     Exactly one of ``actor_id`` / ``group_id`` and exactly one of ``role`` /
     ``actions`` must be supplied. Only actions not already granted are inserted
     (idempotent). Returns the list of action names now held by the principal.
+
+    ``principal_type`` disambiguates an ``actor_id`` that collides with a
+    wildcard: pass ``"actor"`` to grant to a real user literally named e.g.
+    ``_signed_in``. Default None infers via :func:`principal_type_for`.
     """
-    _check_principal(actor_id, group_id)
+    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = _resolve_actions(datasette, resource_type, role, actions)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
     for action_name in resolved:
         if action_name not in existing:
             await _insert_grant(
-                db, resource_id, actor_id, group_id, action_name, by_actor
+                db, resource_id, ptype, actor_id, group_id, action_name, by_actor
             )
     return sorted(existing | set(resolved))
 
@@ -271,18 +353,21 @@ async def revoke(
     actor_id: Optional[str] = None,
     group_id: Optional[int] = None,
     by_actor: Optional[str] = None,
+    principal_type: Optional[Literal["actor", "public"]] = None,
 ) -> List[str]:
     """Remove all acl rows for a principal on a resource. Audits each removal.
 
-    Returns the list of action names that were removed.
+    Returns the list of action names that were removed. ``principal_type``
+    disambiguates wildcard-named actor ids as in :func:`grant`; revoking the
+    ``_signed_in`` wildcard never touches a like-named user's grants.
     """
-    _check_principal(actor_id, group_id)
+    ptype = principal_type_for(actor_id, group_id, principal_type)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
-    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
     for action_name in sorted(existing):
         await _delete_grant(
-            db, resource_id, actor_id, group_id, action_name, by_actor
+            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
         )
     return sorted(existing)
 
@@ -297,25 +382,28 @@ async def update_role(
     group_id: Optional[int] = None,
     role: str,
     by_actor: Optional[str] = None,
+    principal_type: Optional[Literal["actor", "public"]] = None,
 ) -> List[str]:
     """Atomically swap a principal's action set on a resource to ``role``.
 
     Removes any currently-granted actions that are not in the new role, then
     adds any missing ones. Audits each change. Returns the new action list.
+    ``principal_type`` disambiguates wildcard-named actor ids as in
+    :func:`grant`.
     """
-    _check_principal(actor_id, group_id)
+    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = set(_resolve_actions(datasette, resource_type, role, None))
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
     for action_name in sorted(existing - resolved):
         await _delete_grant(
-            db, resource_id, actor_id, group_id, action_name, by_actor
+            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
         )
     for action_name in sorted(resolved - existing):
         await _insert_grant(
-            db, resource_id, actor_id, group_id, action_name, by_actor
+            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
         )
     return sorted(resolved)
 
@@ -328,15 +416,18 @@ async def list_grants(
 ) -> List[Grant]:
     """Return the grants on a resource as a list of dicts.
 
-    Each dict is ``{"principal": "actor"|"group", "actor_id", "group_id",
-    "group_name", "actions": [...]}`` with actions sorted. Group grants whose
-    group is soft-deleted are omitted. The list is ordered by principal then id.
+    Each dict is ``{"principal": "actor"|"group"|"public", "actor_id",
+    "group_id", "group_name", "actions": [...]}`` with actions sorted.
+    ``principal`` comes straight from the stored ``principal_type`` column.
+    Group grants whose group is soft-deleted are omitted. The list is ordered
+    by principal (``actor`` < ``group`` < ``public``) then id.
     """
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     rows = await db.execute(
         """
         SELECT
+            acl.principal_type AS principal_type,
             acl.actor_id AS actor_id,
             acl.group_id AS group_id,
             acl_groups.name AS group_name,
@@ -351,16 +442,18 @@ async def list_grants(
     )
     grants = {}
     for row in rows.rows:
-        if row["actor_id"] is not None:
-            key = ("actor", row["actor_id"], None, None)
-        else:
-            key = ("group", None, row["group_id"], row["group_name"])
+        key = (
+            row["principal_type"],
+            row["actor_id"],
+            row["group_id"],
+            row["group_name"],
+        )
         grants.setdefault(key, set()).add(row["action_name"])
     out: List[Grant] = []
-    for (_principal, actor_id, group_id, group_name), action_set in grants.items():
+    for (principal, actor_id, group_id, group_name), action_set in grants.items():
         out.append(
             {
-                "principal": "actor" if actor_id is not None else "group",
+                "principal": principal,
                 "actor_id": actor_id,
                 "group_id": group_id,
                 "group_name": group_name,

--- a/datasette_acl/grants.py
+++ b/datasette_acl/grants.py
@@ -11,12 +11,12 @@ Every mutating helper:
   * writes the ``acl`` rows, and
   * appends ``acl_audit`` entries (``operation_by`` = ``by_actor``).
 
-Principal invariant: exactly one of ``actor_id`` / ``group_id`` is set, matching
-the CHECK constraint on the ``acl`` table. Every stored row also carries an
-explicit ``principal_type`` (``'actor'`` / ``'group'`` / ``'public'``);
-:func:`principal_type_for` is the single place that resolves it, defaulting to
-inference from ``PUBLIC_PRINCIPALS`` membership for callers that do not pass
-``principal_type=`` explicitly.
+Principal invariant: a grant targets exactly one principal -- an actor
+(``actor_id=``), a group (``group_id=``), or a public audience
+(``principal_type=`` one of ``'everyone'`` / ``'authenticated'`` /
+``'anonymous'``, with no id at all) -- matching the CHECK constraint on the
+``acl`` table. :func:`principal_type_for` is the single place that resolves
+and validates the combination.
 """
 
 from __future__ import annotations
@@ -32,18 +32,23 @@ from typing import (
 )
 
 from datasette_acl.roles import actions_for_role, roles_for
-from datasette_acl.utils import PUBLIC_PRINCIPALS, actions_for_resource_type
+from datasette_acl.utils import PUBLIC_PRINCIPAL_TYPES, actions_for_resource_type
 
 if TYPE_CHECKING:
     from datasette.app import Datasette
     from datasette.database import Database
 
 
-PrincipalType = Literal["actor", "group", "public"]
+PrincipalType = Literal["actor", "group", "everyone", "authenticated", "anonymous"]
 
 
 class Grant(TypedDict):
-    """One principal's grants on a resource, as returned by :func:`list_grants`."""
+    """One principal's grants on a resource, as returned by :func:`list_grants`.
+
+    ``principal`` is the stored ``principal_type``. ``actor_id`` is set only
+    for ``actor`` grants and ``group_id``/``group_name`` only for ``group``
+    grants; public-audience grants carry no id.
+    """
 
     principal: PrincipalType
     actor_id: Optional[str]
@@ -93,39 +98,38 @@ def principal_type_for(
     group_id: Optional[int],
     principal_type: Optional[str] = None,
 ) -> PrincipalType:
-    """Resolve the ``principal_type`` for a grant's principal.
+    """Resolve and validate the ``principal_type`` for a grant's principal.
 
-    Enforces the acl CHECK invariant (exactly one of ``actor_id`` /
-    ``group_id``). ``group_id`` always means ``'group'``. For actor ids, an
-    explicit ``principal_type`` of ``'actor'`` or ``'public'`` is honored
-    (``'public'`` ids are validated against ``PUBLIC_PRINCIPALS``); when it is
-    None the type is **inferred** from ``PUBLIC_PRINCIPALS`` membership. That
-    inference is the back-compat default for callers that say
-    ``actor_id="*"`` -- it lives only here; storage is always explicit and
-    enforcement never infers. Callers that know the type should pass it.
+    A principal is exactly one of: an actor (``actor_id=``), a group
+    (``group_id=``), or a public audience (``principal_type=`` one of
+    ``PUBLIC_PRINCIPAL_TYPES``, with neither id). ``principal_type`` may also
+    redundantly name ``'actor'`` / ``'group'`` alongside the matching id.
+    Raises ``ValueError`` for any other combination, mirroring the acl table's
+    CHECK constraint.
     """
+    if principal_type in PUBLIC_PRINCIPAL_TYPES:
+        if actor_id is not None or group_id is not None:
+            raise ValueError(
+                f"principal_type {principal_type!r} cannot be combined with "
+                "actor_id= or group_id="
+            )
+        return principal_type
     if (actor_id is None) == (group_id is None):
-        raise ValueError("Provide exactly one of actor_id= or group_id=")
+        raise ValueError(
+            "Provide exactly one principal: actor_id=, group_id=, or a "
+            f"public principal_type ({', '.join(PUBLIC_PRINCIPAL_TYPES)})"
+        )
     if group_id is not None:
         if principal_type not in (None, "group"):
             raise ValueError(
                 f"principal_type {principal_type!r} cannot be used with group_id="
             )
         return "group"
-    if principal_type is None:
-        return "public" if actor_id in PUBLIC_PRINCIPALS else "actor"
-    if principal_type == "actor":
-        return "actor"
-    if principal_type == "public":
-        if actor_id not in PUBLIC_PRINCIPALS:
-            raise ValueError(
-                f"principal_type 'public' requires actor_id to be one of "
-                f"{sorted(PUBLIC_PRINCIPALS)!r}, not {actor_id!r}"
-            )
-        return "public"
-    if principal_type == "group":
-        raise ValueError("principal_type 'group' requires group_id=, not actor_id=")
-    raise ValueError(f"Invalid principal_type: {principal_type!r}")
+    if principal_type not in (None, "actor"):
+        raise ValueError(
+            f"principal_type {principal_type!r} cannot be used with actor_id="
+        )
+    return "actor"
 
 
 async def _ensure_resource_id(
@@ -169,10 +173,13 @@ async def _current_actions(
     group_id: Optional[int],
 ) -> Set[str]:
     """Return the set of action names currently granted to a principal."""
-    if actor_id is not None:
-        where = "acl.principal_type = :principal_type AND acl.actor_id = :actor_id"
+    if principal_type == "actor":
+        where = "acl.principal_type = 'actor' AND acl.actor_id = :actor_id"
+    elif principal_type == "group":
+        where = "acl.principal_type = 'group' AND acl.group_id = :group_id"
     else:
-        where = "acl.group_id = :group_id AND acl.actor_id IS NULL"
+        # Public audience: the type alone identifies the principal.
+        where = "acl.principal_type = :principal_type"
     rows = await db.execute(
         f"""
         SELECT acl_actions.name AS name
@@ -234,15 +241,13 @@ async def _delete_grant(
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
-    # Constrain actor deletes by (principal_type, actor_id) so revoking the
-    # '_signed_in' wildcard can never delete a like-named user's grant, and
-    # vice versa.
-    if actor_id is not None:
-        principal_where = (
-            "principal_type = :principal_type AND actor_id = :actor_id"
-        )
+    if principal_type == "actor":
+        principal_where = "principal_type = 'actor' AND actor_id = :actor_id"
+    elif principal_type == "group":
+        principal_where = "principal_type = 'group' AND group_id = :group_id"
     else:
-        principal_where = "group_id = :group_id AND actor_id IS NULL"
+        # Public audience: the type alone identifies the principal.
+        principal_where = "principal_type = :principal_type"
     await db.execute_write(
         f"""
         DELETE FROM acl
@@ -318,17 +323,16 @@ async def grant(
     role: Optional[str] = None,
     actions: Optional[Iterable[str]] = None,
     by_actor: Optional[str] = None,
-    principal_type: Optional[Literal["actor", "public"]] = None,
+    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Grant a principal access to a resource, by role or by raw actions.
 
-    Exactly one of ``actor_id`` / ``group_id`` and exactly one of ``role`` /
-    ``actions`` must be supplied. Only actions not already granted are inserted
-    (idempotent). Returns the list of action names now held by the principal.
-
-    ``principal_type`` disambiguates an ``actor_id`` that collides with a
-    wildcard: pass ``"actor"`` to grant to a real user literally named e.g.
-    ``_signed_in``. Default None infers via :func:`principal_type_for`.
+    The principal is exactly one of ``actor_id=``, ``group_id=``, or a public
+    audience passed as ``principal_type=`` (``'everyone'`` /
+    ``'authenticated'`` / ``'anonymous'``, with neither id). Exactly one of
+    ``role`` / ``actions`` must be supplied. Only actions not already granted
+    are inserted (idempotent). Returns the list of action names now held by
+    the principal.
     """
     ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = _resolve_actions(datasette, resource_type, role, actions)
@@ -353,13 +357,12 @@ async def revoke(
     actor_id: Optional[str] = None,
     group_id: Optional[int] = None,
     by_actor: Optional[str] = None,
-    principal_type: Optional[Literal["actor", "public"]] = None,
+    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Remove all acl rows for a principal on a resource. Audits each removal.
 
-    Returns the list of action names that were removed. ``principal_type``
-    disambiguates wildcard-named actor ids as in :func:`grant`; revoking the
-    ``_signed_in`` wildcard never touches a like-named user's grants.
+    The principal is specified as in :func:`grant`. Returns the list of action
+    names that were removed.
     """
     ptype = principal_type_for(actor_id, group_id, principal_type)
     db = datasette.get_internal_database()
@@ -382,14 +385,13 @@ async def update_role(
     group_id: Optional[int] = None,
     role: str,
     by_actor: Optional[str] = None,
-    principal_type: Optional[Literal["actor", "public"]] = None,
+    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Atomically swap a principal's action set on a resource to ``role``.
 
-    Removes any currently-granted actions that are not in the new role, then
-    adds any missing ones. Audits each change. Returns the new action list.
-    ``principal_type`` disambiguates wildcard-named actor ids as in
-    :func:`grant`.
+    The principal is specified as in :func:`grant`. Removes any currently-
+    granted actions that are not in the new role, then adds any missing ones.
+    Audits each change. Returns the new action list.
     """
     ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = set(_resolve_actions(datasette, resource_type, role, None))
@@ -416,11 +418,10 @@ async def list_grants(
 ) -> List[Grant]:
     """Return the grants on a resource as a list of dicts.
 
-    Each dict is ``{"principal": "actor"|"group"|"public", "actor_id",
-    "group_id", "group_name", "actions": [...]}`` with actions sorted.
-    ``principal`` comes straight from the stored ``principal_type`` column.
-    Group grants whose group is soft-deleted are omitted. The list is ordered
-    by principal (``actor`` < ``group`` < ``public``) then id.
+    Each dict is a :class:`Grant` with actions sorted; ``principal`` comes
+    straight from the stored ``principal_type`` column. Group grants whose
+    group is soft-deleted are omitted. The list is ordered actors first, then
+    groups, then public audiences, then by id.
     """
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
@@ -460,8 +461,10 @@ async def list_grants(
                 "actions": sorted(action_set),
             }
         )
+    kind_order = {"actor": 0, "group": 1}
     out.sort(
         key=lambda g: (
+            kind_order.get(g["principal"], 2),
             g["principal"],
             g["actor_id"] or "",
             g["group_id"] or 0,

--- a/datasette_acl/hookspecs.py
+++ b/datasette_acl/hookspecs.py
@@ -26,7 +26,7 @@ def datasette_acl_roles(datasette):
     wins for display) and `manage=True` marks the role(s) whose actions
     authorize re-sharing the resource.
 
-    May return a list directly, or a function / awaitable returning one.
+    Return a list of AclRole directly.
 
     For the common Viewer/Editor/Manager triple, use
     ``datasette_acl.roles.standard_roles()`` instead of declaring each

--- a/datasette_acl/internal_migrations.py
+++ b/datasette_acl/internal_migrations.py
@@ -102,3 +102,69 @@ def m002_generalize_acl_resources(db: Database):
         SELECT id, 'table', database, resource FROM acl_resources_old;
     DROP TABLE acl_resources_old;
     """)
+
+
+@internal_migrations()
+def m003_principal_type(db: Database):
+    # Add an explicit principal_type discriminator to acl. Wildcard "general
+    # access" principals ('*', '_signed_in', '_anonymous') were stored in-band
+    # as actor_id values and recognized everywhere by string comparison, so a
+    # real user whose id collided with a wildcard inherited its grants. The
+    # rebuild also replaces the old UNIQUE(actor_id, group_id, ...) constraint,
+    # which never fired (exactly one principal column is always NULL and SQLite
+    # treats NULLs as distinct in unique indexes), with partial unique indexes
+    # that actually dedupe. Backfilling wildcard actor_ids as 'public' matches
+    # the enforcement semantics those rows already had. Same
+    # rename/recreate/copy/drop pattern as m002; the GROUP BY collapses any
+    # duplicates the dead UNIQUE let through, min(acl_id) keeps stable ids.
+    db.executescript("""
+    ALTER TABLE acl RENAME TO acl_old;
+    CREATE TABLE acl (
+        acl_id integer primary key,
+        principal_type text not null
+            check (principal_type in ('actor', 'group', 'public')),
+        actor_id text,
+        group_id integer,
+        resource_id integer not null,
+        action_id integer not null,
+        foreign key (group_id) references acl_groups(id),
+        foreign key (resource_id) references acl_resources(id),
+        foreign key (action_id) references acl_actions(id),
+        check (
+            (principal_type = 'group' and group_id is not null and actor_id is null)
+            or (principal_type in ('actor', 'public')
+                and actor_id is not null and group_id is null)
+        ),
+        -- Closed wildcard set; must stay in sync with utils.PUBLIC_PRINCIPALS.
+        -- Adding a fourth wildcard requires a deliberate migration.
+        check (
+            principal_type != 'public'
+            or actor_id in ('*', '_signed_in', '_anonymous')
+        )
+    );
+    CREATE UNIQUE INDEX acl_actor_unique
+        ON acl (principal_type, actor_id, resource_id, action_id)
+        WHERE actor_id IS NOT NULL;
+    CREATE UNIQUE INDEX acl_group_unique
+        ON acl (group_id, resource_id, action_id)
+        WHERE group_id IS NOT NULL;
+    INSERT INTO acl (acl_id, principal_type, actor_id, group_id, resource_id, action_id)
+    SELECT
+        min(acl_id),
+        CASE
+            WHEN group_id IS NOT NULL THEN 'group'
+            WHEN actor_id IN ('*', '_signed_in', '_anonymous') THEN 'public'
+            ELSE 'actor'
+        END,
+        actor_id, group_id, resource_id, action_id
+    FROM acl_old
+    GROUP BY actor_id, group_id, resource_id, action_id;
+    DROP TABLE acl_old;
+
+    ALTER TABLE acl_audit ADD COLUMN principal_type text;
+    UPDATE acl_audit SET principal_type = CASE
+        WHEN group_id IS NOT NULL THEN 'group'
+        WHEN actor_id IN ('*', '_signed_in', '_anonymous') THEN 'public'
+        ELSE 'actor'
+    END;
+    """)

--- a/datasette_acl/internal_migrations.py
+++ b/datasette_acl/internal_migrations.py
@@ -15,11 +15,14 @@ internal_migrations = Migrations("datasette-acl.internal")
 @internal_migrations()
 def m001_initial(db: Database):
     db.executescript("""
+    -- Resources are identified by (resource_type, parent, child); a table is
+    -- ('table', database, table_name), other resource types use what they need.
     create table if not exists acl_resources (
         id integer primary key,
-        database text not null,
-        resource text,
-        unique(database, resource)
+        resource_type text not null,
+        parent text not null,
+        child text,
+        unique(resource_type, parent, child)
     );
 
     create table if not exists acl_actions (
@@ -27,14 +30,13 @@ def m001_initial(db: Database):
         name text not null unique
     );
 
-    -- new table for groups
     create table if not exists acl_groups (
         id integer primary key,
         name text not null unique,
         deleted integer
     );
 
-    -- new table for actor-group relationships
+    -- actor-group membership
     create table if not exists acl_actor_groups (
         actor_id text,
         group_id integer,
@@ -42,7 +44,7 @@ def m001_initial(db: Database):
         foreign key (group_id) references acl_groups(id)
     );
 
-    -- Group membership audit log
+    -- group membership audit log
     create table if not exists acl_groups_audit (
         id integer primary key,
         timestamp text default (datetime('now')),
@@ -53,142 +55,14 @@ def m001_initial(db: Database):
         foreign key (group_id) references acl_groups(id)
     );
 
+    -- A grant's audience is named entirely by principal_type:
+    --   'actor'         -> a specific actor_id
+    --   'group'         -> a specific group_id
+    --   'everyone'      -> any caller, signed in or not (no id)
+    --   'authenticated' -> any signed-in caller (no id)
+    --   'anonymous'     -> signed-out callers only (no id)
+    -- The CHECK pins which of actor_id / group_id may be set for each type.
     create table if not exists acl (
-        acl_id integer primary key,
-        actor_id text,
-        group_id integer,
-        resource_id integer,
-        action_id integer,
-        foreign key (group_id) references acl_groups(id),
-        foreign key (resource_id) references acl_resources(id),
-        foreign key (action_id) references acl_actions(id),
-        check ((actor_id is null) != (group_id is null)),
-        unique(actor_id, group_id, resource_id, action_id)
-    );
-
-    -- ACL audit log
-    create table if not exists acl_audit (
-        id integer primary key,
-        timestamp text default (datetime('now')),
-        operation_by text,
-        operation text check (operation in ('added', 'removed')),
-        action_id integer,
-        resource_id integer,
-        group_id integer,
-        actor_id text,
-        foreign key (group_id) references acl_groups(id),
-        foreign key (resource_id) references acl_resources(id),
-        foreign key (action_id) references acl_actions(id)
-    );
-    """)
-
-
-@internal_migrations()
-def m002_generalize_acl_resources(db: Database):
-    # Generalize acl_resources from the table-only (database, resource) shape to
-    # (resource_type, parent, child) so any resource type can be tracked.
-    # Existing rows are tables, so backfill resource_type='table', preserving
-    # ids. SQLite can't rename/retype columns in place, so rewrite the table.
-    db.executescript("""
-    ALTER TABLE acl_resources RENAME TO acl_resources_old;
-    CREATE TABLE acl_resources (
-        id integer primary key,
-        resource_type text not null,
-        parent text not null,
-        child text,
-        unique(resource_type, parent, child)
-    );
-    INSERT INTO acl_resources (id, resource_type, parent, child)
-        SELECT id, 'table', database, resource FROM acl_resources_old;
-    DROP TABLE acl_resources_old;
-    """)
-
-
-@internal_migrations()
-def m003_principal_type(db: Database):
-    # Add an explicit principal_type discriminator to acl. Wildcard "general
-    # access" principals ('*', '_signed_in', '_anonymous') were stored in-band
-    # as actor_id values and recognized everywhere by string comparison, so a
-    # real user whose id collided with a wildcard inherited its grants. The
-    # rebuild also replaces the old UNIQUE(actor_id, group_id, ...) constraint,
-    # which never fired (exactly one principal column is always NULL and SQLite
-    # treats NULLs as distinct in unique indexes), with partial unique indexes
-    # that actually dedupe. Backfilling wildcard actor_ids as 'public' matches
-    # the enforcement semantics those rows already had. Same
-    # rename/recreate/copy/drop pattern as m002; the GROUP BY collapses any
-    # duplicates the dead UNIQUE let through, min(acl_id) keeps stable ids.
-    db.executescript("""
-    ALTER TABLE acl RENAME TO acl_old;
-    CREATE TABLE acl (
-        acl_id integer primary key,
-        principal_type text not null
-            check (principal_type in ('actor', 'group', 'public')),
-        actor_id text,
-        group_id integer,
-        resource_id integer not null,
-        action_id integer not null,
-        foreign key (group_id) references acl_groups(id),
-        foreign key (resource_id) references acl_resources(id),
-        foreign key (action_id) references acl_actions(id),
-        check (
-            (principal_type = 'group' and group_id is not null and actor_id is null)
-            or (principal_type in ('actor', 'public')
-                and actor_id is not null and group_id is null)
-        ),
-        -- Closed wildcard set; must stay in sync with utils.PUBLIC_PRINCIPALS.
-        -- Adding a fourth wildcard requires a deliberate migration.
-        check (
-            principal_type != 'public'
-            or actor_id in ('*', '_signed_in', '_anonymous')
-        )
-    );
-    CREATE UNIQUE INDEX acl_actor_unique
-        ON acl (principal_type, actor_id, resource_id, action_id)
-        WHERE actor_id IS NOT NULL;
-    CREATE UNIQUE INDEX acl_group_unique
-        ON acl (group_id, resource_id, action_id)
-        WHERE group_id IS NOT NULL;
-    INSERT INTO acl (acl_id, principal_type, actor_id, group_id, resource_id, action_id)
-    SELECT
-        min(acl_id),
-        CASE
-            WHEN group_id IS NOT NULL THEN 'group'
-            WHEN actor_id IN ('*', '_signed_in', '_anonymous') THEN 'public'
-            ELSE 'actor'
-        END,
-        actor_id, group_id, resource_id, action_id
-    FROM acl_old
-    GROUP BY actor_id, group_id, resource_id, action_id;
-    DROP TABLE acl_old;
-
-    ALTER TABLE acl_audit ADD COLUMN principal_type text;
-    UPDATE acl_audit SET principal_type = CASE
-        WHEN group_id IS NOT NULL THEN 'group'
-        WHEN actor_id IN ('*', '_signed_in', '_anonymous') THEN 'public'
-        ELSE 'actor'
-    END;
-    """)
-
-
-@internal_migrations()
-def m004_public_principal_types(db: Database):
-    # Promote the public audiences to first-class principal types. m003 kept
-    # the legacy wildcard ids ('*', '_signed_in', '_anonymous') stored in-band
-    # as actor_id values under a single 'public' type; this rebuild retires
-    # them from the schema entirely: principal_type itself names the audience
-    # ('everyone' / 'authenticated' / 'anonymous') and public rows store no id
-    # at all. Enforcement and application code match on principal_type alone,
-    # so no reserved actor-id namespace exists anywhere outside this migration
-    # (which mentions the old strings only to translate rows written before
-    # it). An actor literally named '_signed_in' is now just an ordinary actor
-    # row -- the collision class m003 guarded against is gone by construction.
-    # The old partial unique indexes are dropped by name before recreation
-    # (index names are database-global, so they would collide with acl_old's).
-    db.executescript("""
-    ALTER TABLE acl RENAME TO acl_old;
-    DROP INDEX IF EXISTS acl_actor_unique;
-    DROP INDEX IF EXISTS acl_group_unique;
-    CREATE TABLE acl (
         acl_id integer primary key,
         principal_type text not null
             check (principal_type in (
@@ -208,36 +82,32 @@ def m004_public_principal_types(db: Database):
                 and actor_id is null and group_id is null)
         )
     );
-    CREATE UNIQUE INDEX acl_actor_unique
-        ON acl (actor_id, resource_id, action_id)
-        WHERE actor_id IS NOT NULL;
-    CREATE UNIQUE INDEX acl_group_unique
-        ON acl (group_id, resource_id, action_id)
-        WHERE group_id IS NOT NULL;
-    CREATE UNIQUE INDEX acl_public_unique
-        ON acl (principal_type, resource_id, action_id)
-        WHERE actor_id IS NULL AND group_id IS NULL;
-    INSERT INTO acl (acl_id, principal_type, actor_id, group_id, resource_id, action_id)
-    SELECT
-        acl_id,
-        CASE
-            WHEN principal_type = 'public' AND actor_id = '*' THEN 'everyone'
-            WHEN principal_type = 'public' AND actor_id = '_signed_in' THEN 'authenticated'
-            WHEN principal_type = 'public' AND actor_id = '_anonymous' THEN 'anonymous'
-            ELSE principal_type
-        END,
-        CASE WHEN principal_type = 'public' THEN NULL ELSE actor_id END,
-        group_id, resource_id, action_id
-    FROM acl_old;
-    DROP TABLE acl_old;
+    -- Partial unique indexes dedupe per principal kind (a plain UNIQUE across
+    -- the nullable principal columns wouldn't fire, since SQLite treats NULLs
+    -- as distinct).
+    create unique index acl_actor_unique
+        on acl (actor_id, resource_id, action_id)
+        where actor_id is not null;
+    create unique index acl_group_unique
+        on acl (group_id, resource_id, action_id)
+        where group_id is not null;
+    create unique index acl_public_unique
+        on acl (principal_type, resource_id, action_id)
+        where actor_id is null and group_id is null;
 
-    UPDATE acl_audit SET
-        principal_type = CASE actor_id
-            WHEN '*' THEN 'everyone'
-            WHEN '_signed_in' THEN 'authenticated'
-            WHEN '_anonymous' THEN 'anonymous'
-            ELSE principal_type
-        END,
-        actor_id = NULL
-    WHERE principal_type = 'public';
+    -- ACL audit log
+    create table if not exists acl_audit (
+        id integer primary key,
+        timestamp text default (datetime('now')),
+        operation_by text,
+        operation text check (operation in ('added', 'removed')),
+        principal_type text,
+        action_id integer,
+        resource_id integer,
+        group_id integer,
+        actor_id text,
+        foreign key (group_id) references acl_groups(id),
+        foreign key (resource_id) references acl_resources(id),
+        foreign key (action_id) references acl_actions(id)
+    );
     """)

--- a/datasette_acl/internal_migrations.py
+++ b/datasette_acl/internal_migrations.py
@@ -168,3 +168,76 @@ def m003_principal_type(db: Database):
         ELSE 'actor'
     END;
     """)
+
+
+@internal_migrations()
+def m004_public_principal_types(db: Database):
+    # Promote the public audiences to first-class principal types. m003 kept
+    # the legacy wildcard ids ('*', '_signed_in', '_anonymous') stored in-band
+    # as actor_id values under a single 'public' type; this rebuild retires
+    # them from the schema entirely: principal_type itself names the audience
+    # ('everyone' / 'authenticated' / 'anonymous') and public rows store no id
+    # at all. Enforcement and application code match on principal_type alone,
+    # so no reserved actor-id namespace exists anywhere outside this migration
+    # (which mentions the old strings only to translate rows written before
+    # it). An actor literally named '_signed_in' is now just an ordinary actor
+    # row -- the collision class m003 guarded against is gone by construction.
+    # The old partial unique indexes are dropped by name before recreation
+    # (index names are database-global, so they would collide with acl_old's).
+    db.executescript("""
+    ALTER TABLE acl RENAME TO acl_old;
+    DROP INDEX IF EXISTS acl_actor_unique;
+    DROP INDEX IF EXISTS acl_group_unique;
+    CREATE TABLE acl (
+        acl_id integer primary key,
+        principal_type text not null
+            check (principal_type in (
+                'actor', 'group', 'everyone', 'authenticated', 'anonymous'
+            )),
+        actor_id text,
+        group_id integer,
+        resource_id integer not null,
+        action_id integer not null,
+        foreign key (group_id) references acl_groups(id),
+        foreign key (resource_id) references acl_resources(id),
+        foreign key (action_id) references acl_actions(id),
+        check (
+            (principal_type = 'actor' and actor_id is not null and group_id is null)
+            or (principal_type = 'group' and group_id is not null and actor_id is null)
+            or (principal_type in ('everyone', 'authenticated', 'anonymous')
+                and actor_id is null and group_id is null)
+        )
+    );
+    CREATE UNIQUE INDEX acl_actor_unique
+        ON acl (actor_id, resource_id, action_id)
+        WHERE actor_id IS NOT NULL;
+    CREATE UNIQUE INDEX acl_group_unique
+        ON acl (group_id, resource_id, action_id)
+        WHERE group_id IS NOT NULL;
+    CREATE UNIQUE INDEX acl_public_unique
+        ON acl (principal_type, resource_id, action_id)
+        WHERE actor_id IS NULL AND group_id IS NULL;
+    INSERT INTO acl (acl_id, principal_type, actor_id, group_id, resource_id, action_id)
+    SELECT
+        acl_id,
+        CASE
+            WHEN principal_type = 'public' AND actor_id = '*' THEN 'everyone'
+            WHEN principal_type = 'public' AND actor_id = '_signed_in' THEN 'authenticated'
+            WHEN principal_type = 'public' AND actor_id = '_anonymous' THEN 'anonymous'
+            ELSE principal_type
+        END,
+        CASE WHEN principal_type = 'public' THEN NULL ELSE actor_id END,
+        group_id, resource_id, action_id
+    FROM acl_old;
+    DROP TABLE acl_old;
+
+    UPDATE acl_audit SET
+        principal_type = CASE actor_id
+            WHEN '*' THEN 'everyone'
+            WHEN '_signed_in' THEN 'authenticated'
+            WHEN '_anonymous' THEN 'anonymous'
+            ELSE principal_type
+        END,
+        actor_id = NULL
+    WHERE principal_type = 'public';
+    """)

--- a/datasette_acl/roles.py
+++ b/datasette_acl/roles.py
@@ -2,9 +2,9 @@
 
 acl stores per-action grants, but users think in roles (Viewer / Editor /
 Manager). Plugins declare roles for their resource types via the
-``datasette_acl_roles`` hook; they are collected at startup into a registry
-keyed by ``resource_type``. Helpers resolve a granted action-set to its
-best-matching role and back.
+``datasette_acl_roles`` hook; :func:`roles_for` gathers them on demand into a
+registry keyed by ``resource_type``. Helpers resolve a granted action-set to
+its best-matching role and back.
 """
 
 from __future__ import annotations
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
 from datasette.plugins import pm
-from datasette.utils import await_me_maybe
 
 if TYPE_CHECKING:
     from datasette.app import Datasette
@@ -119,17 +118,16 @@ def standard_roles(
     ]
 
 
-async def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
+def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
     """Gather declared roles into ``{resource_type: [AclRole, ...]}``.
 
-    Calls the ``datasette_acl_roles`` hook across all plugins, awaiting any
-    callables/awaitables they return, and groups the resulting AclRole objects
-    by ``resource_type``. Within each resource type the roles are sorted by
-    ``rank`` ascending (so the highest-rank role is last) for stable ordering.
+    Calls the ``datasette_acl_roles`` hook across all plugins and groups the
+    resulting AclRole objects by ``resource_type``. Within each resource type
+    the roles are sorted by ``rank`` ascending (so the highest-rank role is
+    last) for stable ordering.
     """
     registry: Dict[str, List[AclRole]] = {}
-    for hook_result in pm.hook.datasette_acl_roles(datasette=datasette):
-        roles = await await_me_maybe(hook_result)
+    for roles in pm.hook.datasette_acl_roles(datasette=datasette):
         if not roles:
             continue
         for role in roles:
@@ -142,13 +140,11 @@ async def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
 def roles_for(datasette: Datasette, resource_type: str) -> List[AclRole]:
     """Return the registered roles for ``resource_type`` (``[]`` if none).
 
-    Reads the registry cached on the Datasette instance at startup by
-    :func:`build_roles_registry` (see ``datasette_acl.startup``). Shared by the
-    grants layer and the JSON API so neither pokes ``_acl_roles_registry``
-    directly.
+    Gathers roles from the ``datasette_acl_roles`` hook on demand via
+    :func:`build_roles_registry`. Shared by the grants layer and the JSON API
+    as the single way to ask "what roles exist for this resource type?".
     """
-    registry = getattr(datasette, "_acl_roles_registry", None) or {}
-    return registry.get(resource_type, [])
+    return build_roles_registry(datasette).get(resource_type, [])
 
 
 def role_for_actions(

--- a/datasette_acl/templates/manage_resource_acls.html
+++ b/datasette_acl/templates/manage_resource_acls.html
@@ -50,7 +50,7 @@ table.audit td {
 <h3>General access</h3>
 {% for principal, label in public_principals.items() %}
   <div style="margin-bottom: 1em">
-    <label style="display: block" for="id_public_permissions_{{ loop.index }}">{{ label }} (<code>{{ principal }}</code>)</label>
+    <label style="display: block" for="id_public_permissions_{{ loop.index }}">{{ label }}</label>
     <select multiple name="public_permissions_{{ principal }}" id="id_public_permissions_{{ loop.index }}">
       {% for action in actions %}
         <option value="{{ action }}" {% if public_permissions and public_permissions.get(principal, {}).get(action) %}selected{% endif %}>{{ action }}</option>
@@ -121,8 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
       <th>Date and time</th>
       <th>Operation by</th>
       <th>Operation</th>
-      <th>Group</th>
-      <th>User</th>
+      <th>Principal</th>
       <th>Action</th>
     </tr>
   </thead>
@@ -132,8 +131,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <td>{{ entry.timestamp }}</td>
         <td>{{ entry.operation_by }}</td>
         <td>{{ entry.operation }}</td>
-        <td>{{ entry.group_name or '' }}</td>
-        <td>{% if entry.principal_type == 'public' %}<code>{{ entry.actor_id }}</code> (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
+        <td>{% if entry.principal_type == 'group' %}{{ entry.group_name }} (group){% elif entry.principal_type == 'public' %}{{ public_principals.get(entry.actor_id, entry.actor_id) }} (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
         <td>{{ entry.action_name }}</td>
       </tr>
     {% endfor %}

--- a/datasette_acl/templates/manage_resource_acls.html
+++ b/datasette_acl/templates/manage_resource_acls.html
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <td>{{ entry.timestamp }}</td>
         <td>{{ entry.operation_by }}</td>
         <td>{{ entry.operation }}</td>
-        <td>{% if entry.principal_type == 'group' %}{{ entry.group_name }} (group){% elif entry.principal_type == 'public' %}{{ public_principals.get(entry.actor_id, entry.actor_id) }} (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
+        <td>{% if entry.principal_type == 'group' %}{{ entry.group_name }} (group){% elif entry.principal_type in public_principals %}{{ public_principals[entry.principal_type] }} (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
         <td>{{ entry.action_name }}</td>
       </tr>
     {% endfor %}

--- a/datasette_acl/templates/manage_resource_acls.html
+++ b/datasette_acl/templates/manage_resource_acls.html
@@ -47,6 +47,18 @@ table.audit td {
   {% endfor %}
 {% endif %}
 
+<h3>General access</h3>
+{% for principal, label in public_principals.items() %}
+  <div style="margin-bottom: 1em">
+    <label style="display: block" for="id_public_permissions_{{ loop.index }}">{{ label }} (<code>{{ principal }}</code>)</label>
+    <select multiple name="public_permissions_{{ principal }}" id="id_public_permissions_{{ loop.index }}">
+      {% for action in actions %}
+        <option value="{{ action }}" {% if public_permissions and public_permissions.get(principal, {}).get(action) %}selected{% endif %}>{{ action }}</option>
+      {% endfor %}
+    </select>
+  </div>
+{% endfor %}
+
 <h3>Users</h3>
 {% for user in user_permissions %}
   <div>

--- a/datasette_acl/templates/manage_resource_acls.html
+++ b/datasette_acl/templates/manage_resource_acls.html
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <td>{{ entry.operation_by }}</td>
         <td>{{ entry.operation }}</td>
         <td>{{ entry.group_name or '' }}</td>
-        <td>{{ entry.actor_id or '' }}</td>
+        <td>{% if entry.principal_type == 'public' %}<code>{{ entry.actor_id }}</code> (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
         <td>{{ entry.action_name }}</td>
       </tr>
     {% endfor %}

--- a/datasette_acl/templates/manage_table_acls.html
+++ b/datasette_acl/templates/manage_table_acls.html
@@ -121,7 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <td>{{ entry.timestamp }}</td>
         <td>{{ entry.operation_by }}</td>
         <td>{{ entry.operation }}</td>
-        <td>{% if entry.principal_type == 'group' %}{{ entry.group_name }} (group){% elif entry.principal_type == 'public' %}{{ public_principals.get(entry.actor_id, entry.actor_id) }} (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
+        <td>{% if entry.principal_type == 'group' %}{{ entry.group_name }} (group){% elif entry.principal_type in public_principals %}{{ public_principals[entry.principal_type] }} (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
         <td>{{ entry.action_name }}</td>
       </tr>
     {% endfor %}

--- a/datasette_acl/templates/manage_table_acls.html
+++ b/datasette_acl/templates/manage_table_acls.html
@@ -111,8 +111,7 @@ document.addEventListener('DOMContentLoaded', function() {
       <th>Date and time</th>
       <th>Operation by</th>
       <th>Operation</th>
-      <th>Group</th>
-      <th>User</th>
+      <th>Principal</th>
       <th>Action</th>
     </tr>
   </thead>
@@ -122,8 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <td>{{ entry.timestamp }}</td>
         <td>{{ entry.operation_by }}</td>
         <td>{{ entry.operation }}</td>
-        <td>{{ entry.group_name or '' }}</td>
-        <td>{% if entry.principal_type == 'public' %}<code>{{ entry.actor_id }}</code> (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
+        <td>{% if entry.principal_type == 'group' %}{{ entry.group_name }} (group){% elif entry.principal_type == 'public' %}{{ public_principals.get(entry.actor_id, entry.actor_id) }} (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
         <td>{{ entry.action_name }}</td>
       </tr>
     {% endfor %}

--- a/datasette_acl/templates/manage_table_acls.html
+++ b/datasette_acl/templates/manage_table_acls.html
@@ -123,7 +123,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <td>{{ entry.operation_by }}</td>
         <td>{{ entry.operation }}</td>
         <td>{{ entry.group_name or '' }}</td>
-        <td>{{ entry.actor_id or '' }}</td>
+        <td>{% if entry.principal_type == 'public' %}<code>{{ entry.actor_id }}</code> (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
         <td>{{ entry.action_name }}</td>
       </tr>
     {% endfor %}

--- a/datasette_acl/utils.py
+++ b/datasette_acl/utils.py
@@ -9,14 +9,17 @@ if TYPE_CHECKING:
     from datasette.permissions import Resource
 
 
-# Wildcard / "general access" principals. These are stored as actor_id values
-# in acl rows but represent classes of actor rather than a specific person --
-# the permission_resources_sql hook matches them specially. Maps principal id
-# to the label shown in admin UIs; dict order is display order.
-PUBLIC_PRINCIPALS = {
-    "*": "Anyone (signed in or not)",
-    "_signed_in": "Any signed-in user",
-    "_anonymous": "Signed-out (anonymous) visitors only",
+# Public / "general access" principal types. Each is a first-class
+# principal_type value on acl rows (alongside 'actor' and 'group') matching a
+# class of caller rather than a specific person; public rows store no id at
+# all. Maps principal_type to the label shown in admin UIs; dict order is
+# display order. The set is closed by design and duplicated in the acl table's
+# CHECK constraint (internal_migrations.m004) -- adding an audience requires a
+# deliberate migration.
+PUBLIC_PRINCIPAL_TYPES = {
+    "everyone": "Anyone (signed in or not)",
+    "authenticated": "Any signed-in user",
+    "anonymous": "Signed-out (anonymous) visitors only",
 }
 
 

--- a/datasette_acl/utils.py
+++ b/datasette_acl/utils.py
@@ -9,6 +9,17 @@ if TYPE_CHECKING:
     from datasette.permissions import Resource
 
 
+# Wildcard / "general access" principals. These are stored as actor_id values
+# in acl rows but represent classes of actor rather than a specific person --
+# the permission_resources_sql hook matches them specially. Maps principal id
+# to the label shown in admin UIs; dict order is display order.
+PUBLIC_PRINCIPALS = {
+    "*": "Anyone (signed in or not)",
+    "_signed_in": "Any signed-in user",
+    "_anonymous": "Signed-out (anonymous) visitors only",
+}
+
+
 async def can_edit_permissions(datasette, actor):
     return await datasette.allowed(actor=actor, action="datasette-acl")
 

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -46,6 +46,7 @@ from datasette import Response, Forbidden
 from datasette_acl.grants import grant, revoke, update_role, list_grants
 from datasette_acl.roles import role_for_actions, roles_for
 from datasette_acl.utils import (
+    PUBLIC_PRINCIPALS,
     build_resource,
     can_manage,
     resource_class_for,
@@ -53,11 +54,6 @@ from datasette_acl.utils import (
     can_edit_permissions,
     get_acl_valid_actors,
 )
-
-# Wildcard / "general access" principals. These are stored as actor_id values in
-# acl rows but represent classes of actor rather than a specific person, so the
-# UI renders them in a separate "General access" section.
-PUBLIC_PRINCIPALS = {"*", "_signed_in", "_anonymous"}
 
 
 def _roles_payload(roles):

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -49,7 +49,7 @@ from datasette_acl.grants import (
     revoke,
     update_role,
     list_grants,
-    principal_type_for,
+    Principal,
 )
 from datasette_acl.roles import role_for_actions, roles_for
 from datasette_acl.utils import (
@@ -202,22 +202,18 @@ async def _group_grant_entry(datasette, roles, group_id, actions):
     return _group_entry(group_id, role, actions, info)
 
 
-def _principal_from_body(body):
-    """Extract ``(actor_id, group_id, principal_type)`` from a request body.
+def _principal_from_body(body) -> Principal:
+    """Build a :class:`Principal` from a request body.
 
     The principal is exactly one of ``actor_id``, ``group_id``, or a public
     audience named by ``principal_type`` (``"everyone"`` / ``"authenticated"``
     / ``"anonymous"`` with neither id). Raises ``ValueError`` for invalid
-    combinations (via :func:`principal_type_for`) so handlers can translate it
-    to a 400.
+    combinations (via :meth:`Principal.from_parts`) so handlers can translate
+    it to a 400.
     """
-    actor_id = body.get("actor_id")
-    group_id = body.get("group_id")
-    principal_type = body.get("principal_type")
-    # Validates the combination eagerly (exactly-one principal, no audience
-    # alongside an id, no 'group' alongside actor_id).
-    principal_type_for(actor_id, group_id, principal_type)
-    return actor_id, group_id, principal_type
+    return Principal.from_parts(
+        body.get("actor_id"), body.get("group_id"), body.get("principal_type")
+    )
 
 
 def _parse_json_body(request_body):
@@ -233,16 +229,18 @@ def _parse_json_body(request_body):
     return data
 
 
-async def _enriched_grant(
-    datasette, roles, actor_id, group_id, actions, principal_type=None
-):
+async def _enriched_grant(datasette, roles, principal: Principal, actions):
     """Build the enriched grant entry for whichever principal was supplied."""
-    if actor_id is not None:
-        return await _actor_grant_entry(datasette, roles, actor_id, actions)
-    if group_id is not None:
-        return await _group_grant_entry(datasette, roles, group_id, actions)
+    if principal.principal_type == "actor":
+        return await _actor_grant_entry(
+            datasette, roles, principal.actor_id, actions
+        )
+    if principal.principal_type == "group":
+        return await _group_grant_entry(
+            datasette, roles, principal.group_id, actions
+        )
     role = role_for_actions(roles, set(actions))
-    return _public_entry(principal_type, role, actions)
+    return _public_entry(principal.principal_type, role, actions)
 
 
 async def resource_grants_json(request, datasette):
@@ -379,27 +377,23 @@ async def grant_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         actions = await grant(
             datasette,
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             role=body.get("role"),
             actions=body.get("actions"),
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(
-        datasette, roles, actor_id, group_id, actions, principal_type
-    )
+    entry = await _enriched_grant(datasette, roles, principal, actions)
     return Response.json({"ok": True, "grant": entry})
 
 
@@ -566,17 +560,15 @@ async def revoke_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         removed = await revoke(
             datasette,
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
@@ -597,7 +589,7 @@ async def update_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         role = body.get("role")
         if not role:
             raise _ApiError(400, "update requires a role")
@@ -607,17 +599,13 @@ async def update_json(request, datasette):
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             role=role,
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(
-        datasette, roles, actor_id, group_id, actions, principal_type
-    )
+    entry = await _enriched_grant(datasette, roles, principal, actions)
     return Response.json({"ok": True, "grant": entry})

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -10,9 +10,10 @@ grouped by principal, each principal's granted action-set is resolved to a
 friendly role, and actor grants are enriched with display name / email / avatar
 via core ``datasette.actors_from_ids`` (owned by user-profiles in phase-03;
 degrades to ``{"id": id}`` when profiles is not installed). Group grants resolve
-to a name + member count from ``acl_groups`` / ``acl_actor_groups``. Wildcard
-principals (``*`` / ``_signed_in`` / ``_anonymous``) are flagged ``kind:"public"``
-and surface in the dialog's "General access" section.
+to a name + member count from ``acl_groups`` / ``acl_actor_groups``. Public-
+audience grants (principal_type ``everyone`` / ``authenticated`` /
+``anonymous``) are flagged ``kind:"public"`` and surface in the dialog's
+"General access" section.
 
 Task 04 adds the *write* side — three JSON POST endpoints, each authorized by a
 **per-resource** manage check rather than a global flag:
@@ -52,6 +53,7 @@ from datasette_acl.grants import (
 )
 from datasette_acl.roles import role_for_actions, roles_for
 from datasette_acl.utils import (
+    PUBLIC_PRINCIPAL_TYPES,
     build_resource,
     can_manage,
     resource_class_for,
@@ -90,16 +92,12 @@ async def _ensure_can_manage(datasette, request, resource_type, parent, child=No
         raise Forbidden("Cannot manage sharing for this resource")
 
 
-def _kind_for(principal, enriched):
-    """Resolve the ``kind`` for an actor-principal grant.
+def _kind_for(enriched):
+    """Resolve the ``kind`` for an actor grant.
 
-    ``principal`` is the stored principal type (``"actor"`` / ``"public"``) --
-    no string inference. Public principals are ``public``. Otherwise prefer a
-    ``kind`` supplied by the actor-resolution layer (profiles / agents);
-    default to ``user``.
+    Prefer a ``kind`` supplied by the actor-resolution layer (profiles /
+    agents); default to ``user``.
     """
-    if principal == "public":
-        return "public"
     if enriched and enriched.get("kind"):
         return enriched["kind"]
     return "user"
@@ -130,27 +128,41 @@ async def _group_info(datasette, group_ids):
     }
 
 
-def _actor_entry(actor_id, role, actions, info, principal="actor"):
+def _actor_entry(actor_id, role, actions, info):
     """Assemble an actor grant entry from an already-resolved role + actor info.
 
     Pure shape-builder shared by the batched GET loop and the per-principal
     mutation helper, so both produce the identical entry shape. ``info`` is the
-    actor's ``actors_from_ids`` record (``{}`` for wildcard / unknown actors).
-    ``principal`` is the stored principal type (``"actor"`` / ``"public"``);
-    the entry's own ``principal`` field stays ``"actor"`` either way (the
-    client contract distinguishes wildcards via ``kind: "public"``).
+    actor's ``actors_from_ids`` record (``{}`` for unknown actors).
     """
     entry = {
         "principal": "actor",
         "id": actor_id,
         "role": role.name if role else None,
         "actions": sorted(actions),
-        "kind": _kind_for(principal, info),
+        "kind": _kind_for(info),
     }
     for key in ("display_name", "email", "avatar_url"):
         if info.get(key):
             entry[key] = info[key]
     return entry
+
+
+def _public_entry(principal_type, role, actions):
+    """Assemble a public-audience grant entry.
+
+    ``principal_type`` is one of ``PUBLIC_PRINCIPAL_TYPES`` and doubles as the
+    entry ``id`` (audiences have no stored id); clients group these into the
+    "General access" section via ``kind: "public"``.
+    """
+    return {
+        "principal": "public",
+        "id": principal_type,
+        "role": role.name if role else None,
+        "actions": sorted(actions),
+        "kind": "public",
+        "display_name": PUBLIC_PRINCIPAL_TYPES[principal_type],
+    }
 
 
 def _group_entry(group_id, role, actions, info, fallback_name=None):
@@ -172,20 +184,15 @@ def _group_entry(group_id, role, actions, info, fallback_name=None):
     }
 
 
-async def _actor_grant_entry(datasette, roles, actor_id, actions, principal):
-    """Build the enriched API entry for one actor-principal grant.
+async def _actor_grant_entry(datasette, roles, actor_id, actions):
+    """Build the enriched API entry for one actor grant.
 
     Resolves the granted action-set to its best role, enriches via core
-    ``actors_from_ids`` (skipped for public principals, which are not real
-    actors), and tags ``kind``. ``principal`` is the stored principal type.
+    ``actors_from_ids``, and tags ``kind``.
     """
     role = role_for_actions(roles, set(actions))
-    enriched = {}
-    if principal == "actor":
-        enriched = (await datasette.actors_from_ids([actor_id])) or {}
-    return _actor_entry(
-        actor_id, role, actions, enriched.get(actor_id) or {}, principal=principal
-    )
+    enriched = (await datasette.actors_from_ids([actor_id])) or {}
+    return _actor_entry(actor_id, role, actions, enriched.get(actor_id) or {})
 
 
 async def _group_grant_entry(datasette, roles, group_id, actions):
@@ -198,18 +205,17 @@ async def _group_grant_entry(datasette, roles, group_id, actions):
 def _principal_from_body(body):
     """Extract ``(actor_id, group_id, principal_type)`` from a request body.
 
-    Exactly one of ``actor_id`` / ``group_id`` must be supplied.
-    ``principal_type`` is optional (``"actor"`` / ``"public"``) and
-    disambiguates a wildcard-named actor id; when absent the grant helpers
-    infer it, preserving the existing ``{"actor_id": "*"}`` client contract.
-    Raises ``ValueError`` for invalid combinations (via
-    :func:`principal_type_for`) so handlers can translate it to a 400.
+    The principal is exactly one of ``actor_id``, ``group_id``, or a public
+    audience named by ``principal_type`` (``"everyone"`` / ``"authenticated"``
+    / ``"anonymous"`` with neither id). Raises ``ValueError`` for invalid
+    combinations (via :func:`principal_type_for`) so handlers can translate it
+    to a 400.
     """
     actor_id = body.get("actor_id")
     group_id = body.get("group_id")
     principal_type = body.get("principal_type")
-    # Validates the combination eagerly (exactly-one principal, public ids
-    # against the wildcard whitelist, no 'group' alongside actor_id).
+    # Validates the combination eagerly (exactly-one principal, no audience
+    # alongside an id, no 'group' alongside actor_id).
     principal_type_for(actor_id, group_id, principal_type)
     return actor_id, group_id, principal_type
 
@@ -232,11 +238,11 @@ async def _enriched_grant(
 ):
     """Build the enriched grant entry for whichever principal was supplied."""
     if actor_id is not None:
-        principal = principal_type_for(actor_id, None, principal_type)
-        return await _actor_grant_entry(
-            datasette, roles, actor_id, actions, principal
-        )
-    return await _group_grant_entry(datasette, roles, group_id, actions)
+        return await _actor_grant_entry(datasette, roles, actor_id, actions)
+    if group_id is not None:
+        return await _group_grant_entry(datasette, roles, group_id, actions)
+    role = role_for_actions(roles, set(actions))
+    return _public_entry(principal_type, role, actions)
 
 
 async def resource_grants_json(request, datasette):
@@ -269,7 +275,7 @@ async def resource_grants_json(request, datasette):
     raw_grants = await list_grants(datasette, resource_type, parent, child)
 
     # Enrich actor grants in one batch via core actors_from_ids. Public
-    # (wildcard) principals are not real actors; we never look them up.
+    # audiences are not real actors; we never look them up.
     actor_ids = [g["actor_id"] for g in raw_grants if g["principal"] == "actor"]
     enriched = {}
     if actor_ids:
@@ -292,7 +298,7 @@ async def resource_grants_json(request, datasette):
                     fallback_name=g["group_name"],
                 )
             )
-        else:
+        elif g["principal"] == "actor":
             actor_id = g["actor_id"]
             grants.append(
                 _actor_entry(
@@ -300,9 +306,10 @@ async def resource_grants_json(request, datasette):
                     role,
                     g["actions"],
                     enriched.get(actor_id) or {},
-                    principal=g["principal"],
                 )
             )
+        else:
+            grants.append(_public_entry(g["principal"], role, g["actions"]))
 
     return Response.json(
         {
@@ -364,9 +371,8 @@ async def _begin_mutation(request, datasette):
 async def grant_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/grant.
 
-    Body: ``{actor_id|group_id, role}`` or ``{actor_id|group_id, actions: [...]}``,
-    plus optional ``principal_type: "actor"|"public"`` to disambiguate a
-    wildcard-named actor id (absent -> inferred).
+    Body: one principal (``actor_id``, ``group_id``, or a public-audience
+    ``principal_type``) plus exactly one of ``role`` / ``actions: [...]``.
     Upserts the grant (idempotent), audits, and returns the enriched grant.
     """
     try:
@@ -385,7 +391,7 @@ async def grant_json(request, datasette):
             role=body.get("role"),
             actions=body.get("actions"),
             by_actor=by_actor,
-            principal_type=principal_type if actor_id is not None else None,
+            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
@@ -552,9 +558,9 @@ async def actors_json(request, datasette):
 async def revoke_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/revoke.
 
-    Body: ``{actor_id}`` or ``{group_id}``, plus optional ``principal_type``.
-    Deletes all acl rows for that principal on this resource, audits each
-    removal, returns ``{ok: true}``.
+    Body: one principal (``actor_id``, ``group_id``, or a public-audience
+    ``principal_type``). Deletes all acl rows for that principal on this
+    resource, audits each removal, returns ``{ok: true}``.
     """
     try:
         resource_type, parent, child, roles, body = await _begin_mutation(
@@ -570,7 +576,7 @@ async def revoke_json(request, datasette):
             actor_id=actor_id,
             group_id=group_id,
             by_actor=by_actor,
-            principal_type=principal_type if actor_id is not None else None,
+            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
@@ -582,9 +588,10 @@ async def revoke_json(request, datasette):
 async def update_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/update.
 
-    Body: ``{actor_id|group_id, role}``, plus optional ``principal_type``.
-    Atomically swaps the principal's action set to the new role, audits each
-    change, and returns the enriched grant.
+    Body: one principal (``actor_id``, ``group_id``, or a public-audience
+    ``principal_type``) plus a required ``role``. Atomically swaps the
+    principal's action set to the new role, audits each change, and returns
+    the enriched grant.
     """
     try:
         resource_type, parent, child, roles, body = await _begin_mutation(
@@ -604,7 +611,7 @@ async def update_json(request, datasette):
             group_id=group_id,
             role=role,
             by_actor=by_actor,
-            principal_type=principal_type if actor_id is not None else None,
+            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -43,10 +43,15 @@ import json
 
 from datasette import Response, Forbidden
 
-from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.grants import (
+    grant,
+    revoke,
+    update_role,
+    list_grants,
+    principal_type_for,
+)
 from datasette_acl.roles import role_for_actions, roles_for
 from datasette_acl.utils import (
-    PUBLIC_PRINCIPALS,
     build_resource,
     can_manage,
     resource_class_for,
@@ -85,13 +90,15 @@ async def _ensure_can_manage(datasette, request, resource_type, parent, child=No
         raise Forbidden("Cannot manage sharing for this resource")
 
 
-def _kind_for(actor_id, enriched):
+def _kind_for(principal, enriched):
     """Resolve the ``kind`` for an actor-principal grant.
 
-    Wildcard principals are ``public``. Otherwise prefer a ``kind`` supplied by
-    the actor-resolution layer (profiles / agents); default to ``user``.
+    ``principal`` is the stored principal type (``"actor"`` / ``"public"``) --
+    no string inference. Public principals are ``public``. Otherwise prefer a
+    ``kind`` supplied by the actor-resolution layer (profiles / agents);
+    default to ``user``.
     """
-    if actor_id in PUBLIC_PRINCIPALS:
+    if principal == "public":
         return "public"
     if enriched and enriched.get("kind"):
         return enriched["kind"]
@@ -123,19 +130,22 @@ async def _group_info(datasette, group_ids):
     }
 
 
-def _actor_entry(actor_id, role, actions, info):
+def _actor_entry(actor_id, role, actions, info, principal="actor"):
     """Assemble an actor grant entry from an already-resolved role + actor info.
 
     Pure shape-builder shared by the batched GET loop and the per-principal
     mutation helper, so both produce the identical entry shape. ``info`` is the
     actor's ``actors_from_ids`` record (``{}`` for wildcard / unknown actors).
+    ``principal`` is the stored principal type (``"actor"`` / ``"public"``);
+    the entry's own ``principal`` field stays ``"actor"`` either way (the
+    client contract distinguishes wildcards via ``kind: "public"``).
     """
     entry = {
         "principal": "actor",
         "id": actor_id,
         "role": role.name if role else None,
         "actions": sorted(actions),
-        "kind": _kind_for(actor_id, info),
+        "kind": _kind_for(principal, info),
     }
     for key in ("display_name", "email", "avatar_url"):
         if info.get(key):
@@ -162,17 +172,20 @@ def _group_entry(group_id, role, actions, info, fallback_name=None):
     }
 
 
-async def _actor_grant_entry(datasette, roles, actor_id, actions):
+async def _actor_grant_entry(datasette, roles, actor_id, actions, principal):
     """Build the enriched API entry for one actor-principal grant.
 
     Resolves the granted action-set to its best role, enriches via core
-    ``actors_from_ids`` (skipped for wildcard principals), and tags ``kind``.
+    ``actors_from_ids`` (skipped for public principals, which are not real
+    actors), and tags ``kind``. ``principal`` is the stored principal type.
     """
     role = role_for_actions(roles, set(actions))
     enriched = {}
-    if actor_id not in PUBLIC_PRINCIPALS:
+    if principal == "actor":
         enriched = (await datasette.actors_from_ids([actor_id])) or {}
-    return _actor_entry(actor_id, role, actions, enriched.get(actor_id) or {})
+    return _actor_entry(
+        actor_id, role, actions, enriched.get(actor_id) or {}, principal=principal
+    )
 
 
 async def _group_grant_entry(datasette, roles, group_id, actions):
@@ -183,17 +196,22 @@ async def _group_grant_entry(datasette, roles, group_id, actions):
 
 
 def _principal_from_body(body):
-    """Extract ``(actor_id, group_id)`` from a request body, enforcing exactly one.
+    """Extract ``(actor_id, group_id, principal_type)`` from a request body.
 
-    Returns ``(actor_id, group_id)`` with exactly one non-None. Raises
-    ``ValueError`` if neither or both are supplied (mirrors the acl CHECK
-    invariant) so handlers can translate it to a 400.
+    Exactly one of ``actor_id`` / ``group_id`` must be supplied.
+    ``principal_type`` is optional (``"actor"`` / ``"public"``) and
+    disambiguates a wildcard-named actor id; when absent the grant helpers
+    infer it, preserving the existing ``{"actor_id": "*"}`` client contract.
+    Raises ``ValueError`` for invalid combinations (via
+    :func:`principal_type_for`) so handlers can translate it to a 400.
     """
     actor_id = body.get("actor_id")
     group_id = body.get("group_id")
-    if (actor_id is None) == (group_id is None):
-        raise ValueError("Provide exactly one of actor_id or group_id")
-    return actor_id, group_id
+    principal_type = body.get("principal_type")
+    # Validates the combination eagerly (exactly-one principal, public ids
+    # against the wildcard whitelist, no 'group' alongside actor_id).
+    principal_type_for(actor_id, group_id, principal_type)
+    return actor_id, group_id, principal_type
 
 
 def _parse_json_body(request_body):
@@ -209,10 +227,15 @@ def _parse_json_body(request_body):
     return data
 
 
-async def _enriched_grant(datasette, roles, actor_id, group_id, actions):
+async def _enriched_grant(
+    datasette, roles, actor_id, group_id, actions, principal_type=None
+):
     """Build the enriched grant entry for whichever principal was supplied."""
     if actor_id is not None:
-        return await _actor_grant_entry(datasette, roles, actor_id, actions)
+        principal = principal_type_for(actor_id, None, principal_type)
+        return await _actor_grant_entry(
+            datasette, roles, actor_id, actions, principal
+        )
     return await _group_grant_entry(datasette, roles, group_id, actions)
 
 
@@ -245,13 +268,9 @@ async def resource_grants_json(request, datasette):
     roles = roles_for(datasette, resource_type)
     raw_grants = await list_grants(datasette, resource_type, parent, child)
 
-    # Enrich actor grants in one batch via core actors_from_ids. Wildcard
-    # principals are not real actors; we never look them up.
-    actor_ids = [
-        g["actor_id"]
-        for g in raw_grants
-        if g["principal"] == "actor" and g["actor_id"] not in PUBLIC_PRINCIPALS
-    ]
+    # Enrich actor grants in one batch via core actors_from_ids. Public
+    # (wildcard) principals are not real actors; we never look them up.
+    actor_ids = [g["actor_id"] for g in raw_grants if g["principal"] == "actor"]
     enriched = {}
     if actor_ids:
         enriched = await datasette.actors_from_ids(actor_ids) or {}
@@ -262,12 +281,7 @@ async def resource_grants_json(request, datasette):
     grants = []
     for g in raw_grants:
         role = role_for_actions(roles, set(g["actions"]))
-        if g["principal"] == "actor":
-            actor_id = g["actor_id"]
-            grants.append(
-                _actor_entry(actor_id, role, g["actions"], enriched.get(actor_id) or {})
-            )
-        else:
+        if g["principal"] == "group":
             info = group_info.get(g["group_id"], {})
             grants.append(
                 _group_entry(
@@ -276,6 +290,17 @@ async def resource_grants_json(request, datasette):
                     g["actions"],
                     info,
                     fallback_name=g["group_name"],
+                )
+            )
+        else:
+            actor_id = g["actor_id"]
+            grants.append(
+                _actor_entry(
+                    actor_id,
+                    role,
+                    g["actions"],
+                    enriched.get(actor_id) or {},
+                    principal=g["principal"],
                 )
             )
 
@@ -339,14 +364,16 @@ async def _begin_mutation(request, datasette):
 async def grant_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/grant.
 
-    Body: ``{actor_id|group_id, role}`` or ``{actor_id|group_id, actions: [...]}``.
+    Body: ``{actor_id|group_id, role}`` or ``{actor_id|group_id, actions: [...]}``,
+    plus optional ``principal_type: "actor"|"public"`` to disambiguate a
+    wildcard-named actor id (absent -> inferred).
     Upserts the grant (idempotent), audits, and returns the enriched grant.
     """
     try:
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id = _principal_from_body(body)
+        actor_id, group_id, principal_type = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         actions = await grant(
             datasette,
@@ -358,12 +385,15 @@ async def grant_json(request, datasette):
             role=body.get("role"),
             actions=body.get("actions"),
             by_actor=by_actor,
+            principal_type=principal_type if actor_id is not None else None,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
+    entry = await _enriched_grant(
+        datasette, roles, actor_id, group_id, actions, principal_type
+    )
     return Response.json({"ok": True, "grant": entry})
 
 
@@ -522,14 +552,15 @@ async def actors_json(request, datasette):
 async def revoke_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/revoke.
 
-    Body: ``{actor_id}`` or ``{group_id}``. Deletes all acl rows for that
-    principal on this resource, audits each removal, returns ``{ok: true}``.
+    Body: ``{actor_id}`` or ``{group_id}``, plus optional ``principal_type``.
+    Deletes all acl rows for that principal on this resource, audits each
+    removal, returns ``{ok: true}``.
     """
     try:
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id = _principal_from_body(body)
+        actor_id, group_id, principal_type = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         removed = await revoke(
             datasette,
@@ -539,6 +570,7 @@ async def revoke_json(request, datasette):
             actor_id=actor_id,
             group_id=group_id,
             by_actor=by_actor,
+            principal_type=principal_type if actor_id is not None else None,
         )
     except _ApiError as exc:
         return _error_response(exc)
@@ -550,14 +582,15 @@ async def revoke_json(request, datasette):
 async def update_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/update.
 
-    Body: ``{actor_id|group_id, role}``. Atomically swaps the principal's action
-    set to the new role, audits each change, and returns the enriched grant.
+    Body: ``{actor_id|group_id, role}``, plus optional ``principal_type``.
+    Atomically swaps the principal's action set to the new role, audits each
+    change, and returns the enriched grant.
     """
     try:
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id = _principal_from_body(body)
+        actor_id, group_id, principal_type = _principal_from_body(body)
         role = body.get("role")
         if not role:
             raise _ApiError(400, "update requires a role")
@@ -571,10 +604,13 @@ async def update_json(request, datasette):
             group_id=group_id,
             role=role,
             by_actor=by_actor,
+            principal_type=principal_type if actor_id is not None else None,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
+    entry = await _enriched_grant(
+        datasette, roles, actor_id, group_id, actions, principal_type
+    )
     return Response.json({"ok": True, "grant": entry})

--- a/datasette_acl/views/resource_acls.py
+++ b/datasette_acl/views/resource_acls.py
@@ -1,6 +1,7 @@
 from datasette import Response, Forbidden
 from datasette_acl.grants import _ensure_resource_id
 from datasette_acl.utils import (
+    PUBLIC_PRINCIPALS,
     actions_for_resource_type,
     can_manage,
     generate_changes_message,
@@ -59,6 +60,7 @@ async def manage_resource_acls(request, datasette):
 
     current_group_permissions = {}
     current_user_permissions = {}
+    current_public_permissions = {}
     acl_rows = await internal_db.execute(
         """
         select
@@ -80,7 +82,12 @@ async def manage_resource_acls(request, datasette):
             current_group_permissions.setdefault(group_name, {})[action_name] = True
         else:
             assert actor_id
-            current_user_permissions.setdefault(actor_id, {})[action_name] = True
+            if actor_id in PUBLIC_PRINCIPALS:
+                current_public_permissions.setdefault(actor_id, {})[
+                    action_name
+                ] = True
+            else:
+                current_user_permissions.setdefault(actor_id, {})[action_name] = True
 
     if request.method == "POST":
         group_changes_made = {"added": [], "removed": []}
@@ -161,10 +168,21 @@ async def manage_resource_acls(request, datasette):
                         },
                     )
         user_changes_made = {"added": [], "removed": []}
-        for actor_id in list(current_user_permissions) + [None]:
+        public_changes_made = {"added": [], "removed": []}
+        # Wildcard "general access" principals are stored as actor_id values, so
+        # they share the actor-grant write path below. Like groups, their selects
+        # are always present in the form, so unchecking removes the grant.
+        for actor_id in (
+            list(PUBLIC_PRINCIPALS) + list(current_user_permissions) + [None]
+        ):
             if actor_id is None:
                 actor_id = (post_vars.get("new_actor_id") or "").strip()
                 if not actor_id:
+                    continue
+                if actor_id in PUBLIC_PRINCIPALS:
+                    # The general-access selects are the canonical write path
+                    # for wildcards; this same request already processed them,
+                    # so a second pass would diff against stale state.
                     continue
                 if not await validate_actor_id(datasette, actor_id):
                     datasette.add_message(
@@ -172,16 +190,25 @@ async def manage_resource_acls(request, datasette):
                     )
                     return Response.redirect(request.path)
                 user_actions_key = "new_user_actions"
+            elif actor_id in PUBLIC_PRINCIPALS:
+                user_actions_key = f"public_permissions_{actor_id}"
             else:
                 user_actions_key = f"user_permissions_{actor_id}"
+
+            if actor_id in PUBLIC_PRINCIPALS:
+                current = current_public_permissions
+                changes_made = public_changes_made
+                display_name = PUBLIC_PRINCIPALS[actor_id]
+            else:
+                current = current_user_permissions
+                changes_made = user_changes_made
+                display_name = actor_id
 
             selected_user_actions = post_vars.getlist(user_actions_key)
 
             for action_name in actions:
                 new_value = action_name in selected_user_actions
-                current_value = bool(
-                    current_user_permissions.get(actor_id, {}).get(action_name)
-                )
+                current_value = bool(current.get(actor_id, {}).get(action_name))
                 if new_value != current_value:
                     if new_value:
                         await internal_db.execute_write(
@@ -201,7 +228,7 @@ async def manage_resource_acls(request, datasette):
                             },
                         )
                         operation = "added"
-                        user_changes_made["added"].append((actor_id, action_name))
+                        changes_made["added"].append((display_name, action_name))
                     else:
                         await internal_db.execute_write(
                             """
@@ -218,7 +245,7 @@ async def manage_resource_acls(request, datasette):
                             },
                         )
                         operation = "removed"
-                        user_changes_made["removed"].append((actor_id, action_name))
+                        changes_made["removed"].append((display_name, action_name))
                     await internal_db.execute_write(
                         """
                         insert into acl_audit (
@@ -246,10 +273,15 @@ async def manage_resource_acls(request, datasette):
                         },
                     )
 
-        if group_changes_made or user_changes_made:
+        if group_changes_made or public_changes_made or user_changes_made:
             group_message = generate_changes_message(group_changes_made, "group")
             if group_message:
                 datasette.add_message(request, group_message)
+            public_message = generate_changes_message(
+                public_changes_made, "general access"
+            )
+            if public_message:
+                datasette.add_message(request, public_message)
             user_message = generate_changes_message(user_changes_made, "user")
             if user_message:
                 datasette.add_message(request, user_message)
@@ -306,6 +338,8 @@ async def manage_resource_acls(request, datasette):
                 "group_sizes": group_sizes,
                 "group_permissions": current_group_permissions,
                 "user_permissions": current_user_permissions,
+                "public_principals": PUBLIC_PRINCIPALS,
+                "public_permissions": current_public_permissions,
                 "audit_log": audit_log.rows,
                 "valid_actors": await get_acl_valid_actors(datasette),
             },

--- a/datasette_acl/views/resource_acls.py
+++ b/datasette_acl/views/resource_acls.py
@@ -1,7 +1,7 @@
 from datasette import Response, Forbidden
 from datasette_acl.grants import _ensure_resource_id
 from datasette_acl.utils import (
-    PUBLIC_PRINCIPALS,
+    PUBLIC_PRINCIPAL_TYPES,
     actions_for_resource_type,
     can_manage,
     generate_changes_message,
@@ -77,12 +77,13 @@ async def manage_resource_acls(request, datasette):
     )
     for row in acl_rows.rows:
         action_name = row["action_name"]
-        if row["principal_type"] == "group":
+        principal_type = row["principal_type"]
+        if principal_type == "group":
             current_group_permissions.setdefault(row["group_name"], {})[
                 action_name
             ] = True
-        elif row["principal_type"] == "public":
-            current_public_permissions.setdefault(row["actor_id"], {})[
+        elif principal_type in PUBLIC_PRINCIPAL_TYPES:
+            current_public_permissions.setdefault(principal_type, {})[
                 action_name
             ] = True
         else:
@@ -171,50 +172,21 @@ async def manage_resource_acls(request, datasette):
                             "operation_by": request.actor["id"],
                         },
                     )
-        user_changes_made = {"added": [], "removed": []}
         public_changes_made = {"added": [], "removed": []}
-        # Wildcard "general access" principals are stored as actor_id values, so
-        # they share the actor-grant write path below. Like groups, their selects
-        # are always present in the form, so unchecking removes the grant.
-        for actor_id in (
-            list(PUBLIC_PRINCIPALS) + list(current_user_permissions) + [None]
-        ):
-            if actor_id is None:
-                actor_id = (post_vars.get("new_actor_id") or "").strip()
-                if not actor_id:
-                    continue
-                if actor_id in PUBLIC_PRINCIPALS:
-                    # The general-access selects are the canonical write path
-                    # for wildcards; this same request already processed them,
-                    # so a second pass would diff against stale state.
-                    continue
-                if not await validate_actor_id(datasette, actor_id):
-                    datasette.add_message(
-                        request, "That user ID is not valid", datasette.ERROR
-                    )
-                    return Response.redirect(request.path)
-                user_actions_key = "new_user_actions"
-            elif actor_id in PUBLIC_PRINCIPALS:
-                user_actions_key = f"public_permissions_{actor_id}"
-            else:
-                user_actions_key = f"user_permissions_{actor_id}"
-
-            if actor_id in PUBLIC_PRINCIPALS:
-                principal_type = "public"
-                current = current_public_permissions
-                changes_made = public_changes_made
-                display_name = PUBLIC_PRINCIPALS[actor_id]
-            else:
-                principal_type = "actor"
-                current = current_user_permissions
-                changes_made = user_changes_made
-                display_name = actor_id
-
-            selected_user_actions = post_vars.getlist(user_actions_key)
-
+        # Public audiences are identified by principal_type alone -- no id.
+        # Like groups, their selects are always present in the form, so
+        # unchecking removes the grant.
+        for principal_type, display_name in PUBLIC_PRINCIPAL_TYPES.items():
+            selected_public_actions = post_vars.getlist(
+                f"public_permissions_{principal_type}"
+            )
             for action_name in actions:
-                new_value = action_name in selected_user_actions
-                current_value = bool(current.get(actor_id, {}).get(action_name))
+                new_value = action_name in selected_public_actions
+                current_value = bool(
+                    current_public_permissions.get(principal_type, {}).get(
+                        action_name
+                    )
+                )
                 if new_value != current_value:
                     if new_value:
                         await internal_db.execute_write(
@@ -222,7 +194,7 @@ async def manage_resource_acls(request, datasette):
                             insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
                             values (
                                 :principal_type,
-                                :actor_id,
+                                null,
                                 null,
                                 :resource_id,
                                 (select id from acl_actions where name = :action_name)
@@ -230,34 +202,32 @@ async def manage_resource_acls(request, datasette):
                             """,
                             {
                                 "principal_type": principal_type,
-                                "actor_id": actor_id,
                                 "action_name": action_name,
                                 "resource_id": resource_id,
                             },
                         )
                         operation = "added"
-                        changes_made["added"].append((display_name, action_name))
+                        public_changes_made["added"].append(
+                            (display_name, action_name)
+                        )
                     else:
-                        # Delete on (principal_type, actor_id) so revoking the
-                        # '_signed_in' wildcard can never delete a like-named
-                        # user's grant, and vice versa.
                         await internal_db.execute_write(
                             """
                             delete from acl where
                                 principal_type = :principal_type
-                                and actor_id = :actor_id
                                 and resource_id = :resource_id
                                 and action_id = (select id from acl_actions where name = :action_name)
                             """,
                             {
                                 "principal_type": principal_type,
-                                "actor_id": actor_id,
                                 "action_name": action_name,
                                 "resource_id": resource_id,
                             },
                         )
                         operation = "removed"
-                        changes_made["removed"].append((display_name, action_name))
+                        public_changes_made["removed"].append(
+                            (display_name, action_name)
+                        )
                     await internal_db.execute_write(
                         """
                         insert into acl_audit (
@@ -271,7 +241,7 @@ async def manage_resource_acls(request, datasette):
                         ) values (
                             :operation,
                             :principal_type,
-                            :actor_id,
+                            null,
                             null,
                             :resource_id,
                             (SELECT id FROM acl_actions WHERE name = :action_name),
@@ -281,6 +251,93 @@ async def manage_resource_acls(request, datasette):
                         {
                             "operation": operation,
                             "principal_type": principal_type,
+                            "resource_id": resource_id,
+                            "action_name": action_name,
+                            "operation_by": request.actor["id"],
+                        },
+                    )
+        user_changes_made = {"added": [], "removed": []}
+        for actor_id in list(current_user_permissions) + [None]:
+            if actor_id is None:
+                actor_id = (post_vars.get("new_actor_id") or "").strip()
+                if not actor_id:
+                    continue
+                if not await validate_actor_id(datasette, actor_id):
+                    datasette.add_message(
+                        request, "That user ID is not valid", datasette.ERROR
+                    )
+                    return Response.redirect(request.path)
+                user_actions_key = "new_user_actions"
+            else:
+                user_actions_key = f"user_permissions_{actor_id}"
+
+            selected_user_actions = post_vars.getlist(user_actions_key)
+
+            for action_name in actions:
+                new_value = action_name in selected_user_actions
+                current_value = bool(
+                    current_user_permissions.get(actor_id, {}).get(action_name)
+                )
+                if new_value != current_value:
+                    if new_value:
+                        await internal_db.execute_write(
+                            """
+                            insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
+                            values (
+                                'actor',
+                                :actor_id,
+                                null,
+                                :resource_id,
+                                (select id from acl_actions where name = :action_name)
+                            )
+                            """,
+                            {
+                                "actor_id": actor_id,
+                                "action_name": action_name,
+                                "resource_id": resource_id,
+                            },
+                        )
+                        operation = "added"
+                        user_changes_made["added"].append((actor_id, action_name))
+                    else:
+                        await internal_db.execute_write(
+                            """
+                            delete from acl where
+                                principal_type = 'actor'
+                                and actor_id = :actor_id
+                                and resource_id = :resource_id
+                                and action_id = (select id from acl_actions where name = :action_name)
+                            """,
+                            {
+                                "actor_id": actor_id,
+                                "action_name": action_name,
+                                "resource_id": resource_id,
+                            },
+                        )
+                        operation = "removed"
+                        user_changes_made["removed"].append((actor_id, action_name))
+                    await internal_db.execute_write(
+                        """
+                        insert into acl_audit (
+                            operation,
+                            principal_type,
+                            actor_id,
+                            group_id,
+                            resource_id,
+                            action_id,
+                            operation_by
+                        ) values (
+                            :operation,
+                            'actor',
+                            :actor_id,
+                            null,
+                            :resource_id,
+                            (SELECT id FROM acl_actions WHERE name = :action_name),
+                            :operation_by
+                        )
+                        """,
+                        {
+                            "operation": operation,
                             "actor_id": actor_id,
                             "resource_id": resource_id,
                             "action_name": action_name,
@@ -354,7 +411,7 @@ async def manage_resource_acls(request, datasette):
                 "group_sizes": group_sizes,
                 "group_permissions": current_group_permissions,
                 "user_permissions": current_user_permissions,
-                "public_principals": PUBLIC_PRINCIPALS,
+                "public_principals": PUBLIC_PRINCIPAL_TYPES,
                 "public_permissions": current_public_permissions,
                 "audit_log": audit_log.rows,
                 "valid_actors": await get_acl_valid_actors(datasette),

--- a/datasette_acl/views/resource_acls.py
+++ b/datasette_acl/views/resource_acls.py
@@ -64,6 +64,7 @@ async def manage_resource_acls(request, datasette):
     acl_rows = await internal_db.execute(
         """
         select
+          acl.principal_type,
           acl_groups.name as group_name,
           acl.actor_id,
           acl_actions.name as action_name
@@ -75,19 +76,19 @@ async def manage_resource_acls(request, datasette):
         [resource_id],
     )
     for row in acl_rows.rows:
-        group_name = row["group_name"]
-        actor_id = row["actor_id"]
         action_name = row["action_name"]
-        if group_name:
-            current_group_permissions.setdefault(group_name, {})[action_name] = True
+        if row["principal_type"] == "group":
+            current_group_permissions.setdefault(row["group_name"], {})[
+                action_name
+            ] = True
+        elif row["principal_type"] == "public":
+            current_public_permissions.setdefault(row["actor_id"], {})[
+                action_name
+            ] = True
         else:
-            assert actor_id
-            if actor_id in PUBLIC_PRINCIPALS:
-                current_public_permissions.setdefault(actor_id, {})[
-                    action_name
-                ] = True
-            else:
-                current_user_permissions.setdefault(actor_id, {})[action_name] = True
+            current_user_permissions.setdefault(row["actor_id"], {})[
+                action_name
+            ] = True
 
     if request.method == "POST":
         group_changes_made = {"added": [], "removed": []}
@@ -108,8 +109,9 @@ async def manage_resource_acls(request, datasette):
                     if new_value:
                         await internal_db.execute_write(
                             """
-                            INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+                            INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
                             VALUES (
+                                'group',
                                 null,
                                 (SELECT id FROM acl_groups WHERE name = :group_name),
                                 :resource_id,
@@ -145,6 +147,7 @@ async def manage_resource_acls(request, datasette):
                         """
                         insert into acl_audit (
                             operation,
+                            principal_type,
                             actor_id,
                             group_id,
                             resource_id,
@@ -152,6 +155,7 @@ async def manage_resource_acls(request, datasette):
                             operation_by
                         ) values (
                             :operation,
+                            'group',
                             null,
                             (SELECT id FROM acl_groups WHERE name = :group_name),
                             :resource_id,
@@ -196,10 +200,12 @@ async def manage_resource_acls(request, datasette):
                 user_actions_key = f"user_permissions_{actor_id}"
 
             if actor_id in PUBLIC_PRINCIPALS:
+                principal_type = "public"
                 current = current_public_permissions
                 changes_made = public_changes_made
                 display_name = PUBLIC_PRINCIPALS[actor_id]
             else:
+                principal_type = "actor"
                 current = current_user_permissions
                 changes_made = user_changes_made
                 display_name = actor_id
@@ -213,8 +219,9 @@ async def manage_resource_acls(request, datasette):
                     if new_value:
                         await internal_db.execute_write(
                             """
-                            insert into acl (actor_id, group_id, resource_id, action_id)
+                            insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
                             values (
+                                :principal_type,
                                 :actor_id,
                                 null,
                                 :resource_id,
@@ -222,6 +229,7 @@ async def manage_resource_acls(request, datasette):
                             )
                             """,
                             {
+                                "principal_type": principal_type,
                                 "actor_id": actor_id,
                                 "action_name": action_name,
                                 "resource_id": resource_id,
@@ -230,15 +238,19 @@ async def manage_resource_acls(request, datasette):
                         operation = "added"
                         changes_made["added"].append((display_name, action_name))
                     else:
+                        # Delete on (principal_type, actor_id) so revoking the
+                        # '_signed_in' wildcard can never delete a like-named
+                        # user's grant, and vice versa.
                         await internal_db.execute_write(
                             """
                             delete from acl where
-                                actor_id = :actor_id
-                                and group_id is null
+                                principal_type = :principal_type
+                                and actor_id = :actor_id
                                 and resource_id = :resource_id
                                 and action_id = (select id from acl_actions where name = :action_name)
                             """,
                             {
+                                "principal_type": principal_type,
                                 "actor_id": actor_id,
                                 "action_name": action_name,
                                 "resource_id": resource_id,
@@ -250,6 +262,7 @@ async def manage_resource_acls(request, datasette):
                         """
                         insert into acl_audit (
                             operation,
+                            principal_type,
                             actor_id,
                             group_id,
                             resource_id,
@@ -257,6 +270,7 @@ async def manage_resource_acls(request, datasette):
                             operation_by
                         ) values (
                             :operation,
+                            :principal_type,
                             :actor_id,
                             null,
                             :resource_id,
@@ -266,6 +280,7 @@ async def manage_resource_acls(request, datasette):
                         """,
                         {
                             "operation": operation,
+                            "principal_type": principal_type,
                             "actor_id": actor_id,
                             "resource_id": resource_id,
                             "action_name": action_name,
@@ -294,6 +309,7 @@ async def manage_resource_acls(request, datasette):
             acl_audit.timestamp,
             acl_audit.operation_by,
             acl_audit.operation,
+            acl_audit.principal_type,
             acl_audit.actor_id,
             acl_groups.name as group_name,
             acl_actions.name as action_name

--- a/datasette_acl/views/table_acls.py
+++ b/datasette_acl/views/table_acls.py
@@ -50,6 +50,7 @@ async def manage_table_acls(request, datasette):
     acl_rows = await internal_db.execute(
         """
         select
+          acl.principal_type,
           acl_groups.name as group_name,
           acl.actor_id,
           acl_actions.name as action_name
@@ -61,15 +62,17 @@ async def manage_table_acls(request, datasette):
         [resource_id],
     )
     for row in acl_rows.rows:
-        group_name = row["group_name"]
-        actor_id = row["actor_id"]
         action_name = row["action_name"]
-        if group_name:
-            current_group_permissions.setdefault(group_name, {})[action_name] = True
-            current_group_permissions[group_name][action_name] = True
-        else:
-            assert actor_id
-            current_user_permissions.setdefault(actor_id, {})[action_name] = True
+        if row["principal_type"] == "group":
+            current_group_permissions.setdefault(row["group_name"], {})[
+                action_name
+            ] = True
+        elif row["principal_type"] == "actor":
+            current_user_permissions.setdefault(row["actor_id"], {})[
+                action_name
+            ] = True
+        # The legacy table page has no General-access section: 'public' rows
+        # (managed on the generic resource page) are not rendered as users.
 
     if request.method == "POST":
         group_changes_made = {"added": [], "removed": []}
@@ -91,8 +94,9 @@ async def manage_table_acls(request, datasette):
                         # They added it, add the record
                         await internal_db.execute_write(
                             """
-                            INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+                            INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
                             VALUES (
+                                'group',
                                 null,
                                 (SELECT id FROM acl_groups WHERE name = :group_name),
                                 :resource_id,
@@ -129,6 +133,7 @@ async def manage_table_acls(request, datasette):
                         """
                         insert into acl_audit (
                             operation,
+                            principal_type,
                             actor_id,
                             group_id,
                             resource_id,
@@ -136,6 +141,7 @@ async def manage_table_acls(request, datasette):
                             operation_by
                         ) values (
                             :operation,
+                            'group',
                             null,
                             (SELECT id FROM acl_groups WHERE name = :group_name),
                             :resource_id,
@@ -176,11 +182,13 @@ async def manage_table_acls(request, datasette):
                 )
                 if new_value != current_value:
                     if new_value:
-                        # They added the permission
+                        # They added the permission. The legacy table page only
+                        # manages real users, so the row is always 'actor'.
                         await internal_db.execute_write(
                             """
-                            insert into acl (actor_id, group_id, resource_id, action_id)
+                            insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
                             values (
+                                'actor',
                                 :actor_id,
                                 null,
                                 :resource_id,
@@ -196,12 +204,14 @@ async def manage_table_acls(request, datasette):
                         operation = "added"
                         user_changes_made["added"].append((actor_id, action_name))
                     else:
-                        # They removed the permission
+                        # They removed the permission. Constrained to 'actor'
+                        # rows so a wildcard grant with a colliding id is never
+                        # deleted from here.
                         await internal_db.execute_write(
                             """
                             delete from acl where
-                                actor_id = :actor_id
-                                and group_id is null
+                                principal_type = 'actor'
+                                and actor_id = :actor_id
                                 and resource_id = :resource_id
                                 and action_id = (select id from acl_actions where name = :action_name)
                             """,
@@ -217,6 +227,7 @@ async def manage_table_acls(request, datasette):
                         """
                         insert into acl_audit (
                             operation,
+                            principal_type,
                             actor_id,
                             group_id,
                             resource_id,
@@ -224,6 +235,7 @@ async def manage_table_acls(request, datasette):
                             operation_by
                         ) values (
                             :operation,
+                            'actor',
                             :actor_id,
                             null,
                             :resource_id,
@@ -256,6 +268,7 @@ async def manage_table_acls(request, datasette):
             acl_audit.timestamp,
             acl_audit.operation_by,
             acl_audit.operation,
+            acl_audit.principal_type,
             acl_audit.actor_id,
             acl_groups.name as group_name,
             acl_actions.name as action_name

--- a/datasette_acl/views/table_acls.py
+++ b/datasette_acl/views/table_acls.py
@@ -1,7 +1,7 @@
 from datasette import Response, Forbidden
 from datasette.utils import MultiParams
 from datasette_acl.utils import (
-    PUBLIC_PRINCIPALS,
+    PUBLIC_PRINCIPAL_TYPES,
     actions_for_resource_type,
     can_edit_permissions,
     generate_changes_message,
@@ -72,8 +72,8 @@ async def manage_table_acls(request, datasette):
             current_user_permissions.setdefault(row["actor_id"], {})[
                 action_name
             ] = True
-        # The legacy table page has no General-access section: 'public' rows
-        # (managed on the generic resource page) are not rendered as users.
+        # The legacy table page has no General-access section: public-audience
+        # rows (managed on the generic resource page) are not rendered as users.
 
     if request.method == "POST":
         group_changes_made = {"added": [], "removed": []}
@@ -314,7 +314,7 @@ async def manage_table_acls(request, datasette):
                 "group_sizes": group_sizes,
                 "group_permissions": current_group_permissions,
                 "user_permissions": current_user_permissions,
-                "public_principals": PUBLIC_PRINCIPALS,
+                "public_principals": PUBLIC_PRINCIPAL_TYPES,
                 "audit_log": audit_log.rows,
                 "valid_actors": await get_acl_valid_actors(datasette),
             },

--- a/datasette_acl/views/table_acls.py
+++ b/datasette_acl/views/table_acls.py
@@ -1,6 +1,7 @@
 from datasette import Response, Forbidden
 from datasette.utils import MultiParams
 from datasette_acl.utils import (
+    PUBLIC_PRINCIPALS,
     actions_for_resource_type,
     can_edit_permissions,
     generate_changes_message,
@@ -313,6 +314,7 @@ async def manage_table_acls(request, datasette):
                 "group_sizes": group_sizes,
                 "group_permissions": current_group_permissions,
                 "user_permissions": current_user_permissions,
+                "public_principals": PUBLIC_PRINCIPALS,
                 "audit_log": audit_log.rows,
                 "valid_actors": await get_acl_valid_actors(datasette),
             },

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -52,38 +52,29 @@ that contain reserved characters.
 
 ### Principals
 
-A grant attaches a set of actions on a resource to exactly **one** principal:
+A grant attaches a set of actions on a resource to exactly **one** principal,
+which takes one of three forms in a mutation body:
 
 - **Actor** — identified by a string `actor_id` (e.g. `"alice"`).
 - **Group** — identified by an integer `group_id` (the `acl_groups.id`).
+- **Public audience** — a *class* of caller rather than a specific person,
+  named by `principal_type` with **neither** id:
 
-Every mutating request must supply **exactly one** of `actor_id` / `group_id`.
-Supplying neither or both is a `400` error.
+| `principal_type` | Matches                                       |
+| ---------------- | --------------------------------------------- |
+| `everyone`       | Literally everyone, including anonymous users |
+| `authenticated`  | Any signed-in actor (has an `id`)             |
+| `anonymous`      | Only unauthenticated callers                  |
 
-**Wildcard / "public" principals.** Three reserved `actor_id` values represent
-classes of caller rather than a specific person:
+Supplying none of these forms — or more than one — is a `400` error.
+(`principal_type` may also redundantly name `"actor"` / `"group"` alongside
+the matching id.)
 
-| `actor_id`    | Matches                                       |
-| ------------- | --------------------------------------------- |
-| `*`           | Literally everyone, including anonymous users |
-| `_signed_in`  | Any authenticated actor (has an `id`)         |
-| `_anonymous`  | Only unauthenticated callers                  |
-
-These are stored with an explicit `principal_type` of `public` (distinct from
-ordinary `actor` grants), are flagged `"kind": "public"` in responses, and are
-never run through actor enrichment (no display name / email / avatar).
-
-**`principal_type`** (optional body field, mutations only). When an `actor_id`
-is supplied, the stored principal type is normally inferred: a wildcard id is
-stored as `public`, anything else as `actor`. Pass
-`"principal_type": "actor"` to override the inference and grant to a real user
-whose id collides with a wildcard (e.g. a user literally named `_signed_in`),
-or `"principal_type": "public"` to assert the id must be a wildcard (a
-non-wildcard id is then a `400`). The two row shapes are independent: granting,
-updating or revoking one never affects the other, and enforcement matches on
-the `(principal_type, id)` pair — a signed-in caller whose actor id is
-literally `_anonymous` only ever matches an explicit `actor` grant, never the
-anonymous wildcard.
+Audience grants store no id at all, so there is no reserved actor-id
+namespace: enforcement matches audiences on `principal_type` alone and actors
+on their literal id, and an actor named e.g. `_signed_in` is just an ordinary
+actor. In responses audiences are flagged `"kind": "public"` and are never run
+through actor enrichment (their `display_name` is the fixed UI label).
 
 ### Roles vs. actions
 
@@ -120,11 +111,10 @@ Read and mutation responses describe a principal's grant with the same shape.
 
 - `actions` is always sorted.
 - `role` is the resolved role name, or `null` if no role matches.
-- `kind` is `"public"` for wildcard principals; otherwise it is taken from the
-  actor-resolution layer (`actors_from_ids`, e.g. `"user"`, `"agent"`),
-  defaulting to `"user"`.
+- `kind` is taken from the actor-resolution layer (`actors_from_ids`, e.g.
+  `"user"`, `"agent"`), defaulting to `"user"`.
 - `display_name`, `email`, `avatar_url` are present only when the actor-
-  resolution layer supplies them (so wildcard and unknown actors omit them).
+  resolution layer supplies them (so unknown actors omit them).
 
 **Group entry:**
 
@@ -145,23 +135,22 @@ Read and mutation responses describe a principal's grant with the same shape.
 - `display_name` is the group name; `member_count` is the number of actors in
   the group.
 
-**Public (wildcard) entry:**
+**Public (audience) entry:**
 
 ```json
 {
-  "principal": "actor",
-  "id": "_signed_in",
+  "principal": "public",
+  "id": "authenticated",
   "role": "Viewer",
   "actions": ["doc-view"],
-  "kind": "public"
+  "kind": "public",
+  "display_name": "Any signed-in user"
 }
 ```
 
-- Note the `principal` field stays `"actor"` for wildcard grants — that is the
-  client contract; distinguish wildcards by `kind: "public"`. (The stored row
-  is `principal_type = 'public'`; only the JSON rendering folds it into
-  `actor`.)
-- Wildcards are never enriched: no `display_name` / `email` / `avatar_url`.
+- `id` echoes the audience's `principal_type` (audiences have no stored id).
+- `display_name` is the fixed UI label; audiences are never enriched (no
+  `email` / `avatar_url`).
 
 ---
 
@@ -326,11 +315,11 @@ principal's full action-set after the grant.
 
 | Field      | Type            | Notes                                                |
 | ---------- | --------------- | ---------------------------------------------------- |
-| `actor_id` | string          | Supply this **or** `group_id`, not both.             |
-| `group_id` | integer         | Supply this **or** `actor_id`, not both.             |
+| `actor_id` | string          | An individual actor. One principal form of three.    |
+| `group_id` | integer         | A group. One principal form of three.                |
+| `principal_type` | string    | A public audience: `"everyone"` / `"authenticated"` / `"anonymous"`, with neither id (see [Principals](#principals)). |
 | `role`     | string          | A role name for this resource type. Expands to its actions. Supply this **or** `actions`. |
 | `actions`  | array of string | Raw action names. Supply this **or** `role`.         |
-| `principal_type` | string    | Optional, with `actor_id` only: `"actor"` or `"public"` (see [Principals](#principals)). Absent → inferred. |
 
 ```json
 { "actor_id": "bob", "role": "Editor" }
@@ -379,10 +368,10 @@ audited. Returns the enriched grant.
 
 | Field      | Type    | Notes                                    |
 | ---------- | ------- | ---------------------------------------- |
-| `actor_id` | string  | Supply this **or** `group_id`.           |
-| `group_id` | integer | Supply this **or** `actor_id`.           |
+| `actor_id` | string  | An individual actor. One principal form of three. |
+| `group_id` | integer | A group. One principal form of three.    |
+| `principal_type` | string | A public audience, with neither id (see [Principals](#principals)). |
 | `role`     | string  | Required. The role to swap the principal to. |
-| `principal_type` | string | Optional, with `actor_id` only: `"actor"` or `"public"`. Absent → inferred. |
 
 ```json
 { "actor_id": "bob", "role": "Viewer" }
@@ -412,9 +401,9 @@ Removes **all** grants for a principal on the resource. Each removal is audited
 
 | Field      | Type    | Notes                          |
 | ---------- | ------- | ------------------------------ |
-| `actor_id` | string  | Supply this **or** `group_id`. |
-| `group_id` | integer | Supply this **or** `actor_id`. |
-| `principal_type` | string | Optional, with `actor_id` only: `"actor"` or `"public"`. Absent → inferred, so revoking `"*"` removes the wildcard grant, never a like-named user's. |
+| `actor_id` | string  | An individual actor. One principal form of three. |
+| `group_id` | integer | A group. One principal form of three. |
+| `principal_type` | string | A public audience, with neither id (see [Principals](#principals)). |
 
 ```json
 { "actor_id": "bob" }
@@ -552,17 +541,18 @@ curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \
   -d '{"group_id": 7, "actions": ["doc-view"]}'
 ```
 
-Make the document public to signed-in users — the wildcard `actor_id` is
-stored as a `public` grant (no `principal_type` needed; it is inferred):
+Make the document public to signed-in users — the `authenticated` audience is
+named by `principal_type`, with no id:
 
 ```bash
 curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \
   -H 'Cookie: ds_actor=...' \
   -H 'Content-Type: application/json' \
-  -d '{"actor_id": "_signed_in", "role": "Viewer"}'
-# -> {"ok": true, "grant": {"principal":"actor","id":"_signed_in",
+  -d '{"principal_type": "authenticated", "role": "Viewer"}'
+# -> {"ok": true, "grant": {"principal":"public","id":"authenticated",
 #                           "role":"Viewer","actions":["doc-view"],
-#                           "kind":"public"}}
+#                           "kind":"public",
+#                           "display_name":"Any signed-in user"}}
 ```
 
 Revoke `bob` entirely:

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -80,7 +80,10 @@ stored as `public`, anything else as `actor`. Pass
 whose id collides with a wildcard (e.g. a user literally named `_signed_in`),
 or `"principal_type": "public"` to assert the id must be a wildcard (a
 non-wildcard id is then a `400`). The two row shapes are independent: granting,
-updating or revoking one never affects the other.
+updating or revoking one never affects the other, and enforcement matches on
+the `(principal_type, id)` pair — a signed-in caller whose actor id is
+literally `_anonymous` only ever matches an explicit `actor` grant, never the
+anonymous wildcard.
 
 ### Roles vs. actions
 
@@ -141,6 +144,24 @@ Read and mutation responses describe a principal's grant with the same shape.
 - `kind` is always `"group"`.
 - `display_name` is the group name; `member_count` is the number of actors in
   the group.
+
+**Public (wildcard) entry:**
+
+```json
+{
+  "principal": "actor",
+  "id": "_signed_in",
+  "role": "Viewer",
+  "actions": ["doc-view"],
+  "kind": "public"
+}
+```
+
+- Note the `principal` field stays `"actor"` for wildcard grants — that is the
+  client contract; distinguish wildcards by `kind: "public"`. (The stored row
+  is `principal_type = 'public'`; only the JSON rendering folds it into
+  `actor`.)
+- Wildcards are never enriched: no `display_name` / `email` / `avatar_url`.
 
 ---
 
@@ -531,13 +552,17 @@ curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \
   -d '{"group_id": 7, "actions": ["doc-view"]}'
 ```
 
-Make the document public to signed-in users:
+Make the document public to signed-in users — the wildcard `actor_id` is
+stored as a `public` grant (no `principal_type` needed; it is inferred):
 
 ```bash
 curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \
   -H 'Cookie: ds_actor=...' \
   -H 'Content-Type: application/json' \
   -d '{"actor_id": "_signed_in", "role": "Viewer"}'
+# -> {"ok": true, "grant": {"principal":"actor","id":"_signed_in",
+#                           "role":"Viewer","actions":["doc-view"],
+#                           "kind":"public"}}
 ```
 
 Revoke `bob` entirely:

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -69,9 +69,18 @@ classes of caller rather than a specific person:
 | `_signed_in`  | Any authenticated actor (has an `id`)         |
 | `_anonymous`  | Only unauthenticated callers                  |
 
-These are stored as ordinary actor grants but are flagged `"kind": "public"` in
-responses and are never run through actor enrichment (no display name / email /
-avatar).
+These are stored with an explicit `principal_type` of `public` (distinct from
+ordinary `actor` grants), are flagged `"kind": "public"` in responses, and are
+never run through actor enrichment (no display name / email / avatar).
+
+**`principal_type`** (optional body field, mutations only). When an `actor_id`
+is supplied, the stored principal type is normally inferred: a wildcard id is
+stored as `public`, anything else as `actor`. Pass
+`"principal_type": "actor"` to override the inference and grant to a real user
+whose id collides with a wildcard (e.g. a user literally named `_signed_in`),
+or `"principal_type": "public"` to assert the id must be a wildcard (a
+non-wildcard id is then a `400`). The two row shapes are independent: granting,
+updating or revoking one never affects the other.
 
 ### Roles vs. actions
 
@@ -300,6 +309,7 @@ principal's full action-set after the grant.
 | `group_id` | integer         | Supply this **or** `actor_id`, not both.             |
 | `role`     | string          | A role name for this resource type. Expands to its actions. Supply this **or** `actions`. |
 | `actions`  | array of string | Raw action names. Supply this **or** `role`.         |
+| `principal_type` | string    | Optional, with `actor_id` only: `"actor"` or `"public"` (see [Principals](#principals)). Absent → inferred. |
 
 ```json
 { "actor_id": "bob", "role": "Editor" }
@@ -351,6 +361,7 @@ audited. Returns the enriched grant.
 | `actor_id` | string  | Supply this **or** `group_id`.           |
 | `group_id` | integer | Supply this **or** `actor_id`.           |
 | `role`     | string  | Required. The role to swap the principal to. |
+| `principal_type` | string | Optional, with `actor_id` only: `"actor"` or `"public"`. Absent → inferred. |
 
 ```json
 { "actor_id": "bob", "role": "Viewer" }
@@ -382,6 +393,7 @@ Removes **all** grants for a principal on the resource. Each removal is audited
 | ---------- | ------- | ------------------------------ |
 | `actor_id` | string  | Supply this **or** `group_id`. |
 | `group_id` | integer | Supply this **or** `actor_id`. |
+| `principal_type` | string | Optional, with `actor_id` only: `"actor"` or `"public"`. Absent → inferred, so revoking `"*"` removes the wildcard grant, never a like-named user's. |
 
 ```json
 { "actor_id": "bob" }

--- a/tests/sample-plugin/templates/widget.html
+++ b/tests/sample-plugin/templates/widget.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}Widget: {{ widget.name }}{% endblock %}
+
+{% block content %}
+<p><a href="{{ urls.path("/-/widgets") }}">&larr; All widgets</a></p>
+
+<h1>{{ widget.name }}</h1>
+
+<p>
+  Created by {{ widget.creator_name }} on {{ widget.created_at }}.
+  Your role: <strong>{{ role }}</strong>
+</p>
+
+{% if can_edit %}
+  <form action="{{ request.path }}" method="post" style="margin-bottom: 1em">
+    <input data-1p-ignore name="name" value="{{ widget.name }}" required>
+    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+    <input type="submit" value="Rename" class="core">
+  </form>
+{% endif %}
+
+{% if can_manage %}
+  <p><a href="{{ acl_url }}">Manage permissions</a> — share this widget with
+  other actors, groups, or expose it via General access.</p>
+{% endif %}
+{% endblock %}

--- a/tests/sample-plugin/templates/widgets_index.html
+++ b/tests/sample-plugin/templates/widgets_index.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Widgets{% endblock %}
+
+{% block content %}
+<h1>Widgets</h1>
+
+{% if signed_in %}
+  <form action="{{ urls.path("/-/widgets") }}" method="post" style="margin-bottom: 1.5em">
+    <input data-1p-ignore name="name" placeholder="Widget name" required>
+    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+    <input type="submit" value="Create widget" class="core">
+  </form>
+{% else %}
+  <p>Sign in (pick a character from the actor switcher) to create widgets.</p>
+{% endif %}
+
+{% if widgets %}
+  <table>
+    <thead>
+      <tr><th>Widget</th><th>Created by</th><th>Your role</th></tr>
+    </thead>
+    <tbody>
+      {% for widget in widgets %}
+        <tr>
+          <td><a href="{{ urls.path("/-/widgets/" + widget.id|string) }}">{{ widget.name }}</a></td>
+          <td>{{ widget.creator_name }}</td>
+          <td>{{ widget.role }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% else %}
+  <p>No widgets are visible to you yet.</p>
+{% endif %}
+{% endblock %}

--- a/tests/sample-plugin/widgets.py
+++ b/tests/sample-plugin/widgets.py
@@ -1,0 +1,306 @@
+"""A throwaway sample plugin for exercising datasette-acl end-to-end.
+
+Loaded via ``--plugins-dir tests/sample-plugin`` from ``just dev`` (NOT a
+packaged plugin — it is dev/demo scaffolding only). It implements a minimal
+"widgets" feature the way a real consumer plugin would:
+
+- A ``widgets`` table in the internal database. Any signed-in actor can create
+  widgets from ``/-/widgets``.
+- An acl resource type ``widget`` (parent ``widgets``, child = the widget id,
+  mirroring e.g. datasette-apps' ``app``/``apps`` shape) with actions
+  ``widget-view`` / ``widget-edit`` / ``widget-manage``.
+- The canonical Viewer / Editor / Manager triple declared via acl's
+  ``standard_roles()`` factory.
+- The creator is granted the Manager role on their widget, so they "own" it:
+  they can rename it, and — because Manager carries ``manage=True`` — acl's
+  ``can_manage`` gate lets them open the admin page at
+  ``/-/acl/resource/widget/widgets/<id>`` to share it with other actors,
+  groups, or the General access wildcards, without holding the global
+  ``datasette-acl`` permission.
+
+Pair with datasette-debug-gotham: its actor switcher signs you in as Clark,
+Bruce, etc., and its cast feeds the admin page's user picker via the
+``datasette_acl_valid_actors`` hook below. The gotham actors carry a
+``newsroom`` attribute, which the ``dynamic-groups`` config in the Justfile
+turns into daily-planet / gotham-gazette groups for group-grant demos.
+"""
+
+from datasette import hookimpl, Forbidden, Response
+from datasette.permissions import Action, Resource
+
+from datasette_acl.grants import grant
+from datasette_acl.roles import role_for_actions, roles_for, standard_roles
+
+# datasette-debug-gotham's demo actors (Clark Kent, Bruce Wayne, …). Imported
+# softly so this plugin still loads without gotham — the picker just goes
+# empty and creators show as raw ids.
+try:
+    from datasette_debug_gotham import ACTORS as GOTHAM_ACTORS
+except Exception:  # pragma: no cover - depends on dev env
+    GOTHAM_ACTORS = {}
+
+WIDGETS_PARENT = "widgets"
+
+
+# --- the resource type -------------------------------------------------------
+
+
+class WidgetsResource(Resource):
+    """The parent container — exists so WidgetResource is a two-level type.
+
+    acl's ``build_resource`` builds two-level types as ``rc(parent, child)``,
+    which is what makes the ``/-/acl/resource/widget/widgets/<id>`` admin URL
+    resolve.
+    """
+
+    name = "widgets"
+    parent_class = None
+
+    def __init__(self):
+        super().__init__(parent=WIDGETS_PARENT, child=None)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return f"SELECT '{WIDGETS_PARENT}' AS parent, NULL AS child"
+
+
+class WidgetResource(Resource):
+    name = "widget"
+    parent_class = WidgetsResource
+
+    def __init__(self, parent=None, child=None):
+        # Accept both the ergonomic WidgetResource(widget_id) and acl's
+        # positional build_resource convention WidgetResource("widgets", id).
+        if child is None:
+            child = parent
+        super().__init__(
+            parent=WIDGETS_PARENT, child=str(child) if child is not None else None
+        )
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        # acl stores resource ids as text; CAST so `child IS :child` matches.
+        return (
+            f"SELECT '{WIDGETS_PARENT}' AS parent, "
+            "CAST(id AS TEXT) AS child FROM widgets"
+        )
+
+
+# --- acl hooks ---------------------------------------------------------------
+
+
+@hookimpl
+def register_actions(datasette):
+    return [
+        Action(
+            name="widget-view",
+            description="View a widget",
+            resource_class=WidgetResource,
+        ),
+        Action(
+            name="widget-edit",
+            description="Edit a widget",
+            resource_class=WidgetResource,
+        ),
+        Action(
+            name="widget-manage",
+            description="Manage sharing for a widget",
+            resource_class=WidgetResource,
+        ),
+    ]
+
+
+@hookimpl
+def datasette_acl_roles(datasette):
+    return standard_roles(
+        "widget",
+        view="widget-view",
+        edit="widget-edit",
+        manage="widget-manage",
+        descriptions={"Manager": "Full control, including sharing"},
+    )
+
+
+@hookimpl
+def datasette_acl_valid_actors(datasette):
+    """Feed the gotham cast into the admin page's "Other user" picker."""
+    return [
+        {"id": actor_id, "display": info.get("name", actor_id)}
+        for actor_id, info in GOTHAM_ACTORS.items()
+    ]
+
+
+# --- storage -----------------------------------------------------------------
+
+
+@hookimpl
+def startup(datasette):
+    async def inner():
+        db = datasette.get_internal_database()
+        await db.execute_write(
+            """
+            CREATE TABLE IF NOT EXISTS widgets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                created_by TEXT NOT NULL,
+                created_at TEXT NOT NULL
+                    DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )
+            """
+        )
+
+    return inner
+
+
+def _creator_name(actor_id):
+    return GOTHAM_ACTORS.get(actor_id, {}).get("name", actor_id)
+
+
+async def _role_name(datasette, widget_id, actor):
+    """The actor's highest role on a widget, or None when they have no access.
+
+    Resolved the same way acl does it: collect the actions the actor is
+    ``allowed`` on this resource, then map that set to the best-fit role.
+    """
+    roles = roles_for(datasette, "widget")
+    resource = WidgetResource(widget_id)
+    granted = set()
+    for action in {a for role in roles for a in role.actions}:
+        if await datasette.allowed(action=action, resource=resource, actor=actor):
+            granted.add(action)
+    role = role_for_actions(roles, granted)
+    return role.name if role else None
+
+
+# --- pages -------------------------------------------------------------------
+
+
+async def widgets_index(request, datasette):
+    db = datasette.get_internal_database()
+
+    if request.method == "POST":
+        actor_id = (request.actor or {}).get("id")
+        if not actor_id:
+            raise Forbidden("Sign in to create widgets")
+        post_vars = await request.post_vars()
+        name = (post_vars.get("name") or "").strip()
+        if not name:
+            datasette.add_message(request, "A widget needs a name", datasette.ERROR)
+            return Response.redirect(request.path)
+        widget_id = await db.execute_write_fn(
+            lambda conn: conn.execute(
+                "INSERT INTO widgets (name, created_by) VALUES (?, ?)",
+                [name, actor_id],
+            ).lastrowid
+        )
+        # The creator owns their widget: a Manager grant gives them
+        # view + edit + manage, and manage authorizes re-sharing from the
+        # /-/acl/resource/widget/widgets/<id> admin page.
+        await grant(
+            datasette,
+            "widget",
+            WIDGETS_PARENT,
+            str(widget_id),
+            actor_id=actor_id,
+            role="Manager",
+            by_actor=actor_id,
+        )
+        datasette.add_message(
+            request, f"Widget '{name}' created — you are its Manager"
+        )
+        return Response.redirect(datasette.urls.path(f"/-/widgets/{widget_id}"))
+
+    # Only list widgets the current actor may view, tagged with their role —
+    # Viewer already implies widget-view, so a non-None role is the view gate.
+    widgets = []
+    rows = await db.execute("SELECT * FROM widgets ORDER BY id")
+    for row in rows.rows:
+        role = await _role_name(datasette, row["id"], request.actor)
+        if role is None:
+            continue
+        widgets.append(
+            {
+                **dict(row),
+                "creator_name": _creator_name(row["created_by"]),
+                "role": role,
+            }
+        )
+    return Response.html(
+        await datasette.render_template(
+            "widgets_index.html",
+            {"widgets": widgets, "signed_in": bool(request.actor)},
+            request=request,
+        )
+    )
+
+
+async def widget_page(request, datasette):
+    db = datasette.get_internal_database()
+    widget_id = request.url_vars["id"]
+    row = (
+        await db.execute("SELECT * FROM widgets WHERE id = ?", [widget_id])
+    ).first()
+    if row is None:
+        return Response.html("Widget not found", status=404)
+
+    resource = WidgetResource(widget_id)
+    if not await datasette.allowed(
+        action="widget-view", resource=resource, actor=request.actor
+    ):
+        raise Forbidden("You don't have access to this widget")
+    can_edit = await datasette.allowed(
+        action="widget-edit", resource=resource, actor=request.actor
+    )
+    can_manage = await datasette.allowed(
+        action="widget-manage", resource=resource, actor=request.actor
+    )
+
+    if request.method == "POST":
+        if not can_edit:
+            raise Forbidden("You cannot edit this widget")
+        post_vars = await request.post_vars()
+        name = (post_vars.get("name") or "").strip()
+        if name:
+            await db.execute_write(
+                "UPDATE widgets SET name = ? WHERE id = ?", [name, widget_id]
+            )
+            datasette.add_message(request, f"Renamed to '{name}'")
+        return Response.redirect(request.path)
+
+    return Response.html(
+        await datasette.render_template(
+            "widget.html",
+            {
+                "widget": {
+                    **dict(row),
+                    "creator_name": _creator_name(row["created_by"]),
+                },
+                "role": await _role_name(datasette, widget_id, request.actor),
+                "can_edit": can_edit,
+                "can_manage": can_manage,
+                "acl_url": datasette.urls.path(
+                    f"/-/acl/resource/widget/{WIDGETS_PARENT}/{widget_id}"
+                ),
+            },
+            request=request,
+        )
+    )
+
+
+@hookimpl
+def register_routes():
+    return [
+        (r"^/-/widgets$", widgets_index),
+        (r"^/-/widgets/(?P<id>[0-9]+)$", widget_page),
+    ]
+
+
+@hookimpl
+def homepage_actions(datasette, actor, request):
+    return [
+        {
+            "href": datasette.urls.path("/-/widgets"),
+            "label": "Widgets",
+            "description": "Sample widgets for exercising acl sharing",
+        }
+    ]

--- a/tests/sample-plugin/widgets.py
+++ b/tests/sample-plugin/widgets.py
@@ -15,7 +15,7 @@ packaged plugin — it is dev/demo scaffolding only). It implements a minimal
   they can rename it, and — because Manager carries ``manage=True`` — acl's
   ``can_manage`` gate lets them open the admin page at
   ``/-/acl/resource/widget/widgets/<id>`` to share it with other actors,
-  groups, or the General access wildcards, without holding the global
+  groups, or the General access audiences, without holding the global
   ``datasette-acl`` permission.
 
 Pair with datasette-debug-gotham: its actor switcher signs you in as Clark,

--- a/tests/sample-plugin/widgets.py
+++ b/tests/sample-plugin/widgets.py
@@ -28,7 +28,7 @@ turns into daily-planet / gotham-gazette groups for group-grant demos.
 from datasette import hookimpl, Forbidden, Response
 from datasette.permissions import Action, Resource
 
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import role_for_actions, roles_for, standard_roles
 
 # datasette-debug-gotham's demo actors (Clark Kent, Bruce Wayne, …). Imported
@@ -201,7 +201,7 @@ async def widgets_index(request, datasette):
             "widget",
             WIDGETS_PARENT,
             str(widget_id),
-            actor_id=actor_id,
+            principal=Principal.actor(actor_id),
             role="Manager",
             by_actor=actor_id,
         )

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -216,51 +216,41 @@ async def test_grant_group(api_ds):
 
 
 @pytest.mark.asyncio
-async def test_grant_wildcard_principal(api_ds):
+async def test_grant_public_audience(api_ds):
+    # A public audience is granted by principal_type alone -- no actor_id --
+    # and stored with no id.
     response = await _post(
         api_ds,
         GRANT_URL,
-        json={"actor_id": "_signed_in", "role": "Viewer"},
+        json={"principal_type": "authenticated", "role": "Viewer"},
         cookies=_root_cookie(api_ds),
     )
     data = response.json()
-    assert data["grant"]["id"] == "_signed_in"
+    assert data["grant"]["principal"] == "public"
+    assert data["grant"]["id"] == "authenticated"
     assert data["grant"]["kind"] == "public"
-    assert "display_name" not in data["grant"]
-
-
-@pytest.mark.asyncio
-async def test_grant_wildcard_without_principal_type_stores_public(api_ds):
-    # Back-compat: a body with just {"actor_id": "*"} (no principal_type, the
-    # pre-principal_type client contract) stores a 'public' row and the
-    # response kind is unchanged.
-    response = await _post(
-        api_ds,
-        GRANT_URL,
-        json={"actor_id": "*", "role": "Viewer"},
-        cookies=_root_cookie(api_ds),
-    )
-    assert response.status_code == 200
-    assert response.json()["grant"]["kind"] == "public"
+    assert data["grant"]["display_name"] == "Any signed-in user"
     rows = [
         dict(r)
         for r in (
             await api_ds.get_internal_database().execute(
-                "select principal_type, actor_id from acl"
+                "select principal_type, actor_id, group_id from acl"
             )
         ).rows
     ]
-    assert rows == [{"principal_type": "public", "actor_id": "*"}]
+    assert rows == [
+        {"principal_type": "authenticated", "actor_id": None, "group_id": None}
+    ]
 
 
 @pytest.mark.asyncio
-async def test_grant_explicit_principal_type_actor(api_ds):
-    # principal_type: "actor" pins a wildcard-named id to a real user: the
-    # stored row is 'actor' and the response kind is user, not public.
+async def test_grant_actor_with_audience_looking_id(api_ds):
+    # An actor id that merely looks like a legacy wildcard is an ordinary
+    # actor grant: the stored row is 'actor' and the response kind is user.
     response = await _post(
         api_ds,
         GRANT_URL,
-        json={"actor_id": "_signed_in", "role": "Viewer", "principal_type": "actor"},
+        json={"actor_id": "_signed_in", "role": "Viewer"},
         cookies=_root_cookie(api_ds),
     )
     assert response.status_code == 200
@@ -279,9 +269,11 @@ async def test_grant_explicit_principal_type_actor(api_ds):
 @pytest.mark.asyncio
 async def test_grant_invalid_principal_type_is_400(api_ds):
     for body in (
-        {"actor_id": "bob", "role": "Viewer", "principal_type": "public"},
+        {"actor_id": "bob", "role": "Viewer", "principal_type": "everyone"},
         {"actor_id": "bob", "role": "Viewer", "principal_type": "group"},
         {"actor_id": "bob", "role": "Viewer", "principal_type": "alien"},
+        {"role": "Viewer", "principal_type": "alien"},
+        {"group_id": 1, "role": "Viewer", "principal_type": "anonymous"},
     ):
         response = await _post(
             api_ds, GRANT_URL, json=body, cookies=_root_cookie(api_ds)

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -230,6 +230,67 @@ async def test_grant_wildcard_principal(api_ds):
 
 
 @pytest.mark.asyncio
+async def test_grant_wildcard_without_principal_type_stores_public(api_ds):
+    # Back-compat: a body with just {"actor_id": "*"} (no principal_type, the
+    # pre-principal_type client contract) stores a 'public' row and the
+    # response kind is unchanged.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "*", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    assert response.json()["grant"]["kind"] == "public"
+    rows = [
+        dict(r)
+        for r in (
+            await api_ds.get_internal_database().execute(
+                "select principal_type, actor_id from acl"
+            )
+        ).rows
+    ]
+    assert rows == [{"principal_type": "public", "actor_id": "*"}]
+
+
+@pytest.mark.asyncio
+async def test_grant_explicit_principal_type_actor(api_ds):
+    # principal_type: "actor" pins a wildcard-named id to a real user: the
+    # stored row is 'actor' and the response kind is user, not public.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"actor_id": "_signed_in", "role": "Viewer", "principal_type": "actor"},
+        cookies=_root_cookie(api_ds),
+    )
+    assert response.status_code == 200
+    assert response.json()["grant"]["kind"] == "user"
+    rows = [
+        dict(r)
+        for r in (
+            await api_ds.get_internal_database().execute(
+                "select principal_type, actor_id from acl"
+            )
+        ).rows
+    ]
+    assert rows == [{"principal_type": "actor", "actor_id": "_signed_in"}]
+
+
+@pytest.mark.asyncio
+async def test_grant_invalid_principal_type_is_400(api_ds):
+    for body in (
+        {"actor_id": "bob", "role": "Viewer", "principal_type": "public"},
+        {"actor_id": "bob", "role": "Viewer", "principal_type": "group"},
+        {"actor_id": "bob", "role": "Viewer", "principal_type": "alien"},
+    ):
+        response = await _post(
+            api_ds, GRANT_URL, json=body, cookies=_root_cookie(api_ds)
+        )
+        assert response.status_code == 400, body
+        assert response.json()["ok"] is False
+
+
+@pytest.mark.asyncio
 async def test_update_swaps_role(api_ds):
     await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
     response = await _post(

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -15,7 +15,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant, list_grants
+from datasette_acl.grants import grant, list_grants, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -284,7 +284,14 @@ async def test_grant_invalid_principal_type_is_400(api_ds):
 
 @pytest.mark.asyncio
 async def test_update_swaps_role(api_ds):
-    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         UPDATE_URL,
@@ -309,7 +316,14 @@ async def test_update_swaps_role(api_ds):
 
 @pytest.mark.asyncio
 async def test_revoke_removes_all(api_ds):
-    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         REVOKE_URL,
@@ -333,7 +347,14 @@ async def test_revoke_removes_all(api_ds):
 @pytest.mark.asyncio
 async def test_revoke_group(api_ds):
     gid = await _group_id(api_ds, "staff")
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         REVOKE_URL,
@@ -372,7 +393,14 @@ async def test_anonymous_cannot_grant(api_ds):
 async def test_manager_role_grants_manage_ability(api_ds):
     # Granting mallory the Manager role (which includes doc-manage) lets her
     # re-share, without the global datasette-acl permission.
-    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -387,7 +415,14 @@ async def test_manager_role_grants_manage_ability(api_ds):
 @pytest.mark.asyncio
 async def test_non_manager_role_cannot_grant(api_ds):
     # Editor is not a manage role, so it must NOT confer re-share ability.
-    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Editor", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Editor",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -406,7 +441,14 @@ async def test_group_manager_role_grants_manage_ability(api_ds):
         "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
         ["mallory", gid],
     )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -544,7 +586,12 @@ HTML_PAGE_URL = "/-/acl/resource/mock-doc/42"
 async def test_html_page_manager_can_view(api_ds):
     # mallory holds the Manager role on mock-doc/42 but is NOT the global admin.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 200
@@ -555,7 +602,12 @@ async def test_html_page_manager_can_grant_via_post(api_ds):
     # A per-resource Manager can grant a raw action through the HTML form,
     # without the global datasette-acl permission.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.post(
         HTML_PAGE_URL,
@@ -578,7 +630,12 @@ async def test_html_page_group_manager_can_view(api_ds):
         ["mallory", gid],
     )
     await grant(
-        api_ds, "mock-doc", "42", group_id=gid, role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 200
@@ -595,7 +652,12 @@ async def test_html_page_non_manager_forbidden(api_ds):
 async def test_html_page_non_manage_role_forbidden(api_ds):
     # Editor is not a manage role, so it must NOT unlock the admin page.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Editor", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Editor",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 403
@@ -635,7 +697,12 @@ async def test_grant_helper_rejects_unknown_raw_action(api_ds):
     # register, rather than silently inventing it.
     with pytest.raises(ValueError):
         await grant(
-            api_ds, "mock-doc", "42", actor_id="bob", actions=["not-real"], by_actor="root"
+            api_ds,
+            "mock-doc",
+            "42",
+            principal=Principal.actor("bob"),
+            actions=["not-real"],
+            by_actor="root",
         )
     # And nothing must have been persisted.
     assert "not-real" not in await _acl_action_names(api_ds)
@@ -664,7 +731,7 @@ async def test_grant_unknown_action_partial_list_is_atomic(api_ds):
             api_ds,
             "mock-doc",
             "42",
-            actor_id="bob",
+            principal=Principal.actor("bob"),
             actions=["doc-view", "not-real"],
             by_actor="root",
         )
@@ -678,7 +745,12 @@ async def test_future_action_name_not_persisted_as_stale_grant(api_ds):
     # mock-doc today, but which a future version might add. It must be rejected,
     # and must never reach acl_actions, so it cannot go live later.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await _post(
         api_ds,

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -18,7 +18,7 @@ from datasette import Response
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -369,7 +369,11 @@ async def resource_ds():
         await db.execute_write("INSERT INTO acl_groups (name) VALUES ('staff')")
         # bruce is a per-resource Manager (no global admin).
         await grant(
-            datasette, "mock-doc", "42", actor_id="bruce", role="Manager",
+            datasette,
+            "mock-doc",
+            "42",
+            principal=Principal.actor("bruce"),
+            role="Manager",
             by_actor="root",
         )
         yield datasette

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -7,9 +7,9 @@ The group picker draws from ``acl_groups`` (active groups + member counts). The
 actor picker is a thin proxy: it delegates to the user-profiles search API
 (``GET /-/profiles/api/search``) when installed, and otherwise falls back to
 ``datasette_acl_valid_actors`` filtered by ``q`` in Python. Both endpoints gate
-on the global ``datasette-acl`` permission. Wildcard / public principals
-(``*``, ``_signed_in``, ``_anonymous``) need no write path — they are plain
-``actor_id`` strings — so they are exercised through the grant helpers in
+on the global ``datasette-acl`` permission. Public audiences (``everyone``,
+``authenticated``, ``anonymous``) need no picker — they are a fixed set named
+by ``principal_type`` — so they are exercised through the grant helpers in
 ``test_custom_resources.py`` rather than here.
 """
 

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -2,11 +2,11 @@
 
     GET /-/acl/api/resource/{resource_type}/{parent}/{child}
 
-Seeds actor / group / wildcard grants on a mock resource and asserts the JSON
-shape: grants grouped by principal with a resolved role, actor enrichment from a
-fake ``actors_from_ids`` test plugin (display name / email / avatar / kind),
-group ``member_count``, wildcard principals flagged ``kind:"public"``, and the
-``roles`` registry + ``can_manage`` flag.
+Seeds actor / group / public-audience grants on a mock resource and asserts the
+JSON shape: grants grouped by principal with a resolved role, actor enrichment
+from a fake ``actors_from_ids`` test plugin (display name / email / avatar /
+kind), group ``member_count``, public audiences flagged ``kind:"public"``, and
+the ``roles`` registry + ``can_manage`` flag.
 """
 
 from datasette import hookimpl
@@ -185,7 +185,12 @@ async def test_read_full_shape(api_ds):
     )
     await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
     await grant(
-        api_ds, "mock-doc", "42", actor_id="_signed_in", role="Viewer", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal_type="authenticated",
+        role="Viewer",
+        by_actor="root",
     )
 
     response = await _get(
@@ -227,12 +232,13 @@ async def test_read_full_shape(api_ds):
     assert group["display_name"] == "staff"
     assert group["member_count"] == 0
 
-    # Wildcard principal flagged public.
-    wildcard = grants[("actor", "_signed_in")]
-    assert wildcard["role"] == "Viewer"
-    assert wildcard["kind"] == "public"
-    # No enrichment looked up for a wildcard principal.
-    assert "display_name" not in wildcard
+    # Public audience flagged public; its id echoes the audience type and the
+    # display name is the friendly label (never looked up via actors_from_ids).
+    public = grants[("public", "authenticated")]
+    assert public["role"] == "Viewer"
+    assert public["kind"] == "public"
+    assert public["display_name"] == "Any signed-in user"
+    assert "email" not in public
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -13,7 +13,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -166,7 +166,14 @@ async def test_read_nonexistent_resource_forbidden(api_ds):
 async def test_per_resource_manager_can_read(api_ds):
     # Grant alice the Manager role (which includes the manage action) and prove
     # she can read the endpoint without the global datasette-acl permission.
-    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
     cookies = {"ds_actor": api_ds.client.actor_cookie({"id": "alice"})}
     response = await _get(api_ds, "/-/acl/api/resource/mock-doc/42", cookies=cookies)
     assert response.status_code == 200
@@ -179,16 +186,35 @@ async def test_per_resource_manager_can_read(api_ds):
 @pytest.mark.asyncio
 async def test_read_full_shape(api_ds):
     gid = await _group_id(api_ds, "staff")
-    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
-    await grant(
-        api_ds, "mock-doc", "42", actor_id="agent:researcher", role="Editor", by_actor="root"
-    )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
     await grant(
         api_ds,
         "mock-doc",
         "42",
-        principal_type="authenticated",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("agent:researcher"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.public("authenticated"),
         role="Viewer",
         by_actor="root",
     )
@@ -250,7 +276,14 @@ async def test_group_member_count(api_ds):
             "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
             [actor_id, gid],
         )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _get(
         api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
     )
@@ -275,7 +308,14 @@ async def test_read_empty_resource(api_ds):
 @pytest.mark.asyncio
 async def test_unknown_actor_falls_back(api_ds):
     # An actor with no directory entry still resolves (kind user, no names).
-    await grant(api_ds, "mock-doc", "42", actor_id="ghost", role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("ghost"),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _get(
         api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
     )

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -567,6 +567,9 @@ async def test_generic_resource_view_grants_public_via_post(widget_ds):
         cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
     )
     assert 'name="user_permissions_*"' not in page.text
+    # Audit history shows the friendly label, not the raw wildcard id
+    assert "Anyone (signed in or not) (general access)" in page.text
+    assert "<code>*</code>" not in page.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -8,6 +8,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
+from datasette_acl.grants import grant, revoke
 import pytest
 import pytest_asyncio
 
@@ -87,20 +88,35 @@ async def _upsert_resource_id(db, resource_type, parent, child):
     )
 
 
-async def _grant_actor(datasette, *, actor_id, resource_type, parent, child, action):
+async def _grant_actor(
+    datasette,
+    *,
+    actor_id,
+    resource_type,
+    parent,
+    child,
+    action,
+    principal_type="actor",
+):
     db = datasette.get_internal_database()
     resource_id = await _upsert_resource_id(db, resource_type, parent, child)
     await db.execute_write(
         """
-        INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+        INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
         VALUES (
+            :principal_type,
             :actor_id,
             null,
             :resource_id,
             (SELECT id FROM acl_actions WHERE name = :action)
         )
         """,
-        {"actor_id": actor_id, "resource_id": resource_id, "action": action},
+        {
+            "principal_type": principal_type,
+            "actor_id": actor_id,
+            "resource_id": resource_id,
+            "action": action,
+        },
     )
 
 
@@ -119,8 +135,9 @@ async def _grant_group(datasette, *, group_name, resource_type, parent, child, a
     resource_id = await _upsert_resource_id(db, resource_type, parent, child)
     await db.execute_write(
         """
-        INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+        INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
         VALUES (
+            'group',
             null,
             :group_id,
             :resource_id,
@@ -214,6 +231,7 @@ async def test_signed_in_wildcard_grant(widget_ds):
         parent="shelf",
         child="gadget",
         action="widget-view",
+        principal_type="public",
     )
     resource = WidgetResource("shelf", "gadget")
     assert await widget_ds.allowed(
@@ -234,6 +252,7 @@ async def test_star_wildcard_grant(widget_ds):
         parent="shelf",
         child="gadget",
         action="widget-view",
+        principal_type="public",
     )
     resource = WidgetResource("shelf", "gadget")
     assert await widget_ds.allowed(
@@ -255,6 +274,7 @@ async def test_anonymous_wildcard_grant(widget_ds):
         parent="shelf",
         child="gadget",
         action="widget-view",
+        principal_type="public",
     )
     resource = WidgetResource("shelf", "gadget")
     assert await widget_ds.allowed(
@@ -262,6 +282,125 @@ async def test_anonymous_wildcard_grant(widget_ds):
     )
     assert not await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_anonymous_wildcard_does_not_leak_to_colliding_actor_id(widget_ds):
+    # The headline regression for the principal_type migration: before it, the
+    # enforcement SQL's direct-grant branch (a.actor_id = :actor_id) matched a
+    # stored '_anonymous' wildcard row for a *signed-in* caller whose actor id
+    # was literally '_anonymous', leaking every grant an admin intended for
+    # signed-out visitors only. Stored as ('public', '_anonymous') -- here via
+    # the admin form, the same write path an admin uses -- the grant must apply
+    # to anonymous callers and no one else.
+    resource = WidgetResource("shelf", "gadget")
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={"public_permissions__anonymous": "widget-view"},
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+    # Anonymous callers are allowed
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    # A signed-in actor whose id is literally '_anonymous' is DENIED
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_actor_grant_with_wildcard_name(widget_ds):
+    # Mirror of the leak test: an explicit ('actor', '_anonymous') grant --
+    # only creatable by deliberately passing principal_type="actor" -- allows
+    # exactly that signed-in user and never anonymous callers.
+    resource = WidgetResource("shelf", "gadget")
+    await grant(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        actor_id="_anonymous",
+        actions=["widget-view"],
+        principal_type="actor",
+        by_actor="root",
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "someone-else"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_and_actor_grants_with_same_id_coexist(widget_ds):
+    # ('public', '_anonymous') and ('actor', '_anonymous') are distinct rows:
+    # each matches only its own audience, and revoking one leaves the other.
+    resource = WidgetResource("shelf", "gadget")
+    await grant(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        actor_id="_anonymous",
+        actions=["widget-view"],
+        principal_type="public",
+        by_actor="root",
+    )
+    await grant(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        actor_id="_anonymous",
+        actions=["widget-view"],
+        principal_type="actor",
+        by_actor="root",
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
+    )
+    # Other signed-in users match neither row
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "someone-else"}
+    )
+    # Revoking the wildcard leaves the like-named user's grant intact...
+    await revoke(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        actor_id="_anonymous",
+        principal_type="public",
+        by_actor="root",
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
+    )
+    # ...and vice versa.
+    await revoke(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        actor_id="_anonymous",
+        principal_type="actor",
+        by_actor="root",
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
     )
 
 
@@ -440,6 +579,7 @@ async def test_generic_resource_view_revokes_public_via_post(widget_ds):
         parent="shelf",
         child="gadget",
         action="widget-view",
+        principal_type="public",
     )
     assert await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "anyone"}

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -387,6 +387,77 @@ async def test_generic_resource_view_grants_via_post(widget_ds):
 
 
 @pytest.mark.asyncio
+async def test_generic_resource_view_renders_general_access(widget_ds):
+    response = await widget_ds.client.get(
+        "/-/acl/resource/widget/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 200
+    assert "General access" in response.text
+    for principal in ("*", "_signed_in", "_anonymous"):
+        assert f'name="public_permissions_{principal}"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_grants_public_via_post(widget_ds):
+    resource = WidgetResource("shelf", "gadget")
+    # Anonymous has no access yet
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={"public_permissions_*": "widget-view"},
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+    # '*' exposes the resource to everyone, including anonymous
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+    # The other action remains denied
+    assert not await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=None
+    )
+    # The wildcard grant renders in the General access section, not as a user
+    page = await widget_ds.client.get(
+        "/-/acl/resource/widget/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert 'name="user_permissions_*"' not in page.text
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_revokes_public_via_post(widget_ds):
+    resource = WidgetResource("shelf", "gadget")
+    await _grant_actor(
+        widget_ds,
+        actor_id="_signed_in",
+        resource_type="widget",
+        parent="shelf",
+        child="gadget",
+        action="widget-view",
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+    # The general-access selects are always present in the form, so a POST with
+    # the principal's select empty removes the grant (same as groups)
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={"public_permissions__signed_in": ""},
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+
+
+@pytest.mark.asyncio
 async def test_generic_resource_view_revokes_via_post(widget_ds):
     actor = {"id": "alice"}
     resource = WidgetResource("shelf", "gadget")

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -8,7 +8,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant, revoke
+from datasette_acl.grants import grant, revoke, Principal
 import pytest
 import pytest_asyncio
 
@@ -348,7 +348,7 @@ async def test_actor_grant_with_legacy_wildcard_looking_id(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -374,7 +374,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        principal_type="anonymous",
+        principal=Principal.anonymous(),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -383,7 +383,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -403,7 +403,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        principal_type="anonymous",
+        principal=Principal.anonymous(),
         by_actor="root",
     )
     assert not await widget_ds.allowed(
@@ -418,7 +418,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         by_actor="root",
     )
     assert not await widget_ds.allowed(

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -96,7 +96,6 @@ async def _grant_actor(
     parent,
     child,
     action,
-    principal_type="actor",
 ):
     db = datasette.get_internal_database()
     resource_id = await _upsert_resource_id(db, resource_type, parent, child)
@@ -104,7 +103,7 @@ async def _grant_actor(
         """
         INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
         VALUES (
-            :principal_type,
+            'actor',
             :actor_id,
             null,
             :resource_id,
@@ -112,8 +111,38 @@ async def _grant_actor(
         )
         """,
         {
-            "principal_type": principal_type,
             "actor_id": actor_id,
+            "resource_id": resource_id,
+            "action": action,
+        },
+    )
+
+
+async def _grant_public(
+    datasette,
+    *,
+    principal_type,
+    resource_type,
+    parent,
+    child,
+    action,
+):
+    # Public audiences are identified by principal_type alone -- no id.
+    db = datasette.get_internal_database()
+    resource_id = await _upsert_resource_id(db, resource_type, parent, child)
+    await db.execute_write(
+        """
+        INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
+        VALUES (
+            :principal_type,
+            null,
+            null,
+            :resource_id,
+            (SELECT id FROM acl_actions WHERE name = :action)
+        )
+        """,
+        {
+            "principal_type": principal_type,
             "resource_id": resource_id,
             "action": action,
         },
@@ -222,16 +251,15 @@ async def test_resource_type_does_not_leak(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_signed_in_wildcard_grant(widget_ds):
-    # Grant _signed_in => any actor with an id is allowed, anonymous is not
-    await _grant_actor(
+async def test_authenticated_public_grant(widget_ds):
+    # 'authenticated' => any actor with an id is allowed, anonymous is not
+    await _grant_public(
         widget_ds,
-        actor_id="_signed_in",
+        principal_type="authenticated",
         resource_type="widget",
         parent="shelf",
         child="gadget",
         action="widget-view",
-        principal_type="public",
     )
     resource = WidgetResource("shelf", "gadget")
     assert await widget_ds.allowed(
@@ -243,16 +271,15 @@ async def test_signed_in_wildcard_grant(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_star_wildcard_grant(widget_ds):
-    # Grant '*' => literally anyone, including anonymous
-    await _grant_actor(
+async def test_everyone_public_grant(widget_ds):
+    # 'everyone' => literally anyone, including anonymous
+    await _grant_public(
         widget_ds,
-        actor_id="*",
+        principal_type="everyone",
         resource_type="widget",
         parent="shelf",
         child="gadget",
         action="widget-view",
-        principal_type="public",
     )
     resource = WidgetResource("shelf", "gadget")
     assert await widget_ds.allowed(
@@ -264,17 +291,16 @@ async def test_star_wildcard_grant(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_anonymous_wildcard_grant(widget_ds):
-    # Grant '_anonymous' => only unauthenticated callers; a signed-in actor is not
+async def test_anonymous_public_grant(widget_ds):
+    # 'anonymous' => only unauthenticated callers; a signed-in actor is not
     # matched by this grant.
-    await _grant_actor(
+    await _grant_public(
         widget_ds,
-        actor_id="_anonymous",
+        principal_type="anonymous",
         resource_type="widget",
         parent="shelf",
         child="gadget",
         action="widget-view",
-        principal_type="public",
     )
     resource = WidgetResource("shelf", "gadget")
     assert await widget_ds.allowed(
@@ -286,18 +312,17 @@ async def test_anonymous_wildcard_grant(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_anonymous_wildcard_does_not_leak_to_colliding_actor_id(widget_ds):
-    # The headline regression for the principal_type migration: before it, the
-    # enforcement SQL's direct-grant branch (a.actor_id = :actor_id) matched a
+async def test_anonymous_grant_never_matches_a_signed_in_actor(widget_ds):
+    # Historic regression: when public audiences were stored in-band as magic
+    # actor_id values, the enforcement SQL's direct-grant branch matched the
     # stored '_anonymous' wildcard row for a *signed-in* caller whose actor id
-    # was literally '_anonymous', leaking every grant an admin intended for
-    # signed-out visitors only. Stored as ('public', '_anonymous') -- here via
-    # the admin form, the same write path an admin uses -- the grant must apply
-    # to anonymous callers and no one else.
+    # was literally '_anonymous'. Audiences now carry no id at all, so no
+    # actor id -- however weird -- can collide with one. Granted via the admin
+    # form, the same write path an admin uses.
     resource = WidgetResource("shelf", "gadget")
     response = await widget_ds.client.post(
         "/-/acl/resource/widget/shelf/gadget",
-        data={"public_permissions__anonymous": "widget-view"},
+        data={"public_permissions_anonymous": "widget-view"},
         cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
     )
     assert response.status_code == 302
@@ -305,17 +330,18 @@ async def test_anonymous_wildcard_does_not_leak_to_colliding_actor_id(widget_ds)
     assert await widget_ds.allowed(
         action="widget-view", resource=resource, actor=None
     )
-    # A signed-in actor whose id is literally '_anonymous' is DENIED
-    assert not await widget_ds.allowed(
-        action="widget-view", resource=resource, actor={"id": "_anonymous"}
-    )
+    # Signed-in actors are denied, even ones with legacy-wildcard-looking ids
+    for actor_id in ("_anonymous", "anonymous", "*", "_signed_in"):
+        assert not await widget_ds.allowed(
+            action="widget-view", resource=resource, actor={"id": actor_id}
+        )
 
 
 @pytest.mark.asyncio
-async def test_explicit_actor_grant_with_wildcard_name(widget_ds):
-    # Mirror of the leak test: an explicit ('actor', '_anonymous') grant --
-    # only creatable by deliberately passing principal_type="actor" -- allows
-    # exactly that signed-in user and never anonymous callers.
+async def test_actor_grant_with_legacy_wildcard_looking_id(widget_ds):
+    # An actor whose id happens to look like an old wildcard is just an
+    # ordinary actor: the grant allows exactly that signed-in user and never
+    # anonymous callers.
     resource = WidgetResource("shelf", "gadget")
     await grant(
         widget_ds,
@@ -324,7 +350,6 @@ async def test_explicit_actor_grant_with_wildcard_name(widget_ds):
         "gadget",
         actor_id="_anonymous",
         actions=["widget-view"],
-        principal_type="actor",
         by_actor="root",
     )
     assert await widget_ds.allowed(
@@ -339,18 +364,18 @@ async def test_explicit_actor_grant_with_wildcard_name(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_public_and_actor_grants_with_same_id_coexist(widget_ds):
-    # ('public', '_anonymous') and ('actor', '_anonymous') are distinct rows:
-    # each matches only its own audience, and revoking one leaves the other.
+async def test_public_and_actor_grants_coexist(widget_ds):
+    # An 'anonymous' audience grant and an actor grant for a user literally
+    # named '_anonymous' are distinct rows: each matches only its own
+    # audience, and revoking one leaves the other.
     resource = WidgetResource("shelf", "gadget")
     await grant(
         widget_ds,
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal_type="anonymous",
         actions=["widget-view"],
-        principal_type="public",
         by_actor="root",
     )
     await grant(
@@ -360,7 +385,6 @@ async def test_public_and_actor_grants_with_same_id_coexist(widget_ds):
         "gadget",
         actor_id="_anonymous",
         actions=["widget-view"],
-        principal_type="actor",
         by_actor="root",
     )
     assert await widget_ds.allowed(
@@ -373,14 +397,13 @@ async def test_public_and_actor_grants_with_same_id_coexist(widget_ds):
     assert not await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "someone-else"}
     )
-    # Revoking the wildcard leaves the like-named user's grant intact...
+    # Revoking the audience leaves the actor's grant intact...
     await revoke(
         widget_ds,
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
-        principal_type="public",
+        principal_type="anonymous",
         by_actor="root",
     )
     assert not await widget_ds.allowed(
@@ -396,7 +419,6 @@ async def test_public_and_actor_grants_with_same_id_coexist(widget_ds):
         "shelf",
         "gadget",
         actor_id="_anonymous",
-        principal_type="actor",
         by_actor="root",
     )
     assert not await widget_ds.allowed(
@@ -533,8 +555,8 @@ async def test_generic_resource_view_renders_general_access(widget_ds):
     )
     assert response.status_code == 200
     assert "General access" in response.text
-    for principal in ("*", "_signed_in", "_anonymous"):
-        assert f'name="public_permissions_{principal}"' in response.text
+    for principal_type in ("everyone", "authenticated", "anonymous"):
+        assert f'name="public_permissions_{principal_type}"' in response.text
 
 
 @pytest.mark.asyncio
@@ -546,11 +568,11 @@ async def test_generic_resource_view_grants_public_via_post(widget_ds):
     )
     response = await widget_ds.client.post(
         "/-/acl/resource/widget/shelf/gadget",
-        data={"public_permissions_*": "widget-view"},
+        data={"public_permissions_everyone": "widget-view"},
         cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
     )
     assert response.status_code == 302
-    # '*' exposes the resource to everyone, including anonymous
+    # 'everyone' exposes the resource to anyone, including anonymous
     assert await widget_ds.allowed(
         action="widget-view", resource=resource, actor=None
     )
@@ -561,28 +583,26 @@ async def test_generic_resource_view_grants_public_via_post(widget_ds):
     assert not await widget_ds.allowed(
         action="widget-edit", resource=resource, actor=None
     )
-    # The wildcard grant renders in the General access section, not as a user
+    # The public grant renders in the General access section, not as a user
     page = await widget_ds.client.get(
         "/-/acl/resource/widget/shelf/gadget",
         cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
     )
-    assert 'name="user_permissions_*"' not in page.text
-    # Audit history shows the friendly label, not the raw wildcard id
+    assert 'name="user_permissions_everyone"' not in page.text
+    # Audit history shows the friendly label
     assert "Anyone (signed in or not) (general access)" in page.text
-    assert "<code>*</code>" not in page.text
 
 
 @pytest.mark.asyncio
 async def test_generic_resource_view_revokes_public_via_post(widget_ds):
     resource = WidgetResource("shelf", "gadget")
-    await _grant_actor(
+    await _grant_public(
         widget_ds,
-        actor_id="_signed_in",
+        principal_type="authenticated",
         resource_type="widget",
         parent="shelf",
         child="gadget",
         action="widget-view",
-        principal_type="public",
     )
     assert await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "anyone"}
@@ -591,7 +611,7 @@ async def test_generic_resource_view_revokes_public_via_post(widget_ds):
     # the principal's select empty removes the grant (same as groups)
     response = await widget_ds.client.post(
         "/-/acl/resource/widget/shelf/gadget",
-        data={"public_permissions__signed_in": ""},
+        data={"public_permissions_authenticated": ""},
         cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
     )
     assert response.status_code == 302

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -14,7 +14,7 @@ from datasette_acl.grants import (
     revoke,
     update_role,
     list_grants,
-    principal_type_for,
+    Principal,
     _insert_grant,
 )
 from datasette_acl.roles import AclRole
@@ -179,7 +179,12 @@ async def test_build_resource_unknown_type(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_by_role(grants_ds):
     result = await grant(
-        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
@@ -192,7 +197,12 @@ async def test_grant_by_role(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_by_raw_actions(grants_ds):
     result = await grant(
-        grants_ds, "doc", "42", actor_id="bob", actions=["doc-view"], by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("bob"),
+        actions=["doc-view"],
+        by_actor="root",
     )
     assert result == ["doc-view"]
     assert await _actions_for(grants_ds, "bob") == ["doc-view"]
@@ -200,10 +210,22 @@ async def test_grant_by_raw_actions(grants_ds):
 
 @pytest.mark.asyncio
 async def test_grant_is_idempotent(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
     # Granting again with overlap only inserts the new action
     result = await grant(
-        grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-manage", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == [
@@ -224,7 +246,12 @@ async def test_grant_is_idempotent(grants_ds):
 async def test_grant_to_group(grants_ds):
     gid = await _group_id(grants_ds, "staff")
     result = await grant(
-        grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
     )
     assert result == ["doc-view"]
     grants = await list_grants(grants_ds, "doc", "42")
@@ -242,25 +269,27 @@ async def test_grant_to_group(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_unknown_role_raises(grants_ds):
     with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="alice", role="Nope")
-
-
-@pytest.mark.asyncio
-async def test_grant_requires_exactly_one_principal(grants_ds):
-    with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", role="Viewer")
-    gid = await _group_id(grants_ds, "staff")
-    with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="a", group_id=gid, role="Viewer")
+        await grant(
+            grants_ds,
+            "doc",
+            "42",
+            principal=Principal.actor("alice"),
+            role="Nope",
+        )
 
 
 @pytest.mark.asyncio
 async def test_grant_requires_exactly_one_of_role_or_actions(grants_ds):
     with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="a")
+        await grant(grants_ds, "doc", "42", principal=Principal.actor("a"))
     with pytest.raises(ValueError):
         await grant(
-            grants_ds, "doc", "42", actor_id="a", role="Viewer", actions=["doc-view"]
+            grants_ds,
+            "doc",
+            "42",
+            principal=Principal.actor("a"),
+            role="Viewer",
+            actions=["doc-view"],
         )
 
 
@@ -269,17 +298,50 @@ async def test_grant_requires_exactly_one_of_role_or_actions(grants_ds):
 
 @pytest.mark.asyncio
 async def test_revoke_removes_all_rows(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
-    removed = await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
+    removed = await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     assert removed == ["doc-edit", "doc-manage", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == []
 
 
 @pytest.mark.asyncio
 async def test_revoke_only_targets_principal(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", actor_id="bob", role="Viewer", by_actor="root")
-    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Viewer",
+        by_actor="root",
+    )
+    await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     assert await _actions_for(grants_ds, "alice") == []
     assert await _actions_for(grants_ds, "bob") == ["doc-view"]
 
@@ -289,9 +351,21 @@ async def test_revoke_only_targets_principal(grants_ds):
 
 @pytest.mark.asyncio
 async def test_update_role_swaps_atomically(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
     result = await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
     )
     assert result == ["doc-view"]
     # Only doc-view remains: doc-edit and doc-manage removed
@@ -300,9 +374,21 @@ async def test_update_role_swaps_atomically(grants_ds):
 
 @pytest.mark.asyncio
 async def test_update_role_upgrades(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
+    )
     result = await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
@@ -313,11 +399,29 @@ async def test_update_role_upgrades(grants_ds):
 
 @pytest.mark.asyncio
 async def test_audit_rows_written(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="admin"
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
-    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await update_role(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="admin",
+    )
+    await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     ops = await _audit_ops(grants_ds)
     # grant Editor: +doc-view +doc-edit; update to Viewer: -doc-edit;
     # revoke: -doc-view
@@ -336,8 +440,22 @@ async def test_audit_rows_written(grants_ds):
 @pytest.mark.asyncio
 async def test_list_grants_actor_and_group(grants_ds):
     gid = await _group_id(grants_ds, "staff")
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     grants = await list_grants(grants_ds, "doc", "42")
     assert grants == [
         {
@@ -369,10 +487,29 @@ async def test_list_grants_public_principal_and_ordering(grants_ds):
     # then groups, then audiences.
     gid = await _group_id(grants_ds, "staff")
     await grant(
-        grants_ds, "doc", "42", principal_type="everyone", role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.public("everyone"),
+        role="Viewer",
+        by_actor="root",
     )
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     grants = await list_grants(grants_ds, "doc", "42")
     assert [(g["principal"], g["actor_id"], g["group_id"]) for g in grants] == [
         ("actor", "alice", None),
@@ -381,50 +518,49 @@ async def test_list_grants_public_principal_and_ordering(grants_ds):
     ]
 
 
-# --- principal_type -------------------------------------------------------
+# --- Principal ------------------------------------------------------------
 
 
-def test_principal_type_for():
+def test_principal_constructors():
+    assert Principal.actor("alice") == Principal("actor", actor_id="alice")
+    assert Principal.group(1) == Principal("group", group_id=1)
+    assert Principal.everyone() == Principal("everyone")
+    assert Principal.authenticated() == Principal("authenticated")
+    assert Principal.anonymous() == Principal("anonymous")
+    assert Principal.public("everyone") == Principal("everyone")
+    # public() rejects names that aren't a known audience
+    with pytest.raises(ValueError):
+        Principal.public("actor")
+
+
+def test_principal_from_parts():
     # Resolution from whichever id was supplied
-    assert principal_type_for("alice", None) == "actor"
-    assert principal_type_for(None, 1) == "group"
+    assert Principal.from_parts("alice", None) == Principal.actor("alice")
+    assert Principal.from_parts(None, 1) == Principal.group(1)
     # Redundant explicit types are accepted alongside the matching id
-    assert principal_type_for("alice", None, "actor") == "actor"
-    assert principal_type_for(None, 1, "group") == "group"
+    assert Principal.from_parts("alice", None, "actor") == Principal.actor("alice")
+    assert Principal.from_parts(None, 1, "group") == Principal.group(1)
     # Public audiences are named by principal_type alone, with no id
-    assert principal_type_for(None, None, "everyone") == "everyone"
-    assert principal_type_for(None, None, "authenticated") == "authenticated"
-    assert principal_type_for(None, None, "anonymous") == "anonymous"
+    assert Principal.from_parts(None, None, "everyone") == Principal.everyone()
+    assert Principal.from_parts(None, None, "authenticated") == Principal.authenticated()
+    assert Principal.from_parts(None, None, "anonymous") == Principal.anonymous()
     # Invalid combinations
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "everyone")  # audience with actor_id
+        Principal.from_parts("bob", None, "everyone")  # audience with actor_id
     with pytest.raises(ValueError):
-        principal_type_for(None, 1, "anonymous")  # audience with group_id
+        Principal.from_parts(None, 1, "anonymous")  # audience with group_id
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "group")  # group needs group_id
+        Principal.from_parts("bob", None, "group")  # group needs group_id
     with pytest.raises(ValueError):
-        principal_type_for(None, 1, "actor")  # group_id with actor type
+        Principal.from_parts(None, 1, "actor")  # group_id with actor type
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "alien")  # unknown type
+        Principal.from_parts("bob", None, "alien")  # unknown type
     with pytest.raises(ValueError):
-        principal_type_for(None, None)  # no principal
+        Principal.from_parts(None, None)  # no principal
     with pytest.raises(ValueError):
-        principal_type_for(None, None, "actor")  # actor type without an id
+        Principal.from_parts(None, None, "actor")  # actor type without an id
     with pytest.raises(ValueError):
-        principal_type_for("bob", 1)  # both ids
-
-
-@pytest.mark.asyncio
-async def test_grant_audience_with_actor_id_raises(grants_ds):
-    with pytest.raises(ValueError):
-        await grant(
-            grants_ds,
-            "doc",
-            "42",
-            actor_id="bob",
-            role="Viewer",
-            principal_type="everyone",
-        )
+        Principal.from_parts("bob", 1)  # both ids
 
 
 @pytest.mark.asyncio
@@ -452,7 +588,14 @@ async def test_insert_grant_dedupes(grants_ds):
     # read-modify-write guard -- yield one row: the partial unique indexes
     # actually enforce non-duplication (the old UNIQUE constraint never fired
     # across its always-NULL columns).
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
+    )
     db = grants_ds.get_internal_database()
     resource_id = (
         await db.execute(
@@ -461,7 +604,7 @@ async def test_insert_grant_dedupes(grants_ds):
     ).single_value()
     for _ in range(2):
         await _insert_grant(
-            db, resource_id, "actor", "alice", None, "doc-view", "root"
+            db, resource_id, Principal.actor("alice"), "doc-view", "root"
         )
     count = (
         await db.execute("select count(*) from acl where actor_id = 'alice'")
@@ -470,7 +613,7 @@ async def test_insert_grant_dedupes(grants_ds):
     # Same for a public audience (covered by acl_public_unique)
     for _ in range(2):
         await _insert_grant(
-            db, resource_id, "everyone", None, None, "doc-view", "root"
+            db, resource_id, Principal.everyone(), "doc-view", "root"
         )
     count = (
         await db.execute(

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -364,17 +364,20 @@ async def test_list_grants_empty(grants_ds):
 
 @pytest.mark.asyncio
 async def test_list_grants_public_principal_and_ordering(grants_ds):
-    # Wildcard grants come back as principal: "public" straight from the
-    # stored column; the list is ordered actor < group < public.
+    # Public-audience grants come back with principal naming the audience,
+    # straight from the stored column, with no id; the list is ordered actors,
+    # then groups, then audiences.
     gid = await _group_id(grants_ds, "staff")
-    await grant(grants_ds, "doc", "42", actor_id="*", role="Viewer", by_actor="root")
+    await grant(
+        grants_ds, "doc", "42", principal_type="everyone", role="Viewer", by_actor="root"
+    )
     await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
     await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
     grants = await list_grants(grants_ds, "doc", "42")
     assert [(g["principal"], g["actor_id"], g["group_id"]) for g in grants] == [
         ("actor", "alice", None),
         ("group", None, gid),
-        ("public", "*", None),
+        ("everyone", None, None),
     ]
 
 
@@ -382,19 +385,21 @@ async def test_list_grants_public_principal_and_ordering(grants_ds):
 
 
 def test_principal_type_for():
-    # Inference (the back-compat default)
+    # Resolution from whichever id was supplied
     assert principal_type_for("alice", None) == "actor"
-    assert principal_type_for("*", None) == "public"
-    assert principal_type_for("_signed_in", None) == "public"
     assert principal_type_for(None, 1) == "group"
-    # Explicit types are honored, letting a real user named like a wildcard
-    # be granted to as an individual
-    assert principal_type_for("_signed_in", None, "actor") == "actor"
-    assert principal_type_for("*", None, "public") == "public"
+    # Redundant explicit types are accepted alongside the matching id
+    assert principal_type_for("alice", None, "actor") == "actor"
     assert principal_type_for(None, 1, "group") == "group"
+    # Public audiences are named by principal_type alone, with no id
+    assert principal_type_for(None, None, "everyone") == "everyone"
+    assert principal_type_for(None, None, "authenticated") == "authenticated"
+    assert principal_type_for(None, None, "anonymous") == "anonymous"
     # Invalid combinations
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "public")  # non-wildcard id
+        principal_type_for("bob", None, "everyone")  # audience with actor_id
+    with pytest.raises(ValueError):
+        principal_type_for(None, 1, "anonymous")  # audience with group_id
     with pytest.raises(ValueError):
         principal_type_for("bob", None, "group")  # group needs group_id
     with pytest.raises(ValueError):
@@ -404,11 +409,13 @@ def test_principal_type_for():
     with pytest.raises(ValueError):
         principal_type_for(None, None)  # no principal
     with pytest.raises(ValueError):
-        principal_type_for("bob", 1)  # both principals
+        principal_type_for(None, None, "actor")  # actor type without an id
+    with pytest.raises(ValueError):
+        principal_type_for("bob", 1)  # both ids
 
 
 @pytest.mark.asyncio
-async def test_grant_public_type_with_real_actor_id_raises(grants_ds):
+async def test_grant_audience_with_actor_id_raises(grants_ds):
     with pytest.raises(ValueError):
         await grant(
             grants_ds,
@@ -416,14 +423,15 @@ async def test_grant_public_type_with_real_actor_id_raises(grants_ds):
             "42",
             actor_id="bob",
             role="Viewer",
-            principal_type="public",
+            principal_type="everyone",
         )
 
 
 @pytest.mark.asyncio
-async def test_raw_public_insert_with_real_actor_id_rejected(grants_ds):
+async def test_raw_audience_insert_with_actor_id_rejected(grants_ds):
     # The CHECK constraint is the storage-layer backstop behind the Python
-    # validation: ('public', 'bob') can never be stored, even by raw SQL.
+    # validation: an audience row carrying an actor_id can never be stored,
+    # even by raw SQL.
     import sqlite3
 
     db = grants_ds.get_internal_database()
@@ -431,7 +439,7 @@ async def test_raw_public_insert_with_real_actor_id_rejected(grants_ds):
         await db.execute_write(
             """
             insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
-            values ('public', 'bob', null,
+            values ('everyone', 'bob', null,
                 (select min(id) from acl_resources),
                 (select min(id) from acl_actions))
             """
@@ -457,5 +465,16 @@ async def test_insert_grant_dedupes(grants_ds):
         )
     count = (
         await db.execute("select count(*) from acl where actor_id = 'alice'")
+    ).single_value()
+    assert count == 1
+    # Same for a public audience (covered by acl_public_unique)
+    for _ in range(2):
+        await _insert_grant(
+            db, resource_id, "everyone", None, None, "doc-view", "root"
+        )
+    count = (
+        await db.execute(
+            "select count(*) from acl where principal_type = 'everyone'"
+        )
     ).single_value()
     assert count == 1

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -9,7 +9,14 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.grants import (
+    grant,
+    revoke,
+    update_role,
+    list_grants,
+    principal_type_for,
+    _insert_grant,
+)
 from datasette_acl.roles import AclRole
 from datasette_acl.utils import build_resource
 import pytest
@@ -353,3 +360,102 @@ async def test_list_grants_actor_and_group(grants_ds):
 @pytest.mark.asyncio
 async def test_list_grants_empty(grants_ds):
     assert await list_grants(grants_ds, "doc", "42") == []
+
+
+@pytest.mark.asyncio
+async def test_list_grants_public_principal_and_ordering(grants_ds):
+    # Wildcard grants come back as principal: "public" straight from the
+    # stored column; the list is ordered actor < group < public.
+    gid = await _group_id(grants_ds, "staff")
+    await grant(grants_ds, "doc", "42", actor_id="*", role="Viewer", by_actor="root")
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    grants = await list_grants(grants_ds, "doc", "42")
+    assert [(g["principal"], g["actor_id"], g["group_id"]) for g in grants] == [
+        ("actor", "alice", None),
+        ("group", None, gid),
+        ("public", "*", None),
+    ]
+
+
+# --- principal_type -------------------------------------------------------
+
+
+def test_principal_type_for():
+    # Inference (the back-compat default)
+    assert principal_type_for("alice", None) == "actor"
+    assert principal_type_for("*", None) == "public"
+    assert principal_type_for("_signed_in", None) == "public"
+    assert principal_type_for(None, 1) == "group"
+    # Explicit types are honored, letting a real user named like a wildcard
+    # be granted to as an individual
+    assert principal_type_for("_signed_in", None, "actor") == "actor"
+    assert principal_type_for("*", None, "public") == "public"
+    assert principal_type_for(None, 1, "group") == "group"
+    # Invalid combinations
+    with pytest.raises(ValueError):
+        principal_type_for("bob", None, "public")  # non-wildcard id
+    with pytest.raises(ValueError):
+        principal_type_for("bob", None, "group")  # group needs group_id
+    with pytest.raises(ValueError):
+        principal_type_for(None, 1, "actor")  # group_id with actor type
+    with pytest.raises(ValueError):
+        principal_type_for("bob", None, "alien")  # unknown type
+    with pytest.raises(ValueError):
+        principal_type_for(None, None)  # no principal
+    with pytest.raises(ValueError):
+        principal_type_for("bob", 1)  # both principals
+
+
+@pytest.mark.asyncio
+async def test_grant_public_type_with_real_actor_id_raises(grants_ds):
+    with pytest.raises(ValueError):
+        await grant(
+            grants_ds,
+            "doc",
+            "42",
+            actor_id="bob",
+            role="Viewer",
+            principal_type="public",
+        )
+
+
+@pytest.mark.asyncio
+async def test_raw_public_insert_with_real_actor_id_rejected(grants_ds):
+    # The CHECK constraint is the storage-layer backstop behind the Python
+    # validation: ('public', 'bob') can never be stored, even by raw SQL.
+    import sqlite3
+
+    db = grants_ds.get_internal_database()
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute_write(
+            """
+            insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
+            values ('public', 'bob', null,
+                (select min(id) from acl_resources),
+                (select min(id) from acl_actions))
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_insert_grant_dedupes(grants_ds):
+    # Two identical _insert_grant calls -- bypassing grant()'s
+    # read-modify-write guard -- yield one row: the partial unique indexes
+    # actually enforce non-duplication (the old UNIQUE constraint never fired
+    # across its always-NULL columns).
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    db = grants_ds.get_internal_database()
+    resource_id = (
+        await db.execute(
+            "select id from acl_resources where resource_type = 'doc' and parent = '42'"
+        )
+    ).single_value()
+    for _ in range(2):
+        await _insert_grant(
+            db, resource_id, "actor", "alice", None, "doc-view", "root"
+        )
+    count = (
+        await db.execute("select count(*) from acl where actor_id = 'alice'")
+    ).single_value()
+    assert count == 1

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -231,8 +231,8 @@ async def test_create_delete_group(ds):
         },
     )
     assert "/groups/sales" not in table_page2.text
-    # But it should still be visible in the audit log
-    assert "<td>sales</td>" in table_page2.text
+    # But it should still be visible in the audit log's Principal column
+    assert "<td>sales (group)</td>" in table_page2.text
 
     # Check the audit log
     audit_rows = [

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,5 +1,5 @@
 """
-Tests for the friendly-roles layer: the datasette_acl_roles hook, the startup
+Tests for the friendly-roles layer: the datasette_acl_roles hook, the
 registry keyed by resource_type, and the role<->action resolution helpers.
 """
 
@@ -9,6 +9,7 @@ from datasette.permissions import Action, Resource
 from datasette.plugins import pm
 from datasette_acl.roles import (
     AclRole,
+    build_roles_registry,
     role_for_actions,
     actions_for_role,
     manage_actions,
@@ -76,7 +77,7 @@ async def doc_ds():
 
 @pytest.mark.asyncio
 async def test_registry_built_and_grouped_by_resource_type(doc_ds):
-    registry = doc_ds._acl_roles_registry
+    registry = build_roles_registry(doc_ds)
     assert set(registry.keys()) == {"mock-doc"}
     roles = registry["mock-doc"]
     # All three roles present, sorted by rank ascending

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -551,60 +551,137 @@ async def test_fresh_acl_resources_schema():
     assert cols == ["id", "resource_type", "parent", "child"]
 
 
-@pytest.mark.asyncio
-async def test_acl_resources_migration():
+def test_acl_resources_migration():
     # Drive the migrations directly: apply everything up to m002 to get the OLD
     # (database, resource) acl_resources schema, insert rows, then run m002 and
     # assert the data migrates to (resource_type, parent, child), backfilling
-    # resource_type='table' and preserving id/parent/child values.
-    datasette = Datasette(memory=True)
-    db = datasette.get_internal_database()
-
-    await db.execute_write_fn(
-        lambda conn: internal_migrations.apply(
-            Database(conn), stop_before="m002_generalize_acl_resources"
-        )
-    )
+    # resource_type='table' and preserving id/parent/child values. Uses a plain
+    # sqlite_utils Database (not Datasette's internal db wrapper): the wrapper
+    # tracks schema changes and dispatches events, which requires a started-up
+    # Datasette, while this test exists precisely to drive the migrations
+    # outside the startup hook.
+    db = Database(memory=True)
+    internal_migrations.apply(db, stop_before="m002_generalize_acl_resources")
 
     # m001 created acl_resources with the old (database, resource) columns
-    cols_before = [
-        r["name"] for r in (await db.execute("PRAGMA table_info(acl_resources)"))
-    ]
+    cols_before = [r[1] for r in db.execute("PRAGMA table_info(acl_resources)")]
     assert cols_before == ["id", "database", "resource"]
 
-    await db.execute_write(
+    db.execute(
         "insert into acl_resources (database, resource) values (?, ?)", ["db1", "t1"]
     )
-    await db.execute_write(
+    db.execute(
         "insert into acl_resources (database, resource) values (?, ?)", ["db2", "t2"]
     )
 
-    # Apply the remaining migrations (m002)
-    await db.execute_write_fn(lambda conn: internal_migrations.apply(Database(conn)))
+    # Apply the remaining migrations (m002 onwards)
+    internal_migrations.apply(db)
 
-    cols_after = [
-        r["name"] for r in (await db.execute("PRAGMA table_info(acl_resources)"))
-    ]
+    cols_after = [r[1] for r in db.execute("PRAGMA table_info(acl_resources)")]
     assert cols_after == ["id", "resource_type", "parent", "child"]
 
-    rows = [
-        dict(r)
-        for r in (await db.execute("select * from acl_resources order by id"))
-    ]
+    rows = list(db["acl_resources"].rows)
     assert rows == [
         {"id": 1, "resource_type": "table", "parent": "db1", "child": "t1"},
         {"id": 2, "resource_type": "table", "parent": "db2", "child": "t2"},
     ]
     # The leftover scratch table must be gone.
-    assert "acl_resources_old" not in await db.table_names()
+    assert "acl_resources_old" not in db.table_names()
 
     # Re-applying is idempotent: no error, no duplicate rows.
-    await db.execute_write_fn(lambda conn: internal_migrations.apply(Database(conn)))
-    rows_again = [
-        dict(r)
-        for r in (await db.execute("select * from acl_resources order by id"))
-    ]
+    internal_migrations.apply(db)
+    rows_again = list(db["acl_resources"].rows)
     assert rows_again == rows
+
+
+def test_principal_type_migration():
+    # Apply up to (not including) m003 to get the old acl shape, insert
+    # old-shape rows -- a wildcard actor, a real actor, a group grant and an
+    # exact duplicate pair (possible before m003 because the old UNIQUE
+    # constraint never fired across NULLs) -- plus audit rows, then run m003.
+    db = Database(memory=True)
+    internal_migrations.apply(db, stop_before="m003_principal_type")
+
+    cols_before = [r[1] for r in db.execute("PRAGMA table_info(acl)")]
+    assert "principal_type" not in cols_before
+
+    db.execute("insert into acl_resources (resource_type, parent) values ('doc', '42')")
+    db.execute("insert into acl_actions (name) values ('doc-view')")
+    db.execute("insert into acl_groups (name) values ('staff')")
+    insert = "insert into acl (actor_id, group_id, resource_id, action_id) values (?, ?, 1, 1)"
+    db.execute(insert, ["_signed_in", None])  # (a) wildcard actor row
+    db.execute(insert, ["alice", None])  # (b) real-actor row
+    db.execute(insert, [None, 1])  # (c) group row
+    db.execute(insert, ["alice", None])  # (d) exact duplicate of (b)
+    db.execute(
+        """
+        insert into acl_audit (operation, actor_id, group_id, resource_id, action_id)
+        values ('added', '_signed_in', null, 1, 1),
+               ('added', 'alice', null, 1, 1),
+               ('added', null, 1, 1, 1)
+        """
+    )
+
+    internal_migrations.apply(db)
+
+    rows = list(
+        db.query(
+            "select acl_id, principal_type, actor_id, group_id from acl order by acl_id"
+        )
+    )
+    # Types backfilled, the duplicate pair collapsed to one row, ids preserved
+    # (min(acl_id) per surviving group).
+    assert rows == [
+        {"acl_id": 1, "principal_type": "public", "actor_id": "_signed_in", "group_id": None},
+        {"acl_id": 2, "principal_type": "actor", "actor_id": "alice", "group_id": None},
+        {"acl_id": 3, "principal_type": "group", "actor_id": None, "group_id": 1},
+    ]
+    assert "acl_old" not in db.table_names()
+
+    # Audit history backfilled with the same classification.
+    audit = list(
+        db.query("select principal_type, actor_id, group_id from acl_audit order by id")
+    )
+    assert audit == [
+        {"principal_type": "public", "actor_id": "_signed_in", "group_id": None},
+        {"principal_type": "actor", "actor_id": "alice", "group_id": None},
+        {"principal_type": "group", "actor_id": None, "group_id": 1},
+    ]
+
+    # The new partial unique indexes actually dedupe: INSERT OR IGNORE of an
+    # existing (principal_type, actor_id, resource, action) is a no-op.
+    db.execute(
+        "insert or ignore into acl (principal_type, actor_id, group_id, resource_id, action_id) "
+        "values ('actor', 'alice', null, 1, 1)"
+    )
+    assert db.execute("select count(*) from acl").fetchone()[0] == 3
+    # ...while ('public', '_signed_in') and ('actor', '_signed_in') coexist as
+    # distinct rows -- the disambiguation this migration exists for.
+    db.execute(
+        "insert or ignore into acl (principal_type, actor_id, group_id, resource_id, action_id) "
+        "values ('actor', '_signed_in', null, 1, 1)"
+    )
+    assert db.execute("select count(*) from acl").fetchone()[0] == 4
+
+    # CHECK constraints reject malformed shapes at the SQL layer.
+    import sqlite3
+
+    for bad in (
+        ("public", "bob", None),  # public with a non-wildcard id
+        ("actor", "carol", 1),  # actor with a group_id
+        ("group", "carol", None),  # group with an actor_id
+        ("alien", "dave", None),  # unknown principal_type
+    ):
+        with pytest.raises(sqlite3.IntegrityError):
+            db.execute(
+                "insert into acl (principal_type, actor_id, group_id, resource_id, action_id) "
+                "values (?, ?, ?, 1, 1)",
+                list(bad),
+            )
+
+    # Re-applying is idempotent.
+    internal_migrations.apply(db)
+    assert db.execute("select count(*) from acl").fetchone()[0] == 4
 
 
 @pytest.mark.asyncio

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -543,7 +543,7 @@ async def test_table_creator_permissions():
 
 @pytest.mark.asyncio
 async def test_fresh_acl_resources_schema():
-    # A fresh internal DB should get the new (resource_type, parent, child) schema.
+    # A fresh internal DB has the (resource_type, parent, child) schema.
     datasette = Datasette(memory=True)
     await datasette.invoke_startup()
     db = datasette.get_internal_database()
@@ -551,130 +551,42 @@ async def test_fresh_acl_resources_schema():
     assert cols == ["id", "resource_type", "parent", "child"]
 
 
-def test_acl_resources_migration():
-    # Drive the migrations directly: apply everything up to m002 to get the OLD
-    # (database, resource) acl_resources schema, insert rows, then run m002 and
-    # assert the data migrates to (resource_type, parent, child), backfilling
-    # resource_type='table' and preserving id/parent/child values. Uses a plain
-    # sqlite_utils Database (not Datasette's internal db wrapper): the wrapper
-    # tracks schema changes and dispatches events, which requires a started-up
-    # Datasette, while this test exists precisely to drive the migrations
-    # outside the startup hook.
+def test_acl_schema_constraints():
+    # A fresh internal DB enforces the acl shape at the SQL layer: the CHECK
+    # constraint rejects malformed principal rows and the partial unique
+    # indexes dedupe each principal kind. Uses a plain sqlite_utils Database
+    # (not Datasette's internal db wrapper, which needs a started-up Datasette)
+    # to drive the migrations outside the startup hook.
+    import sqlite3
+
     db = Database(memory=True)
-    internal_migrations.apply(db, stop_before="m002_generalize_acl_resources")
-
-    # m001 created acl_resources with the old (database, resource) columns
-    cols_before = [r[1] for r in db.execute("PRAGMA table_info(acl_resources)")]
-    assert cols_before == ["id", "database", "resource"]
-
-    db.execute(
-        "insert into acl_resources (database, resource) values (?, ?)", ["db1", "t1"]
-    )
-    db.execute(
-        "insert into acl_resources (database, resource) values (?, ?)", ["db2", "t2"]
-    )
-
-    # Apply the remaining migrations (m002 onwards)
     internal_migrations.apply(db)
-
-    cols_after = [r[1] for r in db.execute("PRAGMA table_info(acl_resources)")]
-    assert cols_after == ["id", "resource_type", "parent", "child"]
-
-    rows = list(db["acl_resources"].rows)
-    assert rows == [
-        {"id": 1, "resource_type": "table", "parent": "db1", "child": "t1"},
-        {"id": 2, "resource_type": "table", "parent": "db2", "child": "t2"},
-    ]
-    # The leftover scratch table must be gone.
-    assert "acl_resources_old" not in db.table_names()
-
-    # Re-applying is idempotent: no error, no duplicate rows.
-    internal_migrations.apply(db)
-    rows_again = list(db["acl_resources"].rows)
-    assert rows_again == rows
-
-
-def test_principal_type_migrations():
-    # Apply up to (not including) m003 to get the original acl shape, insert
-    # original-shape rows -- an in-band wildcard actor row, a real actor, a
-    # group grant and an exact duplicate pair (possible before m003 because
-    # the original UNIQUE constraint never fired across NULLs) -- plus audit
-    # rows, then run the remaining migrations (m003 + m004). The end state is
-    # the audience model: the wildcard row becomes principal_type
-    # 'authenticated' with no id, duplicates collapse, ids are preserved.
-    db = Database(memory=True)
-    internal_migrations.apply(db, stop_before="m003_principal_type")
-
-    cols_before = [r[1] for r in db.execute("PRAGMA table_info(acl)")]
-    assert "principal_type" not in cols_before
 
     db.execute("insert into acl_resources (resource_type, parent) values ('doc', '42')")
     db.execute("insert into acl_actions (name) values ('doc-view')")
     db.execute("insert into acl_groups (name) values ('staff')")
-    insert = "insert into acl (actor_id, group_id, resource_id, action_id) values (?, ?, 1, 1)"
-    db.execute(insert, ["_signed_in", None])  # (a) in-band wildcard row
-    db.execute(insert, ["alice", None])  # (b) real-actor row
-    db.execute(insert, [None, 1])  # (c) group row
-    db.execute(insert, ["alice", None])  # (d) exact duplicate of (b)
-    db.execute(
-        """
-        insert into acl_audit (operation, actor_id, group_id, resource_id, action_id)
-        values ('added', '_signed_in', null, 1, 1),
-               ('added', 'alice', null, 1, 1),
-               ('added', null, 1, 1, 1)
-        """
+    insert = (
+        "insert into acl (principal_type, actor_id, group_id, resource_id, action_id) "
+        "values (?, ?, ?, 1, 1)"
     )
-
-    internal_migrations.apply(db)
-
-    rows = list(
-        db.query(
-            "select acl_id, principal_type, actor_id, group_id from acl order by acl_id"
-        )
-    )
-    # Types backfilled, the legacy wildcard translated to its audience type
-    # (with no id), the duplicate pair collapsed to one row, ids preserved.
-    assert rows == [
-        {"acl_id": 1, "principal_type": "authenticated", "actor_id": None, "group_id": None},
-        {"acl_id": 2, "principal_type": "actor", "actor_id": "alice", "group_id": None},
-        {"acl_id": 3, "principal_type": "group", "actor_id": None, "group_id": 1},
-    ]
-    assert "acl_old" not in db.table_names()
-
-    # Audit history backfilled with the same classification.
-    audit = list(
-        db.query("select principal_type, actor_id, group_id from acl_audit order by id")
-    )
-    assert audit == [
-        {"principal_type": "authenticated", "actor_id": None, "group_id": None},
-        {"principal_type": "actor", "actor_id": "alice", "group_id": None},
-        {"principal_type": "group", "actor_id": None, "group_id": 1},
-    ]
-
-    # The partial unique indexes actually dedupe: INSERT OR IGNORE of an
-    # existing (actor, resource, action) is a no-op.
-    db.execute(
-        "insert or ignore into acl (principal_type, actor_id, group_id, resource_id, action_id) "
-        "values ('actor', 'alice', null, 1, 1)"
-    )
+    db.execute(insert, ["actor", "alice", None])
+    db.execute(insert, ["group", None, 1])
+    db.execute(insert, ["authenticated", None, None])
     assert db.execute("select count(*) from acl").fetchone()[0] == 3
-    # ...and a duplicate audience row is also a no-op (acl_public_unique).
-    db.execute(
-        "insert or ignore into acl (principal_type, actor_id, group_id, resource_id, action_id) "
-        "values ('authenticated', null, null, 1, 1)"
-    )
+
+    # The partial unique indexes dedupe per kind: re-inserting an existing
+    # (actor / group / audience) grant with OR IGNORE is a no-op.
+    db.execute(insert.replace("insert into", "insert or ignore into"), ["actor", "alice", None])
+    db.execute(insert.replace("insert into", "insert or ignore into"), ["group", None, 1])
+    db.execute(insert.replace("insert into", "insert or ignore into"), ["authenticated", None, None])
     assert db.execute("select count(*) from acl").fetchone()[0] == 3
+
     # An actor whose id merely looks like an old wildcard is an ordinary actor
-    # row, coexisting with the audience grant.
-    db.execute(
-        "insert or ignore into acl (principal_type, actor_id, group_id, resource_id, action_id) "
-        "values ('actor', '_signed_in', null, 1, 1)"
-    )
+    # row -- no reserved id namespace exists, so it coexists with the audience.
+    db.execute(insert, ["actor", "_signed_in", None])
     assert db.execute("select count(*) from acl").fetchone()[0] == 4
 
-    # CHECK constraints reject malformed shapes at the SQL layer.
-    import sqlite3
-
+    # CHECK rejects malformed shapes.
     for bad in (
         ("everyone", "bob", None),  # audience with an actor_id
         ("anonymous", None, 1),  # audience with a group_id
@@ -684,69 +596,7 @@ def test_principal_type_migrations():
         ("alien", "dave", None),  # unknown principal_type
     ):
         with pytest.raises(sqlite3.IntegrityError):
-            db.execute(
-                "insert into acl (principal_type, actor_id, group_id, resource_id, action_id) "
-                "values (?, ?, ?, 1, 1)",
-                list(bad),
-            )
-
-    # Re-applying is idempotent.
-    internal_migrations.apply(db)
-    assert db.execute("select count(*) from acl").fetchone()[0] == 4
-
-
-def test_public_principal_types_migration():
-    # m004 specifically: start from the intermediate m003 shape (audiences
-    # stored in-band as 'public' rows with wildcard actor_ids), insert every
-    # wildcard plus a coexisting like-named actor row, then run m004 and
-    # assert each 'public' row converts to its audience type with the id
-    # dropped -- while actor and group rows pass through untouched.
-    db = Database(memory=True)
-    internal_migrations.apply(db, stop_before="m004_public_principal_types")
-
-    db.execute("insert into acl_resources (resource_type, parent) values ('doc', '42')")
-    db.execute("insert into acl_actions (name) values ('doc-view')")
-    db.execute("insert into acl_groups (name) values ('staff')")
-    insert = (
-        "insert into acl (principal_type, actor_id, group_id, resource_id, action_id) "
-        "values (?, ?, ?, 1, 1)"
-    )
-    db.execute(insert, ["public", "*", None])
-    db.execute(insert, ["public", "_signed_in", None])
-    db.execute(insert, ["public", "_anonymous", None])
-    db.execute(insert, ["actor", "_signed_in", None])  # like-named real actor
-    db.execute(insert, ["group", None, 1])
-    db.execute(
-        """
-        insert into acl_audit (operation, principal_type, actor_id, group_id, resource_id, action_id)
-        values ('added', 'public', '*', null, 1, 1),
-               ('added', 'actor', '_signed_in', null, 1, 1)
-        """
-    )
-
-    internal_migrations.apply(db)
-
-    rows = list(
-        db.query(
-            "select acl_id, principal_type, actor_id, group_id from acl order by acl_id"
-        )
-    )
-    assert rows == [
-        {"acl_id": 1, "principal_type": "everyone", "actor_id": None, "group_id": None},
-        {"acl_id": 2, "principal_type": "authenticated", "actor_id": None, "group_id": None},
-        {"acl_id": 3, "principal_type": "anonymous", "actor_id": None, "group_id": None},
-        {"acl_id": 4, "principal_type": "actor", "actor_id": "_signed_in", "group_id": None},
-        {"acl_id": 5, "principal_type": "group", "actor_id": None, "group_id": 1},
-    ]
-    assert "acl_old" not in db.table_names()
-
-    audit = list(
-        db.query("select principal_type, actor_id from acl_audit order by id")
-    )
-    assert audit == [
-        {"principal_type": "everyone", "actor_id": None},
-        {"principal_type": "actor", "actor_id": "_signed_in"},
-    ]
+            db.execute(insert, list(bad))
 
 
 @pytest.mark.asyncio

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -594,11 +594,14 @@ def test_acl_resources_migration():
     assert rows_again == rows
 
 
-def test_principal_type_migration():
-    # Apply up to (not including) m003 to get the old acl shape, insert
-    # old-shape rows -- a wildcard actor, a real actor, a group grant and an
-    # exact duplicate pair (possible before m003 because the old UNIQUE
-    # constraint never fired across NULLs) -- plus audit rows, then run m003.
+def test_principal_type_migrations():
+    # Apply up to (not including) m003 to get the original acl shape, insert
+    # original-shape rows -- an in-band wildcard actor row, a real actor, a
+    # group grant and an exact duplicate pair (possible before m003 because
+    # the original UNIQUE constraint never fired across NULLs) -- plus audit
+    # rows, then run the remaining migrations (m003 + m004). The end state is
+    # the audience model: the wildcard row becomes principal_type
+    # 'authenticated' with no id, duplicates collapse, ids are preserved.
     db = Database(memory=True)
     internal_migrations.apply(db, stop_before="m003_principal_type")
 
@@ -609,7 +612,7 @@ def test_principal_type_migration():
     db.execute("insert into acl_actions (name) values ('doc-view')")
     db.execute("insert into acl_groups (name) values ('staff')")
     insert = "insert into acl (actor_id, group_id, resource_id, action_id) values (?, ?, 1, 1)"
-    db.execute(insert, ["_signed_in", None])  # (a) wildcard actor row
+    db.execute(insert, ["_signed_in", None])  # (a) in-band wildcard row
     db.execute(insert, ["alice", None])  # (b) real-actor row
     db.execute(insert, [None, 1])  # (c) group row
     db.execute(insert, ["alice", None])  # (d) exact duplicate of (b)
@@ -629,10 +632,10 @@ def test_principal_type_migration():
             "select acl_id, principal_type, actor_id, group_id from acl order by acl_id"
         )
     )
-    # Types backfilled, the duplicate pair collapsed to one row, ids preserved
-    # (min(acl_id) per surviving group).
+    # Types backfilled, the legacy wildcard translated to its audience type
+    # (with no id), the duplicate pair collapsed to one row, ids preserved.
     assert rows == [
-        {"acl_id": 1, "principal_type": "public", "actor_id": "_signed_in", "group_id": None},
+        {"acl_id": 1, "principal_type": "authenticated", "actor_id": None, "group_id": None},
         {"acl_id": 2, "principal_type": "actor", "actor_id": "alice", "group_id": None},
         {"acl_id": 3, "principal_type": "group", "actor_id": None, "group_id": 1},
     ]
@@ -643,20 +646,26 @@ def test_principal_type_migration():
         db.query("select principal_type, actor_id, group_id from acl_audit order by id")
     )
     assert audit == [
-        {"principal_type": "public", "actor_id": "_signed_in", "group_id": None},
+        {"principal_type": "authenticated", "actor_id": None, "group_id": None},
         {"principal_type": "actor", "actor_id": "alice", "group_id": None},
         {"principal_type": "group", "actor_id": None, "group_id": 1},
     ]
 
-    # The new partial unique indexes actually dedupe: INSERT OR IGNORE of an
-    # existing (principal_type, actor_id, resource, action) is a no-op.
+    # The partial unique indexes actually dedupe: INSERT OR IGNORE of an
+    # existing (actor, resource, action) is a no-op.
     db.execute(
         "insert or ignore into acl (principal_type, actor_id, group_id, resource_id, action_id) "
         "values ('actor', 'alice', null, 1, 1)"
     )
     assert db.execute("select count(*) from acl").fetchone()[0] == 3
-    # ...while ('public', '_signed_in') and ('actor', '_signed_in') coexist as
-    # distinct rows -- the disambiguation this migration exists for.
+    # ...and a duplicate audience row is also a no-op (acl_public_unique).
+    db.execute(
+        "insert or ignore into acl (principal_type, actor_id, group_id, resource_id, action_id) "
+        "values ('authenticated', null, null, 1, 1)"
+    )
+    assert db.execute("select count(*) from acl").fetchone()[0] == 3
+    # An actor whose id merely looks like an old wildcard is an ordinary actor
+    # row, coexisting with the audience grant.
     db.execute(
         "insert or ignore into acl (principal_type, actor_id, group_id, resource_id, action_id) "
         "values ('actor', '_signed_in', null, 1, 1)"
@@ -667,7 +676,9 @@ def test_principal_type_migration():
     import sqlite3
 
     for bad in (
-        ("public", "bob", None),  # public with a non-wildcard id
+        ("everyone", "bob", None),  # audience with an actor_id
+        ("anonymous", None, 1),  # audience with a group_id
+        ("actor", None, None),  # actor without an id
         ("actor", "carol", 1),  # actor with a group_id
         ("group", "carol", None),  # group with an actor_id
         ("alien", "dave", None),  # unknown principal_type
@@ -682,6 +693,60 @@ def test_principal_type_migration():
     # Re-applying is idempotent.
     internal_migrations.apply(db)
     assert db.execute("select count(*) from acl").fetchone()[0] == 4
+
+
+def test_public_principal_types_migration():
+    # m004 specifically: start from the intermediate m003 shape (audiences
+    # stored in-band as 'public' rows with wildcard actor_ids), insert every
+    # wildcard plus a coexisting like-named actor row, then run m004 and
+    # assert each 'public' row converts to its audience type with the id
+    # dropped -- while actor and group rows pass through untouched.
+    db = Database(memory=True)
+    internal_migrations.apply(db, stop_before="m004_public_principal_types")
+
+    db.execute("insert into acl_resources (resource_type, parent) values ('doc', '42')")
+    db.execute("insert into acl_actions (name) values ('doc-view')")
+    db.execute("insert into acl_groups (name) values ('staff')")
+    insert = (
+        "insert into acl (principal_type, actor_id, group_id, resource_id, action_id) "
+        "values (?, ?, ?, 1, 1)"
+    )
+    db.execute(insert, ["public", "*", None])
+    db.execute(insert, ["public", "_signed_in", None])
+    db.execute(insert, ["public", "_anonymous", None])
+    db.execute(insert, ["actor", "_signed_in", None])  # like-named real actor
+    db.execute(insert, ["group", None, 1])
+    db.execute(
+        """
+        insert into acl_audit (operation, principal_type, actor_id, group_id, resource_id, action_id)
+        values ('added', 'public', '*', null, 1, 1),
+               ('added', 'actor', '_signed_in', null, 1, 1)
+        """
+    )
+
+    internal_migrations.apply(db)
+
+    rows = list(
+        db.query(
+            "select acl_id, principal_type, actor_id, group_id from acl order by acl_id"
+        )
+    )
+    assert rows == [
+        {"acl_id": 1, "principal_type": "everyone", "actor_id": None, "group_id": None},
+        {"acl_id": 2, "principal_type": "authenticated", "actor_id": None, "group_id": None},
+        {"acl_id": 3, "principal_type": "anonymous", "actor_id": None, "group_id": None},
+        {"acl_id": 4, "principal_type": "actor", "actor_id": "_signed_in", "group_id": None},
+        {"acl_id": 5, "principal_type": "group", "actor_id": None, "group_id": 1},
+    ]
+    assert "acl_old" not in db.table_names()
+
+    audit = list(
+        db.query("select principal_type, actor_id from acl_audit order by id")
+    )
+    assert audit == [
+        {"principal_type": "everyone", "actor_id": None},
+        {"principal_type": "actor", "actor_id": "_signed_in"},
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> Note: This PR comment is LLM-generated

**Summary:** Resources can now be shared with general-access audiences — anyone, any signed-in user, or anonymous visitors only — from a new **General access** section on the resource ACL admin page, via the JSON API, and via the Python helpers. Under the hood, every grant carries an explicit `principal_type` (`actor`, `group`, `everyone`, `authenticated`, `anonymous`); public audiences are first-class types that store **no id at all**, replacing the legacy in-band wildcard actor ids (`*`, `_signed_in`, `_anonymous`). This eliminates the reserved-actor-id namespace and, with it, the `_anonymous` privilege leak and the like-named-user revoke hazard — by construction rather than by guard.

## Admin UI

- The generic resource page (`/-/acl/resource/<type>/<parent>/<child>`) gains a **General access** section: one always-present multi-select per audience (unchecking revokes, same as groups), with friendly labels — "Anyone (signed in or not)", "Any signed-in user", "Signed-out (anonymous) visitors only".
- Both audit tables render a single **Principal** column driven by `principal_type`: `daily-planet (group)`, `Any signed-in user (general access)`, plain ids for actors. No raw wildcard strings appear anywhere.

## Storage model

A single clean `m001_initial` migration defines the schema (earlier in-development migrations were collapsed before release, so there is no legacy data to translate). The `acl` table:

- carries the `principal_type` discriminator, with a CHECK constraint pinning which of `actor_id` / `group_id` may be set per type — audiences require both NULL;
- dedupes via three **partial unique indexes** (actor, group, public), since a plain `UNIQUE` across always-nullable principal columns never fires in SQLite.

Audiences match on `principal_type` alone, so an actor whose id merely looks like an old wildcard (e.g. a user literally named `_signed_in`) is just an ordinary actor row, coexisting with audience grants.

## Enforcement

The `permission_resources_sql` hook branches purely on `principal_type` — e.g. `(:actor_id IS NOT NULL AND a.principal_type = 'authenticated')`. No string literals, no inference.

## Python API

A `Principal` value object is the single place that validates the "exactly one principal" invariant. `grant()` / `revoke()` / `update_role()` take one `principal=`:

```python
from datasette_acl.grants import grant, Principal

await grant(datasette, "doc", "doc1", principal=Principal.authenticated(), role="Viewer")
await grant(datasette, "doc", "doc1", principal=Principal.actor("alice"), role="Editor")
await grant(datasette, "doc", "doc1", principal=Principal.group(7), actions=["doc-view"])
```

`Principal.from_parts(actor_id, group_id, principal_type)` resolves the looser combination that arrives from a request body. `list_grants()` returns `principal` straight from the stored column, ordered actors → groups → audiences.

## JSON API

The request surface is unchanged — a mutation body names exactly one principal:

- Grant an audience with `{"principal_type": "authenticated", "role": "Viewer"}` (no id).
- Audience entries render as `{"principal": "public", "id": "<audience>", "kind": "public", "display_name": "<label>", ...}` and are never run through actor enrichment.
- ⚠️ One deliberate semantic change: `{"actor_id": "*"}` is no longer a public grant — it stores a literal actor named `*` that matches nobody. That form never shipped in a release.

## Dev tooling

`just dev` runs datasette with the widgets sample plugin (`tests/sample-plugin`) and datasette-debug-gotham for manually exercising the ACL pages, with dynamic groups wired to the gotham actors' `newsroom` attribute; `just test` runs the suite.

## Tests & docs

125 tests pass, covering: audience enforcement (everyone / authenticated / anonymous); the no-collision regression (an `anonymous` grant never matches a signed-in actor, whatever their id); coexistence and independent revocation of an audience grant and a like-named actor grant; dedup via the partial unique indexes; CHECK-constraint rejection of malformed rows; and JSON API shapes. README and docs/json-api.md are written around the five principal types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
