### PR TITLE
3/5 principal_type: explicit storage model + enforcement + JSON API

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,32 +221,37 @@ def datasette_acl_valid_actors(datasette):
 
 `datasette_acl.grants` provides async helpers so other plugins can read and modify grants without writing raw SQL against the ACL tables. Each call resolves the `(resource_type, parent, child)` resource, writes the `acl` rows, and appends audit entries attributed to `by_actor`.
 
-Provide exactly one principal (`actor_id=` or `group_id=`), and for `grant()` exactly one of `role=` or `actions=`.
+The principal — who a grant targets — is a `Principal` value object, built via one of its constructors: `Principal.actor(id)`, `Principal.group(id)`, or a [public audience](#principals-and-general-access) `Principal.everyone()` / `Principal.authenticated()` / `Principal.anonymous()`. Pass it as `principal=`, and for `grant()` supply exactly one of `role=` or `actions=`:
 
 ```python
-from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.grants import grant, revoke, update_role, list_grants, Principal
+
+# Any signed-in user becomes a Viewer
+await grant(datasette, "doc", "doc1", principal=Principal.authenticated(), role="Viewer")
+# A specific user becomes an Editor
+await grant(datasette, "doc", "doc1", principal=Principal.actor("alice"), role="Editor")
 ```
 
 `grant(...)` — give a principal access, by raw actions or by a role (idempotent). Returns the actions now held. Role names come from the `datasette_acl_roles` hook:
 
 ```python
-await grant(datasette, "table", "mydb", "mytable", actor_id="alice", actions=["insert-row"])
-await grant(datasette, "table", "mydb", "mytable", group_id=3, actions=["insert-row"], by_actor="root")
+await grant(datasette, "table", "mydb", "mytable", principal=Principal.actor("alice"), actions=["insert-row"])
+await grant(datasette, "table", "mydb", "mytable", principal=Principal.group(3), actions=["insert-row"], by_actor="root")
 ```
 
 `update_role(...)` — atomically swap a principal's actions to exactly those of a registered `role`. Returns the new actions:
 
 ```python
-await update_role(datasette, "doc", "doc1", actor_id="alice", role="Viewer")
+await update_role(datasette, "doc", "doc1", principal=Principal.actor("alice"), role="Viewer")
 ```
 
 `revoke(...)` — remove all of a principal's grants on a resource. Returns the actions that were removed:
 
 ```python
-await revoke(datasette, "table", "mydb", "mytable", actor_id="alice")
+await revoke(datasette, "table", "mydb", "mytable", principal=Principal.actor("alice"))
 ```
 
-`list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`):
+`list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`, where `principal` is the stored `principal_type`; audience grants carry no id):
 
 ```python
 grants = await list_grants(datasette, "table", "mydb", "mytable")

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -219,11 +219,15 @@ def permission_resources_sql(datasette, actor, action):
             await update_dynamic_groups(
                 datasette, actor, skip_cache=hasattr(sys, "_pytest_running")
             )
-        # General-access (wildcard) principals always apply:
-        #   '*'          -> anyone, including anonymous
-        #   '_signed_in' -> any actor that has an id (only when signed in)
-        #   '_anonymous' -> only unauthenticated callers (no actor id)
-        # Direct actor grants and group grants only apply when signed in.
+        # A grant's audience is named entirely by principal_type:
+        #   'actor'         -> the one actor whose id matches (signed in only)
+        #   'group'         -> members of the group (signed in only)
+        #   'everyone'      -> anyone, including anonymous
+        #   'authenticated' -> any caller that has an actor id
+        #   'anonymous'     -> only unauthenticated callers (no actor id)
+        # Public-audience rows store no id at all, so no reserved actor-id
+        # namespace exists: an actor's grants are only ever the 'actor' rows
+        # matching their literal id, whatever that id is.
         # NOTE: this must be a single SELECT statement with no leading CTE
         # (WITH ...). Datasette core inlines this SQL after a "UNION ALL" when
         # building its anon_rules block for include_is_private queries, and a
@@ -237,9 +241,11 @@ SELECT
     1 AS allow,
     'datasette-acl: ' || GROUP_CONCAT(
         CASE
-            WHEN a.actor_id IS NOT NULL
+            WHEN a.principal_type = 'group'
+                THEN 'group:' || g.name
+            WHEN a.principal_type = 'actor'
                 THEN 'actor:' || a.actor_id
-            ELSE 'group:' || g.name
+            ELSE a.principal_type
         END,
         ', '
     ) AS reason
@@ -250,18 +256,19 @@ LEFT JOIN acl_groups g ON a.group_id = g.id
 WHERE aa.name = :action
   AND ar.resource_type = :resource_type
   AND (
-    a.actor_id = '*'
-    OR (:actor_id IS NOT NULL AND a.actor_id = :actor_id)
-    OR (:actor_id IS NOT NULL AND a.actor_id = '_signed_in')
-    OR (:actor_id IS NULL AND a.actor_id = '_anonymous')
-    OR a.group_id IN (
+    a.principal_type = 'everyone'
+    OR (:actor_id IS NOT NULL
+        AND a.principal_type = 'actor' AND a.actor_id = :actor_id)
+    OR (:actor_id IS NOT NULL AND a.principal_type = 'authenticated')
+    OR (:actor_id IS NULL AND a.principal_type = 'anonymous')
+    OR (a.principal_type = 'group' AND a.group_id IN (
         SELECT ag.group_id
         FROM acl_actor_groups ag
         JOIN acl_groups ig ON ag.group_id = ig.id
         WHERE :actor_id IS NOT NULL
           AND ag.actor_id = :actor_id
           AND ig.deleted IS NULL
-    )
+    ))
   )
   AND (a.group_id IS NULL OR g.deleted IS NULL)
 GROUP BY ar.parent, ar.child
@@ -329,8 +336,9 @@ def track_event(datasette, event):
         )
         await db.execute_write_many(
             """
-            INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+            INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
             VALUES (
+                'actor',
                 :actor_id,
                 null,
                 :resource_id,

--- a/datasette_acl/grants.py
+++ b/datasette_acl/grants.py
@@ -11,17 +11,18 @@ Every mutating helper:
   * writes the ``acl`` rows, and
   * appends ``acl_audit`` entries (``operation_by`` = ``by_actor``).
 
-Principal invariant: a grant targets exactly one principal -- an actor
-(``actor_id=``), a group (``group_id=``), or a public audience
-(``principal_type=`` one of ``'everyone'`` / ``'authenticated'`` /
-``'anonymous'``, with no id at all) -- matching the CHECK constraint on the
-``acl`` table. :func:`principal_type_for` is the single place that resolves
-and validates the combination.
+Principal invariant: a grant targets exactly one principal -- an actor, a
+group, or a public audience -- matching the CHECK constraint on the ``acl``
+table. The :class:`Principal` value object is the single place that resolves
+and validates the combination; every helper takes one ``principal`` rather
+than threading ``(principal_type, actor_id, group_id)`` around by hand.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import (
+    Dict,
     Iterable,
     List,
     Literal,
@@ -40,6 +41,127 @@ if TYPE_CHECKING:
 
 
 PrincipalType = Literal["actor", "group", "everyone", "authenticated", "anonymous"]
+
+
+@dataclass(frozen=True)
+class Principal:
+    """A grant's target: an actor, a group, or a public audience.
+
+    Build one via the classmethods rather than the raw constructor so the
+    "exactly one principal" invariant (which mirrors the ``acl`` CHECK
+    constraint) is enforced in a single place::
+
+        Principal.actor("alice")
+        Principal.group(7)
+        Principal.everyone()        # / .authenticated() / .anonymous()
+        Principal.public("everyone")
+
+    :meth:`from_parts` resolves the looser ``(actor_id, group_id,
+    principal_type)`` combination that arrives from a request body, validating
+    it the same way. :meth:`where_sql` / :meth:`sql_params` produce the
+    principal-matching SQL fragment shared by every read/write helper.
+    """
+
+    principal_type: PrincipalType
+    actor_id: Optional[str] = None
+    group_id: Optional[int] = None
+
+    @classmethod
+    def actor(cls, actor_id: str) -> "Principal":
+        if actor_id is None:
+            raise ValueError("actor principal requires an actor_id")
+        return cls("actor", actor_id=actor_id)
+
+    @classmethod
+    def group(cls, group_id: int) -> "Principal":
+        if group_id is None:
+            raise ValueError("group principal requires a group_id")
+        return cls("group", group_id=group_id)
+
+    @classmethod
+    def public(cls, principal_type: str) -> "Principal":
+        if principal_type not in PUBLIC_PRINCIPAL_TYPES:
+            raise ValueError(
+                f"Unknown public principal_type {principal_type!r}; expected "
+                f"one of {', '.join(sorted(PUBLIC_PRINCIPAL_TYPES))}"
+            )
+        return cls(principal_type)
+
+    @classmethod
+    def everyone(cls) -> "Principal":
+        return cls("everyone")
+
+    @classmethod
+    def authenticated(cls) -> "Principal":
+        return cls("authenticated")
+
+    @classmethod
+    def anonymous(cls) -> "Principal":
+        return cls("anonymous")
+
+    @classmethod
+    def from_parts(
+        cls,
+        actor_id: Optional[str],
+        group_id: Optional[int],
+        principal_type: Optional[str] = None,
+    ) -> "Principal":
+        """Resolve a principal from a loose ``(actor_id, group_id, type)`` set.
+
+        A principal is exactly one of: an actor (``actor_id``), a group
+        (``group_id``), or a public audience (``principal_type`` in
+        ``PUBLIC_PRINCIPAL_TYPES``, with neither id). ``principal_type`` may
+        also redundantly name ``'actor'`` / ``'group'`` alongside the matching
+        id. Raises ``ValueError`` for any other combination, mirroring the
+        acl table's CHECK constraint.
+        """
+        if principal_type in PUBLIC_PRINCIPAL_TYPES:
+            if actor_id is not None or group_id is not None:
+                raise ValueError(
+                    f"principal_type {principal_type!r} cannot be combined "
+                    "with actor_id= or group_id="
+                )
+            return cls(principal_type)
+        if (actor_id is None) == (group_id is None):
+            raise ValueError(
+                "Provide exactly one principal: actor_id=, group_id=, or a "
+                f"public principal_type ({', '.join(PUBLIC_PRINCIPAL_TYPES)})"
+            )
+        if group_id is not None:
+            if principal_type not in (None, "group"):
+                raise ValueError(
+                    f"principal_type {principal_type!r} cannot be used "
+                    "with group_id="
+                )
+            return cls("group", group_id=group_id)
+        if principal_type not in (None, "actor"):
+            raise ValueError(
+                f"principal_type {principal_type!r} cannot be used "
+                "with actor_id="
+            )
+        return cls("actor", actor_id=actor_id)
+
+    def where_sql(self, alias: Optional[str] = None) -> str:
+        """SQL fragment matching this principal's acl rows.
+
+        ``alias`` qualifies the column references (e.g. ``"acl"`` for a joined
+        query); omit it for a single-table statement. Pair with
+        :meth:`sql_params` for the bind values.
+        """
+        col = f"{alias}." if alias else ""
+        if self.principal_type == "actor":
+            return f"{col}principal_type = 'actor' AND {col}actor_id = :actor_id"
+        if self.principal_type == "group":
+            return f"{col}principal_type = 'group' AND {col}group_id = :group_id"
+        # Public audience: the type alone identifies the principal.
+        return f"{col}principal_type = :principal_type"
+
+    def sql_params(self) -> Dict[str, object]:
+        return {
+            "principal_type": self.principal_type,
+            "actor_id": self.actor_id,
+            "group_id": self.group_id,
+        }
 
 
 class Grant(TypedDict):
@@ -93,45 +215,6 @@ def _resolve_actions(
     return requested
 
 
-def principal_type_for(
-    actor_id: Optional[str],
-    group_id: Optional[int],
-    principal_type: Optional[str] = None,
-) -> PrincipalType:
-    """Resolve and validate the ``principal_type`` for a grant's principal.
-
-    A principal is exactly one of: an actor (``actor_id=``), a group
-    (``group_id=``), or a public audience (``principal_type=`` one of
-    ``PUBLIC_PRINCIPAL_TYPES``, with neither id). ``principal_type`` may also
-    redundantly name ``'actor'`` / ``'group'`` alongside the matching id.
-    Raises ``ValueError`` for any other combination, mirroring the acl table's
-    CHECK constraint.
-    """
-    if principal_type in PUBLIC_PRINCIPAL_TYPES:
-        if actor_id is not None or group_id is not None:
-            raise ValueError(
-                f"principal_type {principal_type!r} cannot be combined with "
-                "actor_id= or group_id="
-            )
-        return principal_type
-    if (actor_id is None) == (group_id is None):
-        raise ValueError(
-            "Provide exactly one principal: actor_id=, group_id=, or a "
-            f"public principal_type ({', '.join(PUBLIC_PRINCIPAL_TYPES)})"
-        )
-    if group_id is not None:
-        if principal_type not in (None, "group"):
-            raise ValueError(
-                f"principal_type {principal_type!r} cannot be used with group_id="
-            )
-        return "group"
-    if principal_type not in (None, "actor"):
-        raise ValueError(
-            f"principal_type {principal_type!r} cannot be used with actor_id="
-        )
-    return "actor"
-
-
 async def _ensure_resource_id(
     db: Database, resource_type: str, parent: str, child: Optional[str]
 ) -> int:
@@ -168,31 +251,17 @@ async def _ensure_actions(db: Database, actions: Iterable[str]) -> None:
 async def _current_actions(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
 ) -> Set[str]:
     """Return the set of action names currently granted to a principal."""
-    if principal_type == "actor":
-        where = "acl.principal_type = 'actor' AND acl.actor_id = :actor_id"
-    elif principal_type == "group":
-        where = "acl.principal_type = 'group' AND acl.group_id = :group_id"
-    else:
-        # Public audience: the type alone identifies the principal.
-        where = "acl.principal_type = :principal_type"
     rows = await db.execute(
         f"""
         SELECT acl_actions.name AS name
         FROM acl
         JOIN acl_actions ON acl.action_id = acl_actions.id
-        WHERE acl.resource_id = :resource_id AND {where}
+        WHERE acl.resource_id = :resource_id AND {principal.where_sql("acl")}
         """,
-        {
-            "resource_id": resource_id,
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
-        },
+        {"resource_id": resource_id, **principal.sql_params()},
     )
     return {row["name"] for row in rows.rows}
 
@@ -200,9 +269,7 @@ async def _current_actions(
 async def _insert_grant(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
@@ -220,68 +287,42 @@ async def _insert_grant(
         )
         """,
         {
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(
-        db, "added", resource_id, principal_type, actor_id, group_id, action_name, by_actor
-    )
+    await _audit(db, "added", resource_id, principal, action_name, by_actor)
 
 
 async def _delete_grant(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
-    if principal_type == "actor":
-        principal_where = "principal_type = 'actor' AND actor_id = :actor_id"
-    elif principal_type == "group":
-        principal_where = "principal_type = 'group' AND group_id = :group_id"
-    else:
-        # Public audience: the type alone identifies the principal.
-        principal_where = "principal_type = :principal_type"
     await db.execute_write(
         f"""
         DELETE FROM acl
-        WHERE {principal_where}
+        WHERE {principal.where_sql()}
           AND resource_id = :resource_id
           AND action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
         """,
         {
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(
-        db,
-        "removed",
-        resource_id,
-        principal_type,
-        actor_id,
-        group_id,
-        action_name,
-        by_actor,
-    )
+    await _audit(db, "removed", resource_id, principal, action_name, by_actor)
 
 
 async def _audit(
     db: Database,
     operation: Literal["added", "removed"],
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
@@ -302,9 +343,7 @@ async def _audit(
         """,
         {
             "operation": operation,
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
             "operation_by": by_actor,
@@ -318,33 +357,27 @@ async def grant(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     role: Optional[str] = None,
     actions: Optional[Iterable[str]] = None,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Grant a principal access to a resource, by role or by raw actions.
 
-    The principal is exactly one of ``actor_id=``, ``group_id=``, or a public
-    audience passed as ``principal_type=`` (``'everyone'`` /
-    ``'authenticated'`` / ``'anonymous'``, with neither id). Exactly one of
-    ``role`` / ``actions`` must be supplied. Only actions not already granted
-    are inserted (idempotent). Returns the list of action names now held by
-    the principal.
+    ``principal`` is a :class:`Principal` (``Principal.actor(...)`` /
+    ``.group(...)`` / ``.everyone()`` / etc). Exactly one of ``role`` /
+    ``actions`` must be supplied. Only actions not already granted are
+    inserted (idempotent). Returns the list of action names now held by the
+    principal.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = _resolve_actions(datasette, resource_type, role, actions)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in resolved:
         if action_name not in existing:
-            await _insert_grant(
-                db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-            )
+            await _insert_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(existing | set(resolved))
 
 
@@ -354,24 +387,19 @@ async def revoke(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Remove all acl rows for a principal on a resource. Audits each removal.
 
     The principal is specified as in :func:`grant`. Returns the list of action
     names that were removed.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in sorted(existing):
-        await _delete_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _delete_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(existing)
 
 
@@ -381,11 +409,9 @@ async def update_role(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     role: str,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Atomically swap a principal's action set on a resource to ``role``.
 
@@ -393,20 +419,15 @@ async def update_role(
     granted actions that are not in the new role, then adds any missing ones.
     Audits each change. Returns the new action list.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = set(_resolve_actions(datasette, resource_type, role, None))
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in sorted(existing - resolved):
-        await _delete_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _delete_grant(db, resource_id, principal, action_name, by_actor)
     for action_name in sorted(resolved - existing):
-        await _insert_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _insert_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(resolved)
 
 

--- a/datasette_acl/grants.py
+++ b/datasette_acl/grants.py
@@ -11,8 +11,12 @@ Every mutating helper:
   * writes the ``acl`` rows, and
   * appends ``acl_audit`` entries (``operation_by`` = ``by_actor``).
 
-Principal invariant: exactly one of ``actor_id`` / ``group_id`` is set, matching
-the CHECK constraint on the ``acl`` table.
+Principal invariant: a grant targets exactly one principal -- an actor
+(``actor_id=``), a group (``group_id=``), or a public audience
+(``principal_type=`` one of ``'everyone'`` / ``'authenticated'`` /
+``'anonymous'``, with no id at all) -- matching the CHECK constraint on the
+``acl`` table. :func:`principal_type_for` is the single place that resolves
+and validates the combination.
 """
 
 from __future__ import annotations
@@ -28,17 +32,25 @@ from typing import (
 )
 
 from datasette_acl.roles import actions_for_role, roles_for
-from datasette_acl.utils import actions_for_resource_type
+from datasette_acl.utils import PUBLIC_PRINCIPAL_TYPES, actions_for_resource_type
 
 if TYPE_CHECKING:
     from datasette.app import Datasette
     from datasette.database import Database
 
 
-class Grant(TypedDict):
-    """One principal's grants on a resource, as returned by :func:`list_grants`."""
+PrincipalType = Literal["actor", "group", "everyone", "authenticated", "anonymous"]
 
-    principal: Literal["actor", "group"]
+
+class Grant(TypedDict):
+    """One principal's grants on a resource, as returned by :func:`list_grants`.
+
+    ``principal`` is the stored ``principal_type``. ``actor_id`` is set only
+    for ``actor`` grants and ``group_id``/``group_name`` only for ``group``
+    grants; public-audience grants carry no id.
+    """
+
+    principal: PrincipalType
     actor_id: Optional[str]
     group_id: Optional[int]
     group_name: Optional[str]
@@ -81,10 +93,43 @@ def _resolve_actions(
     return requested
 
 
-def _check_principal(actor_id: Optional[str], group_id: Optional[int]) -> None:
-    """Enforce the acl CHECK invariant: exactly one of actor_id / group_id."""
+def principal_type_for(
+    actor_id: Optional[str],
+    group_id: Optional[int],
+    principal_type: Optional[str] = None,
+) -> PrincipalType:
+    """Resolve and validate the ``principal_type`` for a grant's principal.
+
+    A principal is exactly one of: an actor (``actor_id=``), a group
+    (``group_id=``), or a public audience (``principal_type=`` one of
+    ``PUBLIC_PRINCIPAL_TYPES``, with neither id). ``principal_type`` may also
+    redundantly name ``'actor'`` / ``'group'`` alongside the matching id.
+    Raises ``ValueError`` for any other combination, mirroring the acl table's
+    CHECK constraint.
+    """
+    if principal_type in PUBLIC_PRINCIPAL_TYPES:
+        if actor_id is not None or group_id is not None:
+            raise ValueError(
+                f"principal_type {principal_type!r} cannot be combined with "
+                "actor_id= or group_id="
+            )
+        return principal_type
     if (actor_id is None) == (group_id is None):
-        raise ValueError("Provide exactly one of actor_id= or group_id=")
+        raise ValueError(
+            "Provide exactly one principal: actor_id=, group_id=, or a "
+            f"public principal_type ({', '.join(PUBLIC_PRINCIPAL_TYPES)})"
+        )
+    if group_id is not None:
+        if principal_type not in (None, "group"):
+            raise ValueError(
+                f"principal_type {principal_type!r} cannot be used with group_id="
+            )
+        return "group"
+    if principal_type not in (None, "actor"):
+        raise ValueError(
+            f"principal_type {principal_type!r} cannot be used with actor_id="
+        )
+    return "actor"
 
 
 async def _ensure_resource_id(
@@ -121,13 +166,20 @@ async def _ensure_actions(db: Database, actions: Iterable[str]) -> None:
 
 
 async def _current_actions(
-    db: Database, resource_id: int, actor_id: Optional[str], group_id: Optional[int]
+    db: Database,
+    resource_id: int,
+    principal_type: PrincipalType,
+    actor_id: Optional[str],
+    group_id: Optional[int],
 ) -> Set[str]:
     """Return the set of action names currently granted to a principal."""
-    if actor_id is not None:
-        where = "acl.actor_id = :actor_id AND acl.group_id IS NULL"
+    if principal_type == "actor":
+        where = "acl.principal_type = 'actor' AND acl.actor_id = :actor_id"
+    elif principal_type == "group":
+        where = "acl.principal_type = 'group' AND acl.group_id = :group_id"
     else:
-        where = "acl.group_id = :group_id AND acl.actor_id IS NULL"
+        # Public audience: the type alone identifies the principal.
+        where = "acl.principal_type = :principal_type"
     rows = await db.execute(
         f"""
         SELECT acl_actions.name AS name
@@ -135,7 +187,12 @@ async def _current_actions(
         JOIN acl_actions ON acl.action_id = acl_actions.id
         WHERE acl.resource_id = :resource_id AND {where}
         """,
-        {"resource_id": resource_id, "actor_id": actor_id, "group_id": group_id},
+        {
+            "resource_id": resource_id,
+            "principal_type": principal_type,
+            "actor_id": actor_id,
+            "group_id": group_id,
+        },
     )
     return {row["name"] for row in rows.rows}
 
@@ -143,6 +200,7 @@ async def _current_actions(
 async def _insert_grant(
     db: Database,
     resource_id: int,
+    principal_type: PrincipalType,
     actor_id: Optional[str],
     group_id: Optional[int],
     action_name: str,
@@ -150,8 +208,11 @@ async def _insert_grant(
 ) -> None:
     await db.execute_write(
         """
-        INSERT OR IGNORE INTO acl (actor_id, group_id, resource_id, action_id)
+        INSERT OR IGNORE INTO acl (
+            principal_type, actor_id, group_id, resource_id, action_id
+        )
         VALUES (
+            :principal_type,
             :actor_id,
             :group_id,
             :resource_id,
@@ -159,27 +220,34 @@ async def _insert_grant(
         )
         """,
         {
+            "principal_type": principal_type,
             "actor_id": actor_id,
             "group_id": group_id,
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(db, "added", resource_id, actor_id, group_id, action_name, by_actor)
+    await _audit(
+        db, "added", resource_id, principal_type, actor_id, group_id, action_name, by_actor
+    )
 
 
 async def _delete_grant(
     db: Database,
     resource_id: int,
+    principal_type: PrincipalType,
     actor_id: Optional[str],
     group_id: Optional[int],
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
-    if actor_id is not None:
-        principal_where = "actor_id = :actor_id AND group_id IS NULL"
+    if principal_type == "actor":
+        principal_where = "principal_type = 'actor' AND actor_id = :actor_id"
+    elif principal_type == "group":
+        principal_where = "principal_type = 'group' AND group_id = :group_id"
     else:
-        principal_where = "group_id = :group_id AND actor_id IS NULL"
+        # Public audience: the type alone identifies the principal.
+        principal_where = "principal_type = :principal_type"
     await db.execute_write(
         f"""
         DELETE FROM acl
@@ -188,19 +256,30 @@ async def _delete_grant(
           AND action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
         """,
         {
+            "principal_type": principal_type,
             "actor_id": actor_id,
             "group_id": group_id,
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(db, "removed", resource_id, actor_id, group_id, action_name, by_actor)
+    await _audit(
+        db,
+        "removed",
+        resource_id,
+        principal_type,
+        actor_id,
+        group_id,
+        action_name,
+        by_actor,
+    )
 
 
 async def _audit(
     db: Database,
     operation: Literal["added", "removed"],
     resource_id: int,
+    principal_type: PrincipalType,
     actor_id: Optional[str],
     group_id: Optional[int],
     action_name: str,
@@ -209,9 +288,11 @@ async def _audit(
     await db.execute_write(
         """
         INSERT INTO acl_audit (
-            operation, actor_id, group_id, resource_id, action_id, operation_by
+            operation, principal_type, actor_id, group_id, resource_id,
+            action_id, operation_by
         ) VALUES (
             :operation,
+            :principal_type,
             :actor_id,
             :group_id,
             :resource_id,
@@ -221,6 +302,7 @@ async def _audit(
         """,
         {
             "operation": operation,
+            "principal_type": principal_type,
             "actor_id": actor_id,
             "group_id": group_id,
             "resource_id": resource_id,
@@ -241,23 +323,27 @@ async def grant(
     role: Optional[str] = None,
     actions: Optional[Iterable[str]] = None,
     by_actor: Optional[str] = None,
+    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Grant a principal access to a resource, by role or by raw actions.
 
-    Exactly one of ``actor_id`` / ``group_id`` and exactly one of ``role`` /
-    ``actions`` must be supplied. Only actions not already granted are inserted
-    (idempotent). Returns the list of action names now held by the principal.
+    The principal is exactly one of ``actor_id=``, ``group_id=``, or a public
+    audience passed as ``principal_type=`` (``'everyone'`` /
+    ``'authenticated'`` / ``'anonymous'``, with neither id). Exactly one of
+    ``role`` / ``actions`` must be supplied. Only actions not already granted
+    are inserted (idempotent). Returns the list of action names now held by
+    the principal.
     """
-    _check_principal(actor_id, group_id)
+    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = _resolve_actions(datasette, resource_type, role, actions)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
     for action_name in resolved:
         if action_name not in existing:
             await _insert_grant(
-                db, resource_id, actor_id, group_id, action_name, by_actor
+                db, resource_id, ptype, actor_id, group_id, action_name, by_actor
             )
     return sorted(existing | set(resolved))
 
@@ -271,18 +357,20 @@ async def revoke(
     actor_id: Optional[str] = None,
     group_id: Optional[int] = None,
     by_actor: Optional[str] = None,
+    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Remove all acl rows for a principal on a resource. Audits each removal.
 
-    Returns the list of action names that were removed.
+    The principal is specified as in :func:`grant`. Returns the list of action
+    names that were removed.
     """
-    _check_principal(actor_id, group_id)
+    ptype = principal_type_for(actor_id, group_id, principal_type)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
-    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
     for action_name in sorted(existing):
         await _delete_grant(
-            db, resource_id, actor_id, group_id, action_name, by_actor
+            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
         )
     return sorted(existing)
 
@@ -297,25 +385,27 @@ async def update_role(
     group_id: Optional[int] = None,
     role: str,
     by_actor: Optional[str] = None,
+    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Atomically swap a principal's action set on a resource to ``role``.
 
-    Removes any currently-granted actions that are not in the new role, then
-    adds any missing ones. Audits each change. Returns the new action list.
+    The principal is specified as in :func:`grant`. Removes any currently-
+    granted actions that are not in the new role, then adds any missing ones.
+    Audits each change. Returns the new action list.
     """
-    _check_principal(actor_id, group_id)
+    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = set(_resolve_actions(datasette, resource_type, role, None))
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
     for action_name in sorted(existing - resolved):
         await _delete_grant(
-            db, resource_id, actor_id, group_id, action_name, by_actor
+            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
         )
     for action_name in sorted(resolved - existing):
         await _insert_grant(
-            db, resource_id, actor_id, group_id, action_name, by_actor
+            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
         )
     return sorted(resolved)
 
@@ -328,15 +418,17 @@ async def list_grants(
 ) -> List[Grant]:
     """Return the grants on a resource as a list of dicts.
 
-    Each dict is ``{"principal": "actor"|"group", "actor_id", "group_id",
-    "group_name", "actions": [...]}`` with actions sorted. Group grants whose
-    group is soft-deleted are omitted. The list is ordered by principal then id.
+    Each dict is a :class:`Grant` with actions sorted; ``principal`` comes
+    straight from the stored ``principal_type`` column. Group grants whose
+    group is soft-deleted are omitted. The list is ordered actors first, then
+    groups, then public audiences, then by id.
     """
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     rows = await db.execute(
         """
         SELECT
+            acl.principal_type AS principal_type,
             acl.actor_id AS actor_id,
             acl.group_id AS group_id,
             acl_groups.name AS group_name,
@@ -351,24 +443,28 @@ async def list_grants(
     )
     grants = {}
     for row in rows.rows:
-        if row["actor_id"] is not None:
-            key = ("actor", row["actor_id"], None, None)
-        else:
-            key = ("group", None, row["group_id"], row["group_name"])
+        key = (
+            row["principal_type"],
+            row["actor_id"],
+            row["group_id"],
+            row["group_name"],
+        )
         grants.setdefault(key, set()).add(row["action_name"])
     out: List[Grant] = []
-    for (_principal, actor_id, group_id, group_name), action_set in grants.items():
+    for (principal, actor_id, group_id, group_name), action_set in grants.items():
         out.append(
             {
-                "principal": "actor" if actor_id is not None else "group",
+                "principal": principal,
                 "actor_id": actor_id,
                 "group_id": group_id,
                 "group_name": group_name,
                 "actions": sorted(action_set),
             }
         )
+    kind_order = {"actor": 0, "group": 1}
     out.sort(
         key=lambda g: (
+            kind_order.get(g["principal"], 2),
             g["principal"],
             g["actor_id"] or "",
             g["group_id"] or 0,

--- a/datasette_acl/internal_migrations.py
+++ b/datasette_acl/internal_migrations.py
@@ -15,11 +15,14 @@ internal_migrations = Migrations("datasette-acl.internal")
 @internal_migrations()
 def m001_initial(db: Database):
     db.executescript("""
+    -- Resources are identified by (resource_type, parent, child); a table is
+    -- ('table', database, table_name), other resource types use what they need.
     create table if not exists acl_resources (
         id integer primary key,
-        database text not null,
-        resource text,
-        unique(database, resource)
+        resource_type text not null,
+        parent text not null,
+        child text,
+        unique(resource_type, parent, child)
     );
 
     create table if not exists acl_actions (
@@ -27,14 +30,13 @@ def m001_initial(db: Database):
         name text not null unique
     );
 
-    -- new table for groups
     create table if not exists acl_groups (
         id integer primary key,
         name text not null unique,
         deleted integer
     );
 
-    -- new table for actor-group relationships
+    -- actor-group membership
     create table if not exists acl_actor_groups (
         actor_id text,
         group_id integer,
@@ -42,7 +44,7 @@ def m001_initial(db: Database):
         foreign key (group_id) references acl_groups(id)
     );
 
-    -- Group membership audit log
+    -- group membership audit log
     create table if not exists acl_groups_audit (
         id integer primary key,
         timestamp text default (datetime('now')),
@@ -53,18 +55,45 @@ def m001_initial(db: Database):
         foreign key (group_id) references acl_groups(id)
     );
 
+    -- A grant's audience is named entirely by principal_type:
+    --   'actor'         -> a specific actor_id
+    --   'group'         -> a specific group_id
+    --   'everyone'      -> any caller, signed in or not (no id)
+    --   'authenticated' -> any signed-in caller (no id)
+    --   'anonymous'     -> signed-out callers only (no id)
+    -- The CHECK pins which of actor_id / group_id may be set for each type.
     create table if not exists acl (
         acl_id integer primary key,
+        principal_type text not null
+            check (principal_type in (
+                'actor', 'group', 'everyone', 'authenticated', 'anonymous'
+            )),
         actor_id text,
         group_id integer,
-        resource_id integer,
-        action_id integer,
+        resource_id integer not null,
+        action_id integer not null,
         foreign key (group_id) references acl_groups(id),
         foreign key (resource_id) references acl_resources(id),
         foreign key (action_id) references acl_actions(id),
-        check ((actor_id is null) != (group_id is null)),
-        unique(actor_id, group_id, resource_id, action_id)
+        check (
+            (principal_type = 'actor' and actor_id is not null and group_id is null)
+            or (principal_type = 'group' and group_id is not null and actor_id is null)
+            or (principal_type in ('everyone', 'authenticated', 'anonymous')
+                and actor_id is null and group_id is null)
+        )
     );
+    -- Partial unique indexes dedupe per principal kind (a plain UNIQUE across
+    -- the nullable principal columns wouldn't fire, since SQLite treats NULLs
+    -- as distinct).
+    create unique index acl_actor_unique
+        on acl (actor_id, resource_id, action_id)
+        where actor_id is not null;
+    create unique index acl_group_unique
+        on acl (group_id, resource_id, action_id)
+        where group_id is not null;
+    create unique index acl_public_unique
+        on acl (principal_type, resource_id, action_id)
+        where actor_id is null and group_id is null;
 
     -- ACL audit log
     create table if not exists acl_audit (
@@ -72,6 +101,7 @@ def m001_initial(db: Database):
         timestamp text default (datetime('now')),
         operation_by text,
         operation text check (operation in ('added', 'removed')),
+        principal_type text,
         action_id integer,
         resource_id integer,
         group_id integer,
@@ -80,25 +110,4 @@ def m001_initial(db: Database):
         foreign key (resource_id) references acl_resources(id),
         foreign key (action_id) references acl_actions(id)
     );
-    """)
-
-
-@internal_migrations()
-def m002_generalize_acl_resources(db: Database):
-    # Generalize acl_resources from the table-only (database, resource) shape to
-    # (resource_type, parent, child) so any resource type can be tracked.
-    # Existing rows are tables, so backfill resource_type='table', preserving
-    # ids. SQLite can't rename/retype columns in place, so rewrite the table.
-    db.executescript("""
-    ALTER TABLE acl_resources RENAME TO acl_resources_old;
-    CREATE TABLE acl_resources (
-        id integer primary key,
-        resource_type text not null,
-        parent text not null,
-        child text,
-        unique(resource_type, parent, child)
-    );
-    INSERT INTO acl_resources (id, resource_type, parent, child)
-        SELECT id, 'table', database, resource FROM acl_resources_old;
-    DROP TABLE acl_resources_old;
     """)

--- a/datasette_acl/utils.py
+++ b/datasette_acl/utils.py
@@ -9,6 +9,20 @@ if TYPE_CHECKING:
     from datasette.permissions import Resource
 
 
+# Public / "general access" principal types. Each is a first-class
+# principal_type value on acl rows (alongside 'actor' and 'group') matching a
+# class of caller rather than a specific person; public rows store no id at
+# all. Maps principal_type to the label shown in admin UIs; dict order is
+# display order. The set is closed by design and duplicated in the acl table's
+# CHECK constraint (internal_migrations.m004) -- adding an audience requires a
+# deliberate migration.
+PUBLIC_PRINCIPAL_TYPES = {
+    "everyone": "Anyone (signed in or not)",
+    "authenticated": "Any signed-in user",
+    "anonymous": "Signed-out (anonymous) visitors only",
+}
+
+
 async def can_edit_permissions(datasette, actor):
     return await datasette.allowed(actor=actor, action="datasette-acl")
 

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -10,9 +10,10 @@ grouped by principal, each principal's granted action-set is resolved to a
 friendly role, and actor grants are enriched with display name / email / avatar
 via core ``datasette.actors_from_ids`` (owned by user-profiles in phase-03;
 degrades to ``{"id": id}`` when profiles is not installed). Group grants resolve
-to a name + member count from ``acl_groups`` / ``acl_actor_groups``. Wildcard
-principals (``*`` / ``_signed_in`` / ``_anonymous``) are flagged ``kind:"public"``
-and surface in the dialog's "General access" section.
+to a name + member count from ``acl_groups`` / ``acl_actor_groups``. Public-
+audience grants (principal_type ``everyone`` / ``authenticated`` /
+``anonymous``) are flagged ``kind:"public"`` and surface in the dialog's
+"General access" section.
 
 Task 04 adds the *write* side — three JSON POST endpoints, each authorized by a
 **per-resource** manage check rather than a global flag:
@@ -43,9 +44,16 @@ import json
 
 from datasette import Response, Forbidden
 
-from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.grants import (
+    grant,
+    revoke,
+    update_role,
+    list_grants,
+    principal_type_for,
+)
 from datasette_acl.roles import role_for_actions, roles_for
 from datasette_acl.utils import (
+    PUBLIC_PRINCIPAL_TYPES,
     build_resource,
     can_manage,
     resource_class_for,
@@ -53,11 +61,6 @@ from datasette_acl.utils import (
     can_edit_permissions,
     get_acl_valid_actors,
 )
-
-# Wildcard / "general access" principals. These are stored as actor_id values in
-# acl rows but represent classes of actor rather than a specific person, so the
-# UI renders them in a separate "General access" section.
-PUBLIC_PRINCIPALS = {"*", "_signed_in", "_anonymous"}
 
 
 def _roles_payload(roles):
@@ -89,14 +92,12 @@ async def _ensure_can_manage(datasette, request, resource_type, parent, child=No
         raise Forbidden("Cannot manage sharing for this resource")
 
 
-def _kind_for(actor_id, enriched):
-    """Resolve the ``kind`` for an actor-principal grant.
+def _kind_for(enriched):
+    """Resolve the ``kind`` for an actor grant.
 
-    Wildcard principals are ``public``. Otherwise prefer a ``kind`` supplied by
-    the actor-resolution layer (profiles / agents); default to ``user``.
+    Prefer a ``kind`` supplied by the actor-resolution layer (profiles /
+    agents); default to ``user``.
     """
-    if actor_id in PUBLIC_PRINCIPALS:
-        return "public"
     if enriched and enriched.get("kind"):
         return enriched["kind"]
     return "user"
@@ -132,19 +133,36 @@ def _actor_entry(actor_id, role, actions, info):
 
     Pure shape-builder shared by the batched GET loop and the per-principal
     mutation helper, so both produce the identical entry shape. ``info`` is the
-    actor's ``actors_from_ids`` record (``{}`` for wildcard / unknown actors).
+    actor's ``actors_from_ids`` record (``{}`` for unknown actors).
     """
     entry = {
         "principal": "actor",
         "id": actor_id,
         "role": role.name if role else None,
         "actions": sorted(actions),
-        "kind": _kind_for(actor_id, info),
+        "kind": _kind_for(info),
     }
     for key in ("display_name", "email", "avatar_url"):
         if info.get(key):
             entry[key] = info[key]
     return entry
+
+
+def _public_entry(principal_type, role, actions):
+    """Assemble a public-audience grant entry.
+
+    ``principal_type`` is one of ``PUBLIC_PRINCIPAL_TYPES`` and doubles as the
+    entry ``id`` (audiences have no stored id); clients group these into the
+    "General access" section via ``kind: "public"``.
+    """
+    return {
+        "principal": "public",
+        "id": principal_type,
+        "role": role.name if role else None,
+        "actions": sorted(actions),
+        "kind": "public",
+        "display_name": PUBLIC_PRINCIPAL_TYPES[principal_type],
+    }
 
 
 def _group_entry(group_id, role, actions, info, fallback_name=None):
@@ -167,15 +185,13 @@ def _group_entry(group_id, role, actions, info, fallback_name=None):
 
 
 async def _actor_grant_entry(datasette, roles, actor_id, actions):
-    """Build the enriched API entry for one actor-principal grant.
+    """Build the enriched API entry for one actor grant.
 
     Resolves the granted action-set to its best role, enriches via core
-    ``actors_from_ids`` (skipped for wildcard principals), and tags ``kind``.
+    ``actors_from_ids``, and tags ``kind``.
     """
     role = role_for_actions(roles, set(actions))
-    enriched = {}
-    if actor_id not in PUBLIC_PRINCIPALS:
-        enriched = (await datasette.actors_from_ids([actor_id])) or {}
+    enriched = (await datasette.actors_from_ids([actor_id])) or {}
     return _actor_entry(actor_id, role, actions, enriched.get(actor_id) or {})
 
 
@@ -187,17 +203,21 @@ async def _group_grant_entry(datasette, roles, group_id, actions):
 
 
 def _principal_from_body(body):
-    """Extract ``(actor_id, group_id)`` from a request body, enforcing exactly one.
+    """Extract ``(actor_id, group_id, principal_type)`` from a request body.
 
-    Returns ``(actor_id, group_id)`` with exactly one non-None. Raises
-    ``ValueError`` if neither or both are supplied (mirrors the acl CHECK
-    invariant) so handlers can translate it to a 400.
+    The principal is exactly one of ``actor_id``, ``group_id``, or a public
+    audience named by ``principal_type`` (``"everyone"`` / ``"authenticated"``
+    / ``"anonymous"`` with neither id). Raises ``ValueError`` for invalid
+    combinations (via :func:`principal_type_for`) so handlers can translate it
+    to a 400.
     """
     actor_id = body.get("actor_id")
     group_id = body.get("group_id")
-    if (actor_id is None) == (group_id is None):
-        raise ValueError("Provide exactly one of actor_id or group_id")
-    return actor_id, group_id
+    principal_type = body.get("principal_type")
+    # Validates the combination eagerly (exactly-one principal, no audience
+    # alongside an id, no 'group' alongside actor_id).
+    principal_type_for(actor_id, group_id, principal_type)
+    return actor_id, group_id, principal_type
 
 
 def _parse_json_body(request_body):
@@ -213,11 +233,16 @@ def _parse_json_body(request_body):
     return data
 
 
-async def _enriched_grant(datasette, roles, actor_id, group_id, actions):
+async def _enriched_grant(
+    datasette, roles, actor_id, group_id, actions, principal_type=None
+):
     """Build the enriched grant entry for whichever principal was supplied."""
     if actor_id is not None:
         return await _actor_grant_entry(datasette, roles, actor_id, actions)
-    return await _group_grant_entry(datasette, roles, group_id, actions)
+    if group_id is not None:
+        return await _group_grant_entry(datasette, roles, group_id, actions)
+    role = role_for_actions(roles, set(actions))
+    return _public_entry(principal_type, role, actions)
 
 
 async def resource_grants_json(request, datasette):
@@ -249,13 +274,9 @@ async def resource_grants_json(request, datasette):
     roles = roles_for(datasette, resource_type)
     raw_grants = await list_grants(datasette, resource_type, parent, child)
 
-    # Enrich actor grants in one batch via core actors_from_ids. Wildcard
-    # principals are not real actors; we never look them up.
-    actor_ids = [
-        g["actor_id"]
-        for g in raw_grants
-        if g["principal"] == "actor" and g["actor_id"] not in PUBLIC_PRINCIPALS
-    ]
+    # Enrich actor grants in one batch via core actors_from_ids. Public
+    # audiences are not real actors; we never look them up.
+    actor_ids = [g["actor_id"] for g in raw_grants if g["principal"] == "actor"]
     enriched = {}
     if actor_ids:
         enriched = await datasette.actors_from_ids(actor_ids) or {}
@@ -266,12 +287,7 @@ async def resource_grants_json(request, datasette):
     grants = []
     for g in raw_grants:
         role = role_for_actions(roles, set(g["actions"]))
-        if g["principal"] == "actor":
-            actor_id = g["actor_id"]
-            grants.append(
-                _actor_entry(actor_id, role, g["actions"], enriched.get(actor_id) or {})
-            )
-        else:
+        if g["principal"] == "group":
             info = group_info.get(g["group_id"], {})
             grants.append(
                 _group_entry(
@@ -282,6 +298,18 @@ async def resource_grants_json(request, datasette):
                     fallback_name=g["group_name"],
                 )
             )
+        elif g["principal"] == "actor":
+            actor_id = g["actor_id"]
+            grants.append(
+                _actor_entry(
+                    actor_id,
+                    role,
+                    g["actions"],
+                    enriched.get(actor_id) or {},
+                )
+            )
+        else:
+            grants.append(_public_entry(g["principal"], role, g["actions"]))
 
     return Response.json(
         {
@@ -343,14 +371,15 @@ async def _begin_mutation(request, datasette):
 async def grant_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/grant.
 
-    Body: ``{actor_id|group_id, role}`` or ``{actor_id|group_id, actions: [...]}``.
+    Body: one principal (``actor_id``, ``group_id``, or a public-audience
+    ``principal_type``) plus exactly one of ``role`` / ``actions: [...]``.
     Upserts the grant (idempotent), audits, and returns the enriched grant.
     """
     try:
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id = _principal_from_body(body)
+        actor_id, group_id, principal_type = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         actions = await grant(
             datasette,
@@ -362,12 +391,15 @@ async def grant_json(request, datasette):
             role=body.get("role"),
             actions=body.get("actions"),
             by_actor=by_actor,
+            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
+    entry = await _enriched_grant(
+        datasette, roles, actor_id, group_id, actions, principal_type
+    )
     return Response.json({"ok": True, "grant": entry})
 
 
@@ -526,14 +558,15 @@ async def actors_json(request, datasette):
 async def revoke_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/revoke.
 
-    Body: ``{actor_id}`` or ``{group_id}``. Deletes all acl rows for that
-    principal on this resource, audits each removal, returns ``{ok: true}``.
+    Body: one principal (``actor_id``, ``group_id``, or a public-audience
+    ``principal_type``). Deletes all acl rows for that principal on this
+    resource, audits each removal, returns ``{ok: true}``.
     """
     try:
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id = _principal_from_body(body)
+        actor_id, group_id, principal_type = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         removed = await revoke(
             datasette,
@@ -543,6 +576,7 @@ async def revoke_json(request, datasette):
             actor_id=actor_id,
             group_id=group_id,
             by_actor=by_actor,
+            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
@@ -554,14 +588,16 @@ async def revoke_json(request, datasette):
 async def update_json(request, datasette):
     """POST /-/acl/api/resource/{type}/{parent}/{child}/update.
 
-    Body: ``{actor_id|group_id, role}``. Atomically swaps the principal's action
-    set to the new role, audits each change, and returns the enriched grant.
+    Body: one principal (``actor_id``, ``group_id``, or a public-audience
+    ``principal_type``) plus a required ``role``. Atomically swaps the
+    principal's action set to the new role, audits each change, and returns
+    the enriched grant.
     """
     try:
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id = _principal_from_body(body)
+        actor_id, group_id, principal_type = _principal_from_body(body)
         role = body.get("role")
         if not role:
             raise _ApiError(400, "update requires a role")
@@ -575,10 +611,13 @@ async def update_json(request, datasette):
             group_id=group_id,
             role=role,
             by_actor=by_actor,
+            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(datasette, roles, actor_id, group_id, actions)
+    entry = await _enriched_grant(
+        datasette, roles, actor_id, group_id, actions, principal_type
+    )
     return Response.json({"ok": True, "grant": entry})

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -49,7 +49,7 @@ from datasette_acl.grants import (
     revoke,
     update_role,
     list_grants,
-    principal_type_for,
+    Principal,
 )
 from datasette_acl.roles import role_for_actions, roles_for
 from datasette_acl.utils import (
@@ -202,22 +202,18 @@ async def _group_grant_entry(datasette, roles, group_id, actions):
     return _group_entry(group_id, role, actions, info)
 
 
-def _principal_from_body(body):
-    """Extract ``(actor_id, group_id, principal_type)`` from a request body.
+def _principal_from_body(body) -> Principal:
+    """Build a :class:`Principal` from a request body.
 
     The principal is exactly one of ``actor_id``, ``group_id``, or a public
     audience named by ``principal_type`` (``"everyone"`` / ``"authenticated"``
     / ``"anonymous"`` with neither id). Raises ``ValueError`` for invalid
-    combinations (via :func:`principal_type_for`) so handlers can translate it
-    to a 400.
+    combinations (via :meth:`Principal.from_parts`) so handlers can translate
+    it to a 400.
     """
-    actor_id = body.get("actor_id")
-    group_id = body.get("group_id")
-    principal_type = body.get("principal_type")
-    # Validates the combination eagerly (exactly-one principal, no audience
-    # alongside an id, no 'group' alongside actor_id).
-    principal_type_for(actor_id, group_id, principal_type)
-    return actor_id, group_id, principal_type
+    return Principal.from_parts(
+        body.get("actor_id"), body.get("group_id"), body.get("principal_type")
+    )
 
 
 def _parse_json_body(request_body):
@@ -233,16 +229,18 @@ def _parse_json_body(request_body):
     return data
 
 
-async def _enriched_grant(
-    datasette, roles, actor_id, group_id, actions, principal_type=None
-):
+async def _enriched_grant(datasette, roles, principal: Principal, actions):
     """Build the enriched grant entry for whichever principal was supplied."""
-    if actor_id is not None:
-        return await _actor_grant_entry(datasette, roles, actor_id, actions)
-    if group_id is not None:
-        return await _group_grant_entry(datasette, roles, group_id, actions)
+    if principal.principal_type == "actor":
+        return await _actor_grant_entry(
+            datasette, roles, principal.actor_id, actions
+        )
+    if principal.principal_type == "group":
+        return await _group_grant_entry(
+            datasette, roles, principal.group_id, actions
+        )
     role = role_for_actions(roles, set(actions))
-    return _public_entry(principal_type, role, actions)
+    return _public_entry(principal.principal_type, role, actions)
 
 
 async def resource_grants_json(request, datasette):
@@ -379,27 +377,23 @@ async def grant_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         actions = await grant(
             datasette,
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             role=body.get("role"),
             actions=body.get("actions"),
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(
-        datasette, roles, actor_id, group_id, actions, principal_type
-    )
+    entry = await _enriched_grant(datasette, roles, principal, actions)
     return Response.json({"ok": True, "grant": entry})
 
 
@@ -566,17 +560,15 @@ async def revoke_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         removed = await revoke(
             datasette,
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
@@ -597,7 +589,7 @@ async def update_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         role = body.get("role")
         if not role:
             raise _ApiError(400, "update requires a role")
@@ -607,17 +599,13 @@ async def update_json(request, datasette):
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             role=role,
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(
-        datasette, roles, actor_id, group_id, actions, principal_type
-    )
+    entry = await _enriched_grant(datasette, roles, principal, actions)
     return Response.json({"ok": True, "grant": entry})

--- a/datasette_acl/views/resource_acls.py
+++ b/datasette_acl/views/resource_acls.py
@@ -62,6 +62,7 @@ async def manage_resource_acls(request, datasette):
     acl_rows = await internal_db.execute(
         """
         select
+          acl.principal_type,
           acl_groups.name as group_name,
           acl.actor_id,
           acl_actions.name as action_name
@@ -73,14 +74,17 @@ async def manage_resource_acls(request, datasette):
         [resource_id],
     )
     for row in acl_rows.rows:
-        group_name = row["group_name"]
-        actor_id = row["actor_id"]
         action_name = row["action_name"]
-        if group_name:
-            current_group_permissions.setdefault(group_name, {})[action_name] = True
-        else:
-            assert actor_id
-            current_user_permissions.setdefault(actor_id, {})[action_name] = True
+        principal_type = row["principal_type"]
+        if principal_type == "group":
+            current_group_permissions.setdefault(row["group_name"], {})[
+                action_name
+            ] = True
+        elif principal_type == "actor":
+            current_user_permissions.setdefault(row["actor_id"], {})[
+                action_name
+            ] = True
+        # Public-audience rows are not surfaced by this view.
 
     if request.method == "POST":
         group_changes_made = {"added": [], "removed": []}
@@ -101,8 +105,9 @@ async def manage_resource_acls(request, datasette):
                     if new_value:
                         await internal_db.execute_write(
                             """
-                            INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+                            INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
                             VALUES (
+                                'group',
                                 null,
                                 (SELECT id FROM acl_groups WHERE name = :group_name),
                                 :resource_id,
@@ -138,6 +143,7 @@ async def manage_resource_acls(request, datasette):
                         """
                         insert into acl_audit (
                             operation,
+                            principal_type,
                             actor_id,
                             group_id,
                             resource_id,
@@ -145,6 +151,7 @@ async def manage_resource_acls(request, datasette):
                             operation_by
                         ) values (
                             :operation,
+                            'group',
                             null,
                             (SELECT id FROM acl_groups WHERE name = :group_name),
                             :resource_id,
@@ -186,8 +193,9 @@ async def manage_resource_acls(request, datasette):
                     if new_value:
                         await internal_db.execute_write(
                             """
-                            insert into acl (actor_id, group_id, resource_id, action_id)
+                            insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
                             values (
+                                'actor',
                                 :actor_id,
                                 null,
                                 :resource_id,
@@ -206,8 +214,8 @@ async def manage_resource_acls(request, datasette):
                         await internal_db.execute_write(
                             """
                             delete from acl where
-                                actor_id = :actor_id
-                                and group_id is null
+                                principal_type = 'actor'
+                                and actor_id = :actor_id
                                 and resource_id = :resource_id
                                 and action_id = (select id from acl_actions where name = :action_name)
                             """,
@@ -223,6 +231,7 @@ async def manage_resource_acls(request, datasette):
                         """
                         insert into acl_audit (
                             operation,
+                            principal_type,
                             actor_id,
                             group_id,
                             resource_id,
@@ -230,6 +239,7 @@ async def manage_resource_acls(request, datasette):
                             operation_by
                         ) values (
                             :operation,
+                            'actor',
                             :actor_id,
                             null,
                             :resource_id,
@@ -262,6 +272,7 @@ async def manage_resource_acls(request, datasette):
             acl_audit.timestamp,
             acl_audit.operation_by,
             acl_audit.operation,
+            acl_audit.principal_type,
             acl_audit.actor_id,
             acl_groups.name as group_name,
             acl_actions.name as action_name

--- a/datasette_acl/views/table_acls.py
+++ b/datasette_acl/views/table_acls.py
@@ -1,6 +1,7 @@
 from datasette import Response, Forbidden
 from datasette.utils import MultiParams
 from datasette_acl.utils import (
+    PUBLIC_PRINCIPAL_TYPES,
     actions_for_resource_type,
     can_edit_permissions,
     generate_changes_message,
@@ -50,6 +51,7 @@ async def manage_table_acls(request, datasette):
     acl_rows = await internal_db.execute(
         """
         select
+          acl.principal_type,
           acl_groups.name as group_name,
           acl.actor_id,
           acl_actions.name as action_name
@@ -61,15 +63,17 @@ async def manage_table_acls(request, datasette):
         [resource_id],
     )
     for row in acl_rows.rows:
-        group_name = row["group_name"]
-        actor_id = row["actor_id"]
         action_name = row["action_name"]
-        if group_name:
-            current_group_permissions.setdefault(group_name, {})[action_name] = True
-            current_group_permissions[group_name][action_name] = True
-        else:
-            assert actor_id
-            current_user_permissions.setdefault(actor_id, {})[action_name] = True
+        if row["principal_type"] == "group":
+            current_group_permissions.setdefault(row["group_name"], {})[
+                action_name
+            ] = True
+        elif row["principal_type"] == "actor":
+            current_user_permissions.setdefault(row["actor_id"], {})[
+                action_name
+            ] = True
+        # The legacy table page has no General-access section: public-audience
+        # rows (managed on the generic resource page) are not rendered as users.
 
     if request.method == "POST":
         group_changes_made = {"added": [], "removed": []}
@@ -91,8 +95,9 @@ async def manage_table_acls(request, datasette):
                         # They added it, add the record
                         await internal_db.execute_write(
                             """
-                            INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+                            INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
                             VALUES (
+                                'group',
                                 null,
                                 (SELECT id FROM acl_groups WHERE name = :group_name),
                                 :resource_id,
@@ -129,6 +134,7 @@ async def manage_table_acls(request, datasette):
                         """
                         insert into acl_audit (
                             operation,
+                            principal_type,
                             actor_id,
                             group_id,
                             resource_id,
@@ -136,6 +142,7 @@ async def manage_table_acls(request, datasette):
                             operation_by
                         ) values (
                             :operation,
+                            'group',
                             null,
                             (SELECT id FROM acl_groups WHERE name = :group_name),
                             :resource_id,
@@ -176,11 +183,13 @@ async def manage_table_acls(request, datasette):
                 )
                 if new_value != current_value:
                     if new_value:
-                        # They added the permission
+                        # They added the permission. The legacy table page only
+                        # manages real users, so the row is always 'actor'.
                         await internal_db.execute_write(
                             """
-                            insert into acl (actor_id, group_id, resource_id, action_id)
+                            insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
                             values (
+                                'actor',
                                 :actor_id,
                                 null,
                                 :resource_id,
@@ -196,12 +205,14 @@ async def manage_table_acls(request, datasette):
                         operation = "added"
                         user_changes_made["added"].append((actor_id, action_name))
                     else:
-                        # They removed the permission
+                        # They removed the permission. Constrained to 'actor'
+                        # rows so a wildcard grant with a colliding id is never
+                        # deleted from here.
                         await internal_db.execute_write(
                             """
                             delete from acl where
-                                actor_id = :actor_id
-                                and group_id is null
+                                principal_type = 'actor'
+                                and actor_id = :actor_id
                                 and resource_id = :resource_id
                                 and action_id = (select id from acl_actions where name = :action_name)
                             """,
@@ -217,6 +228,7 @@ async def manage_table_acls(request, datasette):
                         """
                         insert into acl_audit (
                             operation,
+                            principal_type,
                             actor_id,
                             group_id,
                             resource_id,
@@ -224,6 +236,7 @@ async def manage_table_acls(request, datasette):
                             operation_by
                         ) values (
                             :operation,
+                            'actor',
                             :actor_id,
                             null,
                             :resource_id,
@@ -256,6 +269,7 @@ async def manage_table_acls(request, datasette):
             acl_audit.timestamp,
             acl_audit.operation_by,
             acl_audit.operation,
+            acl_audit.principal_type,
             acl_audit.actor_id,
             acl_groups.name as group_name,
             acl_actions.name as action_name
@@ -300,6 +314,7 @@ async def manage_table_acls(request, datasette):
                 "group_sizes": group_sizes,
                 "group_permissions": current_group_permissions,
                 "user_permissions": current_user_permissions,
+                "public_principals": PUBLIC_PRINCIPAL_TYPES,
                 "audit_log": audit_log.rows,
                 "valid_actors": await get_acl_valid_actors(datasette),
             },

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -52,26 +52,29 @@ that contain reserved characters.
 
 ### Principals
 
-A grant attaches a set of actions on a resource to exactly **one** principal:
+A grant attaches a set of actions on a resource to exactly **one** principal,
+which takes one of three forms in a mutation body:
 
 - **Actor** — identified by a string `actor_id` (e.g. `"alice"`).
 - **Group** — identified by an integer `group_id` (the `acl_groups.id`).
+- **Public audience** — a *class* of caller rather than a specific person,
+  named by `principal_type` with **neither** id:
 
-Every mutating request must supply **exactly one** of `actor_id` / `group_id`.
-Supplying neither or both is a `400` error.
+| `principal_type` | Matches                                       |
+| ---------------- | --------------------------------------------- |
+| `everyone`       | Literally everyone, including anonymous users |
+| `authenticated`  | Any signed-in actor (has an `id`)             |
+| `anonymous`      | Only unauthenticated callers                  |
 
-**Wildcard / "public" principals.** Three reserved `actor_id` values represent
-classes of caller rather than a specific person:
+Supplying none of these forms — or more than one — is a `400` error.
+(`principal_type` may also redundantly name `"actor"` / `"group"` alongside
+the matching id.)
 
-| `actor_id`    | Matches                                       |
-| ------------- | --------------------------------------------- |
-| `*`           | Literally everyone, including anonymous users |
-| `_signed_in`  | Any authenticated actor (has an `id`)         |
-| `_anonymous`  | Only unauthenticated callers                  |
-
-These are stored as ordinary actor grants but are flagged `"kind": "public"` in
-responses and are never run through actor enrichment (no display name / email /
-avatar).
+Audience grants store no id at all, so there is no reserved actor-id
+namespace: enforcement matches audiences on `principal_type` alone and actors
+on their literal id, and an actor named e.g. `_signed_in` is just an ordinary
+actor. In responses audiences are flagged `"kind": "public"` and are never run
+through actor enrichment (their `display_name` is the fixed UI label).
 
 ### Roles vs. actions
 
@@ -108,11 +111,10 @@ Read and mutation responses describe a principal's grant with the same shape.
 
 - `actions` is always sorted.
 - `role` is the resolved role name, or `null` if no role matches.
-- `kind` is `"public"` for wildcard principals; otherwise it is taken from the
-  actor-resolution layer (`actors_from_ids`, e.g. `"user"`, `"agent"`),
-  defaulting to `"user"`.
+- `kind` is taken from the actor-resolution layer (`actors_from_ids`, e.g.
+  `"user"`, `"agent"`), defaulting to `"user"`.
 - `display_name`, `email`, `avatar_url` are present only when the actor-
-  resolution layer supplies them (so wildcard and unknown actors omit them).
+  resolution layer supplies them (so unknown actors omit them).
 
 **Group entry:**
 
@@ -132,6 +134,23 @@ Read and mutation responses describe a principal's grant with the same shape.
 - `kind` is always `"group"`.
 - `display_name` is the group name; `member_count` is the number of actors in
   the group.
+
+**Public (audience) entry:**
+
+```json
+{
+  "principal": "public",
+  "id": "authenticated",
+  "role": "Viewer",
+  "actions": ["doc-view"],
+  "kind": "public",
+  "display_name": "Any signed-in user"
+}
+```
+
+- `id` echoes the audience's `principal_type` (audiences have no stored id).
+- `display_name` is the fixed UI label; audiences are never enriched (no
+  `email` / `avatar_url`).
 
 ---
 
@@ -296,8 +315,9 @@ principal's full action-set after the grant.
 
 | Field      | Type            | Notes                                                |
 | ---------- | --------------- | ---------------------------------------------------- |
-| `actor_id` | string          | Supply this **or** `group_id`, not both.             |
-| `group_id` | integer         | Supply this **or** `actor_id`, not both.             |
+| `actor_id` | string          | An individual actor. One principal form of three.    |
+| `group_id` | integer         | A group. One principal form of three.                |
+| `principal_type` | string    | A public audience: `"everyone"` / `"authenticated"` / `"anonymous"`, with neither id (see [Principals](#principals)). |
 | `role`     | string          | A role name for this resource type. Expands to its actions. Supply this **or** `actions`. |
 | `actions`  | array of string | Raw action names. Supply this **or** `role`.         |
 
@@ -348,8 +368,9 @@ audited. Returns the enriched grant.
 
 | Field      | Type    | Notes                                    |
 | ---------- | ------- | ---------------------------------------- |
-| `actor_id` | string  | Supply this **or** `group_id`.           |
-| `group_id` | integer | Supply this **or** `actor_id`.           |
+| `actor_id` | string  | An individual actor. One principal form of three. |
+| `group_id` | integer | A group. One principal form of three.    |
+| `principal_type` | string | A public audience, with neither id (see [Principals](#principals)). |
 | `role`     | string  | Required. The role to swap the principal to. |
 
 ```json
@@ -380,8 +401,9 @@ Removes **all** grants for a principal on the resource. Each removal is audited
 
 | Field      | Type    | Notes                          |
 | ---------- | ------- | ------------------------------ |
-| `actor_id` | string  | Supply this **or** `group_id`. |
-| `group_id` | integer | Supply this **or** `actor_id`. |
+| `actor_id` | string  | An individual actor. One principal form of three. |
+| `group_id` | integer | A group. One principal form of three. |
+| `principal_type` | string | A public audience, with neither id (see [Principals](#principals)). |
 
 ```json
 { "actor_id": "bob" }
@@ -519,13 +541,18 @@ curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \
   -d '{"group_id": 7, "actions": ["doc-view"]}'
 ```
 
-Make the document public to signed-in users:
+Make the document public to signed-in users — the `authenticated` audience is
+named by `principal_type`, with no id:
 
 ```bash
 curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \
   -H 'Cookie: ds_actor=...' \
   -H 'Content-Type: application/json' \
-  -d '{"actor_id": "_signed_in", "role": "Viewer"}'
+  -d '{"principal_type": "authenticated", "role": "Viewer"}'
+# -> {"ok": true, "grant": {"principal":"public","id":"authenticated",
+#                           "role":"Viewer","actions":["doc-view"],
+#                           "kind":"public",
+#                           "display_name":"Any signed-in user"}}
 ```
 
 Revoke `bob` entirely:

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -1,11 +1,9 @@
 # datasette-acl JSON API
 
-A JSON HTTP API for reading and managing per-resource access grants. It is the
-backend for the "share" dialog, but it is a general-purpose API: any tool or
-agent can drive it to inspect and mutate grants programmatically.
+A JSON HTTP API for reading and managing per-resource access grants.
 
-All routes are registered by the plugin under the `/-/acl/api/` prefix and
-return `application/json`.
+All routes are registered under the `/-/acl/api/` prefix and
+return JSON.
 
 - [Concepts](#concepts)
   - [Resources](#resources)
@@ -13,7 +11,7 @@ return `application/json`.
   - [Roles vs. actions](#roles-vs-actions)
   - [The grant entry object](#the-grant-entry-object)
 - [Authorization](#authorization)
-- [Requests, CSRF, and errors](#requests-csrf-and-errors)
+- [API errors](#api-errors)
 - [Endpoints](#endpoints)
   - [GET resource grants](#get-resource-grants)
   - [POST grant](#post-grant)
@@ -29,18 +27,18 @@ return `application/json`.
 
 ### Resources
 
+A [resource](https://docs.datasette.io/en/latest/authentication.html#permissions) is something within Datasette that can be controlled via ACL rules. Examples include tables, queries, and additional concepts introduced by plugins such as [datasette-apps](https://github.com/datasette/datasette-apps).
+
 A resource is addressed by a `(resource_type, parent, child)` triple:
 
 - **`resource_type`** — the `Resource.name` of a registered resource class,
   e.g. `table`, or a custom type like `mock-doc`. A resource type is "known"
   only if some registered action declares it via `resource_class`. Requests for
   an unknown type are rejected (`403`).
-- **`parent`** — the first-level identifier (e.g. a database name, or a
-  document id).
+- **`parent`** — the first-level identifier (e.g. a database name).
 - **`child`** — the optional second-level identifier (e.g. a table name). Two-
   level types (`parent_class` set, e.g. a table inside a database) use both;
-  parent-only types (`parent_class is None`, e.g. a database or a standalone
-  document) use only `parent`.
+  parent-only types (`parent_class is None`, e.g. a database) use only `parent`.
 
 In URLs the child segment is **optional** — every resource route is registered
 in both a `/{parent}/{child}` and a `/{parent}` form. For a parent-only
@@ -55,10 +53,11 @@ that contain reserved characters.
 A grant attaches a set of actions on a resource to exactly **one** principal,
 which takes one of three forms in a mutation body:
 
-- **Actor** — identified by a string `actor_id` (e.g. `"alice"`).
-- **Group** — identified by an integer `group_id` (the `acl_groups.id`).
+- **Actor** — a [Datasette actor](https://docs.datasette.io/en/latest/authentication.html#actors) identified by a string `actor_id` (e.g. `"alice"`).
+- **Group** — an ACL group identified by an integer `group_id` (the `acl_groups.id`).
 - **Public audience** — a *class* of caller rather than a specific person,
-  named by `principal_type` with **neither** id:
+  named by `principal_type` alone; do not include either ID field
+  (`actor_id` or `group_id`):
 
 | `principal_type` | Matches                                       |
 | ---------------- | --------------------------------------------- |
@@ -70,16 +69,20 @@ Supplying none of these forms — or more than one — is a `400` error.
 (`principal_type` may also redundantly name `"actor"` / `"group"` alongside
 the matching id.)
 
-Audience grants store no id at all, so there is no reserved actor-id
-namespace: enforcement matches audiences on `principal_type` alone and actors
-on their literal id, and an actor named e.g. `_signed_in` is just an ordinary
-actor. In responses audiences are flagged `"kind": "public"` and are never run
-through actor enrichment (their `display_name` is the fixed UI label).
+Audience grants store no id at all. Enforcement matches audiences on
+`principal_type` alone. In responses these audience entries use
+`"principal": "public"` and `"kind": "public"` to distinguish them from actors
+and groups, and are never run through actor enrichment (their `display_name` is
+the fixed UI label).
 
 ### Roles vs. actions
 
-acl stores grants at the granularity of individual **actions** (e.g.
-`doc-view`, `doc-edit`, `doc-manage`). A **role** is a friendly named bundle of
+Datasette's default permission system is finely-grained: permissions to add,
+edit, and delete an item are managed separately.
+
+This can be inconvenient for end-users. `datasette-acl` introduces the concept of **roles** to provide a more human-friendly way of managing permissions, as an abstraction over the lower level permissions.
+
+A **role** is a friendly named bundle of
 actions declared for a resource type via the `datasette_acl_roles` hook (e.g.
 `Viewer = [doc-view]`, `Editor = [doc-view, doc-edit]`,
 `Manager = [doc-view, doc-edit, doc-manage]`).
@@ -92,7 +95,8 @@ raw `actions` array.
 
 ### The grant entry object
 
-Read and mutation responses describe a principal's grant with the same shape.
+Both the `GET` endpoint and successful write endpoints describe grants using
+the same object shapes.
 
 **Actor entry:**
 
@@ -109,10 +113,12 @@ Read and mutation responses describe a principal's grant with the same shape.
 }
 ```
 
-- `actions` is always sorted.
+- `actions` is always sorted alphabetically.
 - `role` is the resolved role name, or `null` if no role matches.
-- `kind` is taken from the actor-resolution layer (`actors_from_ids`, e.g.
-  `"user"`, `"agent"`), defaulting to `"user"`.
+- `kind` is taken from the actor-resolution layer (`actors_from_ids`) when
+  supplied, defaulting to `"user"`. Other kinds such as `"api_key"` or
+  `"agent"` may be used when an alternative mechanism is acting on behalf of a
+  user.
 - `display_name`, `email`, `avatar_url` are present only when the actor-
   resolution layer supplies them (so unknown actors omit them).
 
@@ -174,8 +180,8 @@ manager concept for it, so management falls back to the global `datasette-acl`
 permission only. (This is how table-style resources, which have raw actions but
 no roles, keep working.)
 
-The **read** endpoint is, in v1, also manager-only (it returns the full grant
-list). The **picker** endpoints accept the resource triple as optional query
+The **read** endpoint is also manager-only because it returns the full grant
+list. The **picker** endpoints accept the resource triple as optional query
 params and apply the same per-resource check when present, falling back to the
 global permission when absent (see each endpoint).
 
@@ -184,21 +190,9 @@ body is **not** the `{"ok": false}` shape — see below).
 
 ---
 
-## Requests, CSRF, and errors
+## API errors
 
-**Content type.** Mutation endpoints read a JSON object request body. An empty
-body is treated as `{}`. A body that is not valid JSON, or is valid JSON but
-not an object, is a `400` error.
-
-**CSRF.** These endpoints carry no token-based CSRF logic of their own. On
-Datasette 1.0a30+ the header-based `CrossOriginProtectionMiddleware`
-(Sec-Fetch-Site + Origin) rejects cross-origin browser writes before they reach
-the handler. Same-origin browser requests pass; non-browser clients (curl, the
-test client, server-to-server) send neither header and pass through. No
-`x-csrftoken` is required (the dialog may send one for forward-compat; core
-ignores it).
-
-**Error shapes.** There are two distinct failure renderings:
+There are two distinct error shapes:
 
 - **`403 Forbidden`** — raised for failed authorization and for unknown
   resource types. Rendered by Datasette core's forbidden handler (content
@@ -207,7 +201,10 @@ ignores it).
 - **`400` / `405` from the handler** — returned as a JSON envelope:
 
   ```json
-  { "ok": false, "error": "Provide exactly one of actor_id or group_id" }
+  {
+    "ok": false,
+    "error": "update requires a role"
+  }
   ```
 
   - `400` — bad/duplicate principal, unparseable body, unknown role, or
@@ -241,22 +238,39 @@ Returns the full share state for one resource: its role catalog, every grant
 grouped by principal (each enriched and role-resolved), and the caller's
 `can_manage` flag.
 
+Datasette's default resource types are:
+
+- `database` — `parent` is the database name; omit `child`.
+- `table` — `parent` is the database name, `child` is the table or view name.
+- `query` — `parent` is the database name, `child` is the stored query name.
+
+Plugins can add additional resource types by registering actions with custom
+resource classes; use the resource class's `name` as `resource_type`.
+
 **Authorization:** manager-only (`can_manage` must be true).
 
 **Response `200`:**
 
 ```json
 {
-  "resource_type": "mock-doc",
-  "parent": "42",
-  "child": null,
+  "resource_type": "query",
+  "parent": "content",
+  "child": "recent_releases",
   "can_manage": true,
   "roles": [
-    { "name": "Viewer", "actions": ["doc-view"], "rank": 1 },
-    { "name": "Editor", "actions": ["doc-view", "doc-edit"], "rank": 2 },
+    {
+      "name": "Viewer",
+      "actions": ["view-query"],
+      "rank": 1
+    },
+    {
+      "name": "Editor",
+      "actions": ["update-query", "view-query"],
+      "rank": 2
+    },
     {
       "name": "Manager",
-      "actions": ["doc-view", "doc-edit", "doc-manage"],
+      "actions": ["delete-query", "update-query", "view-query"],
       "rank": 3,
       "manage": true,
       "description": "Full control"
@@ -267,7 +281,7 @@ grouped by principal (each enriched and role-resolved), and the caller's
       "principal": "actor",
       "id": "alice",
       "role": "Manager",
-      "actions": ["doc-edit", "doc-manage", "doc-view"],
+      "actions": ["delete-query", "update-query", "view-query"],
       "kind": "user",
       "display_name": "Alice Garcia",
       "email": "alice@example.com",
@@ -277,7 +291,7 @@ grouped by principal (each enriched and role-resolved), and the caller's
       "principal": "group",
       "id": "7",
       "role": "Viewer",
-      "actions": ["doc-view"],
+      "actions": ["view-query"],
       "kind": "group",
       "display_name": "staff",
       "member_count": 3
@@ -304,28 +318,42 @@ POST /-/acl/api/resource/{resource_type}/{parent}/{child}/grant
 POST /-/acl/api/resource/{resource_type}/{parent}/grant
 ```
 
-Adds actions for a principal on the resource. **Idempotent** — only actions not
-already held are inserted; each insert is written to the audit log
-(`operation: "added"`, `operation_by` = the calling actor's id). Returns the
-principal's full action-set after the grant.
+Adds actions for a principal on the resource.
+
+This endpoint is **idempotent** — only actions not
+already held are inserted, and each insert is written to the audit log
+(`operation: "added"`, `operation_by` = the calling actor's id).
+
+Returns the principal's full action-set after the grant.
 
 **Authorization:** `can_manage`.
 
-**Body** — exactly one principal, and exactly one of `role` / `actions`:
+**Body** — exactly one of `actor_id` / `group_id` / `principal_type`, and exactly one of `role` / `actions`:
 
 | Field      | Type            | Notes                                                |
 | ---------- | --------------- | ---------------------------------------------------- |
 | `actor_id` | string          | An individual actor. One principal form of three.    |
 | `group_id` | integer         | A group. One principal form of three.                |
-| `principal_type` | string    | A public audience: `"everyone"` / `"authenticated"` / `"anonymous"`, with neither id (see [Principals](#principals)). |
+| `principal_type` | string    | A public audience: `"everyone"` / `"authenticated"` / `"anonymous"`. Do not include `actor_id` or `group_id` (see [Principals](#principals)). |
 | `role`     | string          | A role name for this resource type. Expands to its actions. Supply this **or** `actions`. |
 | `actions`  | array of string | Raw action names. Supply this **or** `role`.         |
 
+To grant the "Editor" role to "bob":
+
 ```json
-{ "actor_id": "bob", "role": "Editor" }
+{
+  "actor_id": "bob",
+  "role": "Editor"
+}
 ```
+
+To allow members of group 7 the ability to both `doc-view` and `doc-edit`:
+
 ```json
-{ "group_id": 7, "actions": ["doc-view", "doc-edit"] }
+{
+  "group_id": 7,
+  "actions": ["doc-view", "doc-edit"]
+}
 ```
 
 **Response `200`:**
@@ -364,17 +392,23 @@ audited. Returns the enriched grant.
 
 **Authorization:** `can_manage`.
 
-**Body** — exactly one principal, plus a **required** `role`:
+**Body** — exactly one of `actor_id` / `group_id` / `principal_type`, plus a
+**required** `role`:
 
 | Field      | Type    | Notes                                    |
 | ---------- | ------- | ---------------------------------------- |
 | `actor_id` | string  | An individual actor. One principal form of three. |
 | `group_id` | integer | A group. One principal form of three.    |
-| `principal_type` | string | A public audience, with neither id (see [Principals](#principals)). |
+| `principal_type` | string | A public audience. Do not include `actor_id` or `group_id` (see [Principals](#principals)). |
 | `role`     | string  | Required. The role to swap the principal to. |
 
+To replace the actor `bob`'s current actions with the "Viewer" role:
+
 ```json
-{ "actor_id": "bob", "role": "Viewer" }
+{
+  "actor_id": "bob",
+  "role": "Viewer"
+}
 ```
 
 **Response `200`:** same `{ "ok": true, "grant": <entry> }` shape as
@@ -383,7 +417,8 @@ audited. Returns the enriched grant.
 **Errors:** `400` if `role` is missing/unknown or the principal is invalid;
 `403` for authz / unknown resource type. Use `update` (not repeated
 grant/revoke) when you want the principal's actions to end up *exactly* equal to
-one role.
+one role. To replace a principal's actions with an arbitrary raw `actions`
+list, first `revoke` that principal's grant and then `grant` the new `actions`.
 
 ### POST revoke
 
@@ -397,22 +432,31 @@ Removes **all** grants for a principal on the resource. Each removal is audited
 
 **Authorization:** `can_manage`.
 
-**Body** — exactly one principal (no role/actions):
+**Body** — exactly one of `actor_id` / `group_id` / `principal_type` (no role/actions):
 
 | Field      | Type    | Notes                          |
 | ---------- | ------- | ------------------------------ |
 | `actor_id` | string  | An individual actor. One principal form of three. |
 | `group_id` | integer | A group. One principal form of three. |
-| `principal_type` | string | A public audience, with neither id (see [Principals](#principals)). |
+| `principal_type` | string | A public audience. Do not include `actor_id` or `group_id` (see [Principals](#principals)). |
+
+To remove all grants for the actor `bob` on this resource:
 
 ```json
-{ "actor_id": "bob" }
+{
+  "actor_id": "bob"
+}
 ```
 
 **Response `200`:**
 
+A successful response lists the action names that were removed:
+
 ```json
-{ "ok": true, "removed": ["doc-edit", "doc-manage", "doc-view"] }
+{
+  "ok": true,
+  "removed": ["doc-edit", "doc-manage", "doc-view"]
+}
 ```
 
 `removed` is sorted. Revoking a principal with no grants returns
@@ -431,24 +475,36 @@ GET /-/acl/api/groups?resource_type={type}&parent={parent}&child={child}
 Lists every active (non soft-deleted) group with a member count — the source
 for a group autocomplete. Ordered by group name.
 
-**Authorization:** if `resource_type` **and** `parent` query params are present,
-the per-resource `can_manage` check is applied (so a per-resource Manager who
-lacks the global admin permission can still use the picker). Otherwise the
-global `datasette-acl` permission is required. If neither passes → `403`.
+**Authorization:** group names may be sensitive, so this endpoint is only
+available to callers who are trusted to manage permissions somewhere. There
+are two ways to qualify:
+
+- Global ACL admins can call `/groups` directly using the `datasette-acl`
+  permission.
+- Resource managers can pass `resource_type` and `parent` (`child` is
+  optional). Those query params are used only for the `can_manage` check on
+  that resource; they do not filter the returned groups.
+
+If neither check passes → `403`.
 
 **Response `200`:**
 
 ```json
 {
   "groups": [
-    { "id": 7, "name": "staff", "member_count": 3 },
-    { "id": 9, "name": "interns", "member_count": 0 }
+    {
+      "id": 7,
+      "name": "staff",
+      "member_count": 3
+    },
+    {
+      "id": 9,
+      "name": "interns",
+      "member_count": 0
+    }
   ]
 }
 ```
-
-(Here `id` is a number; note that grant *entries* render group `id` as a
-string.)
 
 ### GET actors picker
 
@@ -457,7 +513,7 @@ GET /-/acl/api/actors?q={query}&kind={kind}
 GET /-/acl/api/actors?q={query}&resource_type={type}&parent={parent}&child={child}
 ```
 
-Actor autocomplete. If the `datasette-acl` deployment also has the user-profiles
+Actor autocomplete. If the Datasette instance also has the [datasette-user-profiles](https://github.com/datasette/datasette-user-profiles)
 plugin installed, this proxies to its search API
 (`GET /-/profiles/api/search`), forwarding the caller's identity so the
 profiles access gate evaluates against the real caller. Otherwise it falls back
@@ -542,7 +598,7 @@ curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \
 ```
 
 Make the document public to signed-in users — the `authenticated` audience is
-named by `principal_type`, with no id:
+named by `principal_type` alone:
 
 ```bash
 curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -2,8 +2,7 @@
 
 A JSON HTTP API for reading and managing per-resource access grants.
 
-All routes are registered under the `/-/acl/api/` prefix and
-return JSON.
+All routes are registered under the `/-/acl/api/` prefix and return JSON.
 
 - [Concepts](#concepts)
   - [Resources](#resources)
@@ -31,33 +30,21 @@ A [resource](https://docs.datasette.io/en/latest/authentication.html#permissions
 
 A resource is addressed by a `(resource_type, parent, child)` triple:
 
-- **`resource_type`** — the `Resource.name` of a registered resource class,
-  e.g. `table`, or a custom type like `mock-doc`. A resource type is "known"
-  only if some registered action declares it via `resource_class`. Requests for
-  an unknown type are rejected (`403`).
+- **`resource_type`** — the `Resource.name` of a registered resource class, e.g. `table`, or a custom type like `mock-doc`. A resource type is "known" only if some registered action declares it via `resource_class`. Requests for an unknown type are rejected (`403`).
 - **`parent`** — the first-level identifier (e.g. a database name).
-- **`child`** — the optional second-level identifier (e.g. a table name). Two-
-  level types (`parent_class` set, e.g. a table inside a database) use both;
-  parent-only types (`parent_class is None`, e.g. a database) use only `parent`.
+- **`child`** — the optional second-level identifier (e.g. a table name). Two-level types (`parent_class` set, e.g. a table inside a database) use both; parent-only types (`parent_class is None`, e.g. a database) use only `parent`.
 
-In URLs the child segment is **optional** — every resource route is registered
-in both a `/{parent}/{child}` and a `/{parent}` form. For a parent-only
-resource, omit the child segment entirely; in JSON responses the absent child
-is reported as `"child": null`.
+In URLs the child segment is **optional** — every resource route is registered in both a `/{parent}/{child}` and a `/{parent}` form. For a parent-only resource, omit the child segment entirely; in JSON responses the absent child is reported as `"child": null`.
 
-All three segments are single path components (no slashes). URL-encode values
-that contain reserved characters.
+All three segments are single path components (no slashes). URL-encode values that contain reserved characters.
 
 ### Principals
 
-A grant attaches a set of actions on a resource to exactly **one** principal,
-which takes one of three forms in a mutation body:
+A grant attaches a set of actions on a resource to exactly **one** principal, which takes one of three forms in a mutation body:
 
 - **Actor** — a [Datasette actor](https://docs.datasette.io/en/latest/authentication.html#actors) identified by a string `actor_id` (e.g. `"alice"`).
 - **Group** — an ACL group identified by an integer `group_id` (the `acl_groups.id`).
-- **Public audience** — a *class* of caller rather than a specific person,
-  named by `principal_type` alone; do not include either ID field
-  (`actor_id` or `group_id`):
+- **Public audience** — a *class* of caller rather than a specific person, named by `principal_type` alone; do not include either ID field (`actor_id` or `group_id`):
 
 | `principal_type` | Matches                                       |
 | ---------------- | --------------------------------------------- |
@@ -65,38 +52,23 @@ which takes one of three forms in a mutation body:
 | `authenticated`  | Any signed-in actor (has an `id`)             |
 | `anonymous`      | Only unauthenticated callers                  |
 
-Supplying none of these forms — or more than one — is a `400` error.
-(`principal_type` may also redundantly name `"actor"` / `"group"` alongside
-the matching id.)
+Supplying none of these forms — or more than one — is a `400` error. (`principal_type` may also redundantly name `"actor"` / `"group"` alongside the matching id.)
 
-Audience grants store no id at all. Enforcement matches audiences on
-`principal_type` alone. In responses these audience entries use
-`"principal": "public"` and `"kind": "public"` to distinguish them from actors
-and groups, and are never run through actor enrichment (their `display_name` is
-the fixed UI label).
+Audience grants store no id at all. Enforcement matches audiences on `principal_type` alone. In responses these audience entries use `"principal": "public"` and `"kind": "public"` to distinguish them from actors and groups, and are never run through actor enrichment (their `display_name` is the fixed UI label).
 
 ### Roles vs. actions
 
-Datasette's default permission system is finely-grained: permissions to add,
-edit, and delete an item are managed separately.
+Datasette's default permission system is finely-grained: permissions to add, edit, and delete an item are managed separately.
 
 This can be inconvenient for end-users. `datasette-acl` introduces the concept of **roles** to provide a more human-friendly way of managing permissions, as an abstraction over the lower level permissions.
 
-A **role** is a friendly named bundle of
-actions declared for a resource type via the `datasette_acl_roles` hook (e.g.
-`Viewer = [doc-view]`, `Editor = [doc-view, doc-edit]`,
-`Manager = [doc-view, doc-edit, doc-manage]`).
+A **role** is a friendly named bundle of actions declared for a resource type via the `datasette_acl_roles` hook (e.g. `Viewer = [doc-view]`, `Editor = [doc-view, doc-edit]`, `Manager = [doc-view, doc-edit, doc-manage]`).
 
-You may grant **by role** (the actions are expanded from the role) or **by raw
-actions**. In responses, a principal's current action-set is resolved back to
-the **highest-rank role whose actions are a subset of the granted set**; if no
-role fits, `"role"` is `null` and the caller should fall back to displaying the
-raw `actions` array.
+You may grant **by role** (the actions are expanded from the role) or **by raw actions**. In responses, a principal's current action-set is resolved back to the **highest-rank role whose actions are a subset of the granted set**; if no role fits, `"role"` is `null` and the caller should fall back to displaying the raw `actions` array.
 
 ### The grant entry object
 
-Both the `GET` endpoint and successful write endpoints describe grants using
-the same object shapes.
+Both the `GET` endpoint and successful write endpoints describe grants using the same object shapes.
 
 **Actor entry:**
 
@@ -115,12 +87,8 @@ the same object shapes.
 
 - `actions` is always sorted alphabetically.
 - `role` is the resolved role name, or `null` if no role matches.
-- `kind` is taken from the actor-resolution layer (`actors_from_ids`) when
-  supplied, defaulting to `"user"`. Other kinds such as `"api_key"` or
-  `"agent"` may be used when an alternative mechanism is acting on behalf of a
-  user.
-- `display_name`, `email`, `avatar_url` are present only when the actor-
-  resolution layer supplies them (so unknown actors omit them).
+- `kind` is taken from the actor-resolution layer (`actors_from_ids`) when supplied, defaulting to `"user"`. Other kinds such as `"api_key"` or `"agent"` may be used when an alternative mechanism is acting on behalf of a user.
+- `display_name`, `email`, `avatar_url` are present only when the actor-resolution layer supplies them (so unknown actors omit them).
 
 **Group entry:**
 
@@ -138,8 +106,7 @@ the same object shapes.
 
 - `id` is the group id rendered as a **string**.
 - `kind` is always `"group"`.
-- `display_name` is the group name; `member_count` is the number of actors in
-  the group.
+- `display_name` is the group name; `member_count` is the number of actors in the group.
 
 **Public (audience) entry:**
 
@@ -155,38 +122,24 @@ the same object shapes.
 ```
 
 - `id` echoes the audience's `principal_type` (audiences have no stored id).
-- `display_name` is the fixed UI label; audiences are never enriched (no
-  `email` / `avatar_url`).
+- `display_name` is the fixed UI label; audiences are never enriched (no `email` / `avatar_url`).
 
 ---
 
 ## Authorization
 
-Every endpoint is gated by a **per-resource manage check**, `can_manage`. A
-caller may manage sharing for a resource if **either**:
+Every endpoint is gated by a **per-resource manage check**, `can_manage`. A caller may manage sharing for a resource if **either**:
 
 1. They hold the global `datasette-acl` permission (acl admin), **or**
-2. They are `datasette.allowed` one of the resource type's **manage-only**
-   actions on *that specific resource* — i.e. they hold a `manage=True` role
-   (Manager/Owner) grant. Because this flows through the same acl machinery, it
-   composes with group membership.
+2. They are `datasette.allowed` one of the resource type's **manage-only** actions on *that specific resource* — i.e. they hold a `manage=True` role (Manager/Owner) grant. Because this flows through the same acl machinery, it composes with group membership.
 
-The manage check authorizes against the action that is *exclusive* to manage
-roles (e.g. `doc-manage`), not the whole Manager bundle — otherwise any Viewer
-or Editor (who also holds `doc-view`) would pass.
+The manage check authorizes against the action that is *exclusive* to manage roles (e.g. `doc-manage`), not the whole Manager bundle — otherwise any Viewer or Editor (who also holds `doc-view`) would pass.
 
-If a resource type registers **no** `manage` role, there is no per-resource
-manager concept for it, so management falls back to the global `datasette-acl`
-permission only. (This is how table-style resources, which have raw actions but
-no roles, keep working.)
+If a resource type registers **no** `manage` role, there is no per-resource manager concept for it, so management falls back to the global `datasette-acl` permission only. (This is how table-style resources, which have raw actions but no roles, keep working.)
 
-The **read** endpoint is also manager-only because it returns the full grant
-list. The **picker** endpoints accept the resource triple as optional query
-params and apply the same per-resource check when present, falling back to the
-global permission when absent (see each endpoint).
+The **read** endpoint is also manager-only because it returns the full grant list. The **picker** endpoints accept the resource triple as optional query params and apply the same per-resource check when present, falling back to the global permission when absent (see each endpoint).
 
-Failed authorization raises a `403 Forbidden`, rendered by Datasette core (its
-body is **not** the `{"ok": false}` shape — see below).
+Failed authorization raises a `403 Forbidden`, rendered by Datasette core (its body is **not** the `{"ok": false}` shape — see below).
 
 ---
 
@@ -194,10 +147,7 @@ body is **not** the `{"ok": false}` shape — see below).
 
 There are two distinct error shapes:
 
-- **`403 Forbidden`** — raised for failed authorization and for unknown
-  resource types. Rendered by Datasette core's forbidden handler (content
-  negotiated; not guaranteed to be the `{"ok": false}` envelope). Treat any
-  `403` as "not allowed / unknown resource."
+- **`403 Forbidden`** — raised for failed authorization and for unknown resource types. Rendered by Datasette core's forbidden handler (content negotiated; not guaranteed to be the `{"ok": false}` envelope). Treat any `403` as "not allowed / unknown resource."
 - **`400` / `405` from the handler** — returned as a JSON envelope:
 
   ```json
@@ -207,8 +157,7 @@ There are two distinct error shapes:
   }
   ```
 
-  - `400` — bad/duplicate principal, unparseable body, unknown role, or
-    `update` without a role.
+  - `400` — bad/duplicate principal, unparseable body, unknown role, or `update` without a role.
   - `405` — wrong HTTP method on a mutation route (e.g. `GET` on `/grant`).
 
 Successful mutation responses always include `"ok": true`.
@@ -224,8 +173,7 @@ Successful mutation responses always include `"ok": true`.
 
 ## Endpoints
 
-Path parameters `{resource_type}` / `{parent}` / `{child}` are described under
-[Resources](#resources). `{child}` is optional in every resource route.
+Path parameters `{resource_type}` / `{parent}` / `{child}` are described under [Resources](#resources). `{child}` is optional in every resource route.
 
 ### GET resource grants
 
@@ -234,9 +182,7 @@ GET /-/acl/api/resource/{resource_type}/{parent}/{child}
 GET /-/acl/api/resource/{resource_type}/{parent}
 ```
 
-Returns the full share state for one resource: its role catalog, every grant
-grouped by principal (each enriched and role-resolved), and the caller's
-`can_manage` flag.
+Returns the full share state for one resource: its role catalog, every grant grouped by principal (each enriched and role-resolved), and the caller's `can_manage` flag.
 
 Datasette's default resource types are:
 
@@ -244,8 +190,7 @@ Datasette's default resource types are:
 - `table` — `parent` is the database name, `child` is the table or view name.
 - `query` — `parent` is the database name, `child` is the stored query name.
 
-Plugins can add additional resource types by registering actions with custom
-resource classes; use the resource class's `name` as `resource_type`.
+Plugins can add additional resource types by registering actions with custom resource classes; use the resource class's `name` as `resource_type`.
 
 **Authorization:** manager-only (`can_manage` must be true).
 
@@ -302,13 +247,8 @@ resource classes; use the resource class's `name` as `resource_type`.
 
 Notes:
 
-- `roles` is the resource type's role catalog ordered by ascending `rank`. The
-  `manage` (boolean `true`) and `description` (string) keys appear only when
-  set on the role.
-- `grants` is one entry per principal (see
-  [grant entry object](#the-grant-entry-object)). Grants whose group is soft-
-  deleted are omitted. An empty resource returns `"grants": []` but still
-  includes `roles` and `can_manage`.
+- `roles` is the resource type's role catalog ordered by ascending `rank`. The `manage` (boolean `true`) and `description` (string) keys appear only when set on the role.
+- `grants` is one entry per principal (see [grant entry object](#the-grant-entry-object)). Grants whose group is soft-deleted are omitted. An empty resource returns `"grants": []` but still includes `roles` and `can_manage`.
 - `child` is `null` for parent-only resources.
 
 ### POST grant
@@ -320,9 +260,7 @@ POST /-/acl/api/resource/{resource_type}/{parent}/grant
 
 Adds actions for a principal on the resource.
 
-This endpoint is **idempotent** — only actions not
-already held are inserted, and each insert is written to the audit log
-(`operation: "added"`, `operation_by` = the calling actor's id).
+This endpoint is **idempotent** — actions already held are left unchanged and do not add audit rows. Each newly inserted action is written to the audit log (`operation: "added"`, `operation_by` = the calling actor's id).
 
 Returns the principal's full action-set after the grant.
 
@@ -371,12 +309,9 @@ To allow members of group 7 the ability to both `doc-view` and `doc-edit`:
 }
 ```
 
-`grant.grant` is the enriched [grant entry](#the-grant-entry-object) reflecting
-the principal's complete action-set (not just the newly-added actions).
+`grant.grant` is the enriched [grant entry](#the-grant-entry-object) reflecting the principal's complete action-set (not just the newly-added actions).
 
-**Errors:** `400` for missing/duplicate principal, neither/both of
-`role`/`actions`, an unknown `role`, or an unparseable body. `403` for authz or
-unknown resource type.
+**Errors:** `400` for missing/duplicate principal, neither/both of `role`/`actions`, an unknown `role`, or an unparseable body. `403` for authz or unknown resource type.
 
 ### POST update
 
@@ -385,15 +320,11 @@ POST /-/acl/api/resource/{resource_type}/{parent}/{child}/update
 POST /-/acl/api/resource/{resource_type}/{parent}/update
 ```
 
-Atomically **swaps** a principal's action-set on the resource to exactly the
-actions of the given role: actions in the new role that are missing are added,
-and currently-granted actions not in the new role are removed. Each change is
-audited. Returns the enriched grant.
+Atomically **swaps** a principal's action-set on the resource to exactly the actions of the given role: actions in the new role that are missing are added, and currently-granted actions not in the new role are removed. Each change is audited. Returns the enriched grant.
 
 **Authorization:** `can_manage`.
 
-**Body** — exactly one of `actor_id` / `group_id` / `principal_type`, plus a
-**required** `role`:
+**Body** — exactly one of `actor_id` / `group_id` / `principal_type`, plus a **required** `role`:
 
 | Field      | Type    | Notes                                    |
 | ---------- | ------- | ---------------------------------------- |
@@ -411,14 +342,9 @@ To replace the actor `bob`'s current actions with the "Viewer" role:
 }
 ```
 
-**Response `200`:** same `{ "ok": true, "grant": <entry> }` shape as
-[grant](#post-grant).
+**Response `200`:** same `{ "ok": true, "grant": <entry> }` shape as [grant](#post-grant).
 
-**Errors:** `400` if `role` is missing/unknown or the principal is invalid;
-`403` for authz / unknown resource type. Use `update` (not repeated
-grant/revoke) when you want the principal's actions to end up *exactly* equal to
-one role. To replace a principal's actions with an arbitrary raw `actions`
-list, first `revoke` that principal's grant and then `grant` the new `actions`.
+**Errors:** `400` if `role` is missing/unknown or the principal is invalid; `403` for authz / unknown resource type. Use `update` (not repeated grant/revoke) when you want the principal's actions to end up *exactly* equal to one role. To replace a principal's actions with an arbitrary raw `actions` list, first `revoke` that principal's grant and then `grant` the new `actions`.
 
 ### POST revoke
 
@@ -427,8 +353,7 @@ POST /-/acl/api/resource/{resource_type}/{parent}/{child}/revoke
 POST /-/acl/api/resource/{resource_type}/{parent}/revoke
 ```
 
-Removes **all** grants for a principal on the resource. Each removal is audited
-(`operation: "removed"`). Returns the action names that were removed.
+Removes **all** grants for a principal on the resource. Each removal is audited (`operation: "removed"`). Returns the action names that were removed.
 
 **Authorization:** `can_manage`.
 
@@ -459,11 +384,9 @@ A successful response lists the action names that were removed:
 }
 ```
 
-`removed` is sorted. Revoking a principal with no grants returns
-`"removed": []`.
+`removed` is sorted. Revoking a principal with no grants returns `"removed": []`.
 
-**Errors:** `400` for an invalid principal; `403` for authz / unknown resource
-type.
+**Errors:** `400` for an invalid principal; `403` for authz / unknown resource type.
 
 ### GET groups picker
 
@@ -472,18 +395,12 @@ GET /-/acl/api/groups
 GET /-/acl/api/groups?resource_type={type}&parent={parent}&child={child}
 ```
 
-Lists every active (non soft-deleted) group with a member count — the source
-for a group autocomplete. Ordered by group name.
+Lists every active (non soft-deleted) group with a member count — the source for a group autocomplete. Ordered by group name.
 
-**Authorization:** group names may be sensitive, so this endpoint is only
-available to callers who are trusted to manage permissions somewhere. There
-are two ways to qualify:
+**Authorization:** group names may be sensitive, so this endpoint is only available to callers who are trusted to manage permissions somewhere. There are two ways to qualify:
 
-- Global ACL admins can call `/groups` directly using the `datasette-acl`
-  permission.
-- Resource managers can pass `resource_type` and `parent` (`child` is
-  optional). Those query params are used only for the `can_manage` check on
-  that resource; they do not filter the returned groups.
+- Global ACL admins can call `/groups` directly using the `datasette-acl` permission.
+- Resource managers can pass `resource_type` and `parent` (`child` is optional). Those query params are used only for the `can_manage` check on that resource; they do not filter the returned groups.
 
 If neither check passes → `403`.
 
@@ -513,12 +430,7 @@ GET /-/acl/api/actors?q={query}&kind={kind}
 GET /-/acl/api/actors?q={query}&resource_type={type}&parent={parent}&child={child}
 ```
 
-Actor autocomplete. If the Datasette instance also has the [datasette-user-profiles](https://github.com/datasette/datasette-user-profiles)
-plugin installed, this proxies to its search API
-(`GET /-/profiles/api/search`), forwarding the caller's identity so the
-profiles access gate evaluates against the real caller. Otherwise it falls back
-to acl's own `datasette_acl_valid_actors` list, filtered by `q` as a
-case-insensitive substring of either the id or the display name.
+Actor autocomplete. If the Datasette instance also has the [datasette-user-profiles](https://github.com/datasette/datasette-user-profiles) plugin installed, this proxies to its search API (`GET /-/profiles/api/search`), forwarding the caller's identity so the profiles access gate evaluates against the real caller. Otherwise it falls back to acl's own `datasette_acl_valid_actors` list, filtered by `q` as a case-insensitive substring of either the id or the display name.
 
 **Query params:**
 
@@ -528,9 +440,7 @@ case-insensitive substring of either the id or the display name.
 | `kind`          | Optional kind filter, passed through to user-profiles when used. |
 | `resource_type` / `parent` / `child` | Optional; authorize as a per-resource Manager (see below). |
 
-**Authorization:** same rule as the groups picker — per-resource `can_manage`
-when `resource_type` + `parent` are supplied, else the global `datasette-acl`
-permission. Neither → `403`.
+**Authorization:** same rule as the groups picker — per-resource `can_manage` when `resource_type` + `parent` are supplied, else the global `datasette-acl` permission. Neither → `403`.
 
 **Response `200`:**
 
@@ -547,19 +457,13 @@ permission. Neither → `403`.
 }
 ```
 
-The exact fields depend on the backing source. The user-profiles backend may
-return richer records (avatar, email, kind such as `agent`). The acl-only
-fallback returns minimal entries: `{ "id", "display_name", "kind": "user" }`
-(no avatar/email). The profiles backend degrades gracefully: a missing route,
-non-200, or unparseable response yields `"results": []` (the picker stays
-usable) rather than an error.
+The exact fields depend on the backing source. The user-profiles backend may return richer records (avatar, email, kind such as `agent`). The acl-only fallback returns minimal entries: `{ "id", "display_name", "kind": "user" }` (no avatar/email). The profiles backend degrades gracefully: a missing route, non-200, or unparseable response yields `"results": []` (the picker stays usable) rather than an error.
 
 ---
 
 ## Worked example
 
-Assume a parent-only resource type `mock-doc`, document id `42`, with roles
-`Viewer` / `Editor` / `Manager`, called by an admin (cookie `ds_actor`).
+Assume a parent-only resource type `mock-doc`, document id `42`, with roles `Viewer` / `Editor` / `Manager`, called by an admin (cookie `ds_actor`).
 
 Read the current share state:
 
@@ -597,8 +501,7 @@ curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \
   -d '{"group_id": 7, "actions": ["doc-view"]}'
 ```
 
-Make the document public to signed-in users — the `authenticated` audience is
-named by `principal_type` alone:
+Make the document public to signed-in users — the `authenticated` audience is named by `principal_type` alone:
 
 ```bash
 curl -s -X POST 'https://example.org/-/acl/api/resource/mock-doc/42/grant' \

--- a/tests/sample-plugin/widgets.py
+++ b/tests/sample-plugin/widgets.py
@@ -28,7 +28,7 @@ turns into daily-planet / gotham-gazette groups for group-grant demos.
 from datasette import hookimpl, Forbidden, Response
 from datasette.permissions import Action, Resource
 
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import role_for_actions, roles_for, standard_roles
 
 # datasette-debug-gotham's demo actors (Clark Kent, Bruce Wayne, …). Imported
@@ -201,7 +201,7 @@ async def widgets_index(request, datasette):
             "widget",
             WIDGETS_PARENT,
             str(widget_id),
-            actor_id=actor_id,
+            principal=Principal.actor(actor_id),
             role="Manager",
             by_actor=actor_id,
         )

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -15,7 +15,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant, list_grants
+from datasette_acl.grants import grant, list_grants, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -284,7 +284,14 @@ async def test_grant_invalid_principal_type_is_400(api_ds):
 
 @pytest.mark.asyncio
 async def test_update_swaps_role(api_ds):
-    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         UPDATE_URL,
@@ -309,7 +316,14 @@ async def test_update_swaps_role(api_ds):
 
 @pytest.mark.asyncio
 async def test_revoke_removes_all(api_ds):
-    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         REVOKE_URL,
@@ -333,7 +347,14 @@ async def test_revoke_removes_all(api_ds):
 @pytest.mark.asyncio
 async def test_revoke_group(api_ds):
     gid = await _group_id(api_ds, "staff")
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         REVOKE_URL,
@@ -372,7 +393,14 @@ async def test_anonymous_cannot_grant(api_ds):
 async def test_manager_role_grants_manage_ability(api_ds):
     # Granting mallory the Manager role (which includes doc-manage) lets her
     # re-share, without the global datasette-acl permission.
-    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -387,7 +415,14 @@ async def test_manager_role_grants_manage_ability(api_ds):
 @pytest.mark.asyncio
 async def test_non_manager_role_cannot_grant(api_ds):
     # Editor is not a manage role, so it must NOT confer re-share ability.
-    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Editor", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Editor",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -406,7 +441,14 @@ async def test_group_manager_role_grants_manage_ability(api_ds):
         "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
         ["mallory", gid],
     )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -544,7 +586,12 @@ HTML_PAGE_URL = "/-/acl/resource/mock-doc/42"
 async def test_html_page_manager_can_view(api_ds):
     # mallory holds the Manager role on mock-doc/42 but is NOT the global admin.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 200
@@ -555,7 +602,12 @@ async def test_html_page_manager_can_grant_via_post(api_ds):
     # A per-resource Manager can grant a raw action through the HTML form,
     # without the global datasette-acl permission.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.post(
         HTML_PAGE_URL,
@@ -578,7 +630,12 @@ async def test_html_page_group_manager_can_view(api_ds):
         ["mallory", gid],
     )
     await grant(
-        api_ds, "mock-doc", "42", group_id=gid, role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 200
@@ -595,7 +652,12 @@ async def test_html_page_non_manager_forbidden(api_ds):
 async def test_html_page_non_manage_role_forbidden(api_ds):
     # Editor is not a manage role, so it must NOT unlock the admin page.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Editor", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Editor",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 403
@@ -635,7 +697,12 @@ async def test_grant_helper_rejects_unknown_raw_action(api_ds):
     # register, rather than silently inventing it.
     with pytest.raises(ValueError):
         await grant(
-            api_ds, "mock-doc", "42", actor_id="bob", actions=["not-real"], by_actor="root"
+            api_ds,
+            "mock-doc",
+            "42",
+            principal=Principal.actor("bob"),
+            actions=["not-real"],
+            by_actor="root",
         )
     # And nothing must have been persisted.
     assert "not-real" not in await _acl_action_names(api_ds)
@@ -664,7 +731,7 @@ async def test_grant_unknown_action_partial_list_is_atomic(api_ds):
             api_ds,
             "mock-doc",
             "42",
-            actor_id="bob",
+            principal=Principal.actor("bob"),
             actions=["doc-view", "not-real"],
             by_actor="root",
         )
@@ -678,7 +745,12 @@ async def test_future_action_name_not_persisted_as_stale_grant(api_ds):
     # mock-doc today, but which a future version might add. It must be rejected,
     # and must never reach acl_actions, so it cannot go live later.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await _post(
         api_ds,

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -216,17 +216,70 @@ async def test_grant_group(api_ds):
 
 
 @pytest.mark.asyncio
-async def test_grant_wildcard_principal(api_ds):
+async def test_grant_public_audience(api_ds):
+    # A public audience is granted by principal_type alone -- no actor_id --
+    # and stored with no id.
+    response = await _post(
+        api_ds,
+        GRANT_URL,
+        json={"principal_type": "authenticated", "role": "Viewer"},
+        cookies=_root_cookie(api_ds),
+    )
+    data = response.json()
+    assert data["grant"]["principal"] == "public"
+    assert data["grant"]["id"] == "authenticated"
+    assert data["grant"]["kind"] == "public"
+    assert data["grant"]["display_name"] == "Any signed-in user"
+    rows = [
+        dict(r)
+        for r in (
+            await api_ds.get_internal_database().execute(
+                "select principal_type, actor_id, group_id from acl"
+            )
+        ).rows
+    ]
+    assert rows == [
+        {"principal_type": "authenticated", "actor_id": None, "group_id": None}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_grant_actor_with_audience_looking_id(api_ds):
+    # An actor id that merely looks like a legacy wildcard is an ordinary
+    # actor grant: the stored row is 'actor' and the response kind is user.
     response = await _post(
         api_ds,
         GRANT_URL,
         json={"actor_id": "_signed_in", "role": "Viewer"},
         cookies=_root_cookie(api_ds),
     )
-    data = response.json()
-    assert data["grant"]["id"] == "_signed_in"
-    assert data["grant"]["kind"] == "public"
-    assert "display_name" not in data["grant"]
+    assert response.status_code == 200
+    assert response.json()["grant"]["kind"] == "user"
+    rows = [
+        dict(r)
+        for r in (
+            await api_ds.get_internal_database().execute(
+                "select principal_type, actor_id from acl"
+            )
+        ).rows
+    ]
+    assert rows == [{"principal_type": "actor", "actor_id": "_signed_in"}]
+
+
+@pytest.mark.asyncio
+async def test_grant_invalid_principal_type_is_400(api_ds):
+    for body in (
+        {"actor_id": "bob", "role": "Viewer", "principal_type": "everyone"},
+        {"actor_id": "bob", "role": "Viewer", "principal_type": "group"},
+        {"actor_id": "bob", "role": "Viewer", "principal_type": "alien"},
+        {"role": "Viewer", "principal_type": "alien"},
+        {"group_id": 1, "role": "Viewer", "principal_type": "anonymous"},
+    ):
+        response = await _post(
+            api_ds, GRANT_URL, json=body, cookies=_root_cookie(api_ds)
+        )
+        assert response.status_code == 400, body
+        assert response.json()["ok"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -18,7 +18,7 @@ from datasette import Response
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -369,7 +369,11 @@ async def resource_ds():
         await db.execute_write("INSERT INTO acl_groups (name) VALUES ('staff')")
         # bruce is a per-resource Manager (no global admin).
         await grant(
-            datasette, "mock-doc", "42", actor_id="bruce", role="Manager",
+            datasette,
+            "mock-doc",
+            "42",
+            principal=Principal.actor("bruce"),
+            role="Manager",
             by_actor="root",
         )
         yield datasette

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -7,9 +7,9 @@ The group picker draws from ``acl_groups`` (active groups + member counts). The
 actor picker is a thin proxy: it delegates to the user-profiles search API
 (``GET /-/profiles/api/search``) when installed, and otherwise falls back to
 ``datasette_acl_valid_actors`` filtered by ``q`` in Python. Both endpoints gate
-on the global ``datasette-acl`` permission. Wildcard / public principals
-(``*``, ``_signed_in``, ``_anonymous``) need no write path — they are plain
-``actor_id`` strings — so they are exercised through the grant helpers in
+on the global ``datasette-acl`` permission. Public audiences (``everyone``,
+``authenticated``, ``anonymous``) need no picker — they are a fixed set named
+by ``principal_type`` — so they are exercised through the grant helpers in
 ``test_custom_resources.py`` rather than here.
 """
 

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -2,11 +2,11 @@
 
     GET /-/acl/api/resource/{resource_type}/{parent}/{child}
 
-Seeds actor / group / wildcard grants on a mock resource and asserts the JSON
-shape: grants grouped by principal with a resolved role, actor enrichment from a
-fake ``actors_from_ids`` test plugin (display name / email / avatar / kind),
-group ``member_count``, wildcard principals flagged ``kind:"public"``, and the
-``roles`` registry + ``can_manage`` flag.
+Seeds actor / group / public-audience grants on a mock resource and asserts the
+JSON shape: grants grouped by principal with a resolved role, actor enrichment
+from a fake ``actors_from_ids`` test plugin (display name / email / avatar /
+kind), group ``member_count``, public audiences flagged ``kind:"public"``, and
+the ``roles`` registry + ``can_manage`` flag.
 """
 
 from datasette import hookimpl
@@ -185,7 +185,12 @@ async def test_read_full_shape(api_ds):
     )
     await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
     await grant(
-        api_ds, "mock-doc", "42", actor_id="_signed_in", role="Viewer", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal_type="authenticated",
+        role="Viewer",
+        by_actor="root",
     )
 
     response = await _get(
@@ -227,12 +232,13 @@ async def test_read_full_shape(api_ds):
     assert group["display_name"] == "staff"
     assert group["member_count"] == 0
 
-    # Wildcard principal flagged public.
-    wildcard = grants[("actor", "_signed_in")]
-    assert wildcard["role"] == "Viewer"
-    assert wildcard["kind"] == "public"
-    # No enrichment looked up for a wildcard principal.
-    assert "display_name" not in wildcard
+    # Public audience flagged public; its id echoes the audience type and the
+    # display name is the friendly label (never looked up via actors_from_ids).
+    public = grants[("public", "authenticated")]
+    assert public["role"] == "Viewer"
+    assert public["kind"] == "public"
+    assert public["display_name"] == "Any signed-in user"
+    assert "email" not in public
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -13,7 +13,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -166,7 +166,14 @@ async def test_read_nonexistent_resource_forbidden(api_ds):
 async def test_per_resource_manager_can_read(api_ds):
     # Grant alice the Manager role (which includes the manage action) and prove
     # she can read the endpoint without the global datasette-acl permission.
-    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
     cookies = {"ds_actor": api_ds.client.actor_cookie({"id": "alice"})}
     response = await _get(api_ds, "/-/acl/api/resource/mock-doc/42", cookies=cookies)
     assert response.status_code == 200
@@ -179,16 +186,35 @@ async def test_per_resource_manager_can_read(api_ds):
 @pytest.mark.asyncio
 async def test_read_full_shape(api_ds):
     gid = await _group_id(api_ds, "staff")
-    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
-    await grant(
-        api_ds, "mock-doc", "42", actor_id="agent:researcher", role="Editor", by_actor="root"
-    )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
     await grant(
         api_ds,
         "mock-doc",
         "42",
-        principal_type="authenticated",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("agent:researcher"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.public("authenticated"),
         role="Viewer",
         by_actor="root",
     )
@@ -250,7 +276,14 @@ async def test_group_member_count(api_ds):
             "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
             [actor_id, gid],
         )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _get(
         api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
     )
@@ -275,7 +308,14 @@ async def test_read_empty_resource(api_ds):
 @pytest.mark.asyncio
 async def test_unknown_actor_falls_back(api_ds):
     # An actor with no directory entry still resolves (kind user, no names).
-    await grant(api_ds, "mock-doc", "42", actor_id="ghost", role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("ghost"),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _get(
         api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
     )

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -8,6 +8,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
+from datasette_acl.grants import grant, revoke
 import pytest
 import pytest_asyncio
 
@@ -87,20 +88,64 @@ async def _upsert_resource_id(db, resource_type, parent, child):
     )
 
 
-async def _grant_actor(datasette, *, actor_id, resource_type, parent, child, action):
+async def _grant_actor(
+    datasette,
+    *,
+    actor_id,
+    resource_type,
+    parent,
+    child,
+    action,
+):
     db = datasette.get_internal_database()
     resource_id = await _upsert_resource_id(db, resource_type, parent, child)
     await db.execute_write(
         """
-        INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+        INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
         VALUES (
+            'actor',
             :actor_id,
             null,
             :resource_id,
             (SELECT id FROM acl_actions WHERE name = :action)
         )
         """,
-        {"actor_id": actor_id, "resource_id": resource_id, "action": action},
+        {
+            "actor_id": actor_id,
+            "resource_id": resource_id,
+            "action": action,
+        },
+    )
+
+
+async def _grant_public(
+    datasette,
+    *,
+    principal_type,
+    resource_type,
+    parent,
+    child,
+    action,
+):
+    # Public audiences are identified by principal_type alone -- no id.
+    db = datasette.get_internal_database()
+    resource_id = await _upsert_resource_id(db, resource_type, parent, child)
+    await db.execute_write(
+        """
+        INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
+        VALUES (
+            :principal_type,
+            null,
+            null,
+            :resource_id,
+            (SELECT id FROM acl_actions WHERE name = :action)
+        )
+        """,
+        {
+            "principal_type": principal_type,
+            "resource_id": resource_id,
+            "action": action,
+        },
     )
 
 
@@ -119,8 +164,9 @@ async def _grant_group(datasette, *, group_name, resource_type, parent, child, a
     resource_id = await _upsert_resource_id(db, resource_type, parent, child)
     await db.execute_write(
         """
-        INSERT INTO acl (actor_id, group_id, resource_id, action_id)
+        INSERT INTO acl (principal_type, actor_id, group_id, resource_id, action_id)
         VALUES (
+            'group',
             null,
             :group_id,
             :resource_id,
@@ -205,11 +251,11 @@ async def test_resource_type_does_not_leak(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_signed_in_wildcard_grant(widget_ds):
-    # Grant _signed_in => any actor with an id is allowed, anonymous is not
-    await _grant_actor(
+async def test_authenticated_public_grant(widget_ds):
+    # 'authenticated' => any actor with an id is allowed, anonymous is not
+    await _grant_public(
         widget_ds,
-        actor_id="_signed_in",
+        principal_type="authenticated",
         resource_type="widget",
         parent="shelf",
         child="gadget",
@@ -225,11 +271,11 @@ async def test_signed_in_wildcard_grant(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_star_wildcard_grant(widget_ds):
-    # Grant '*' => literally anyone, including anonymous
-    await _grant_actor(
+async def test_everyone_public_grant(widget_ds):
+    # 'everyone' => literally anyone, including anonymous
+    await _grant_public(
         widget_ds,
-        actor_id="*",
+        principal_type="everyone",
         resource_type="widget",
         parent="shelf",
         child="gadget",
@@ -245,12 +291,12 @@ async def test_star_wildcard_grant(widget_ds):
 
 
 @pytest.mark.asyncio
-async def test_anonymous_wildcard_grant(widget_ds):
-    # Grant '_anonymous' => only unauthenticated callers; a signed-in actor is not
+async def test_anonymous_public_grant(widget_ds):
+    # 'anonymous' => only unauthenticated callers; a signed-in actor is not
     # matched by this grant.
-    await _grant_actor(
+    await _grant_public(
         widget_ds,
-        actor_id="_anonymous",
+        principal_type="anonymous",
         resource_type="widget",
         parent="shelf",
         child="gadget",
@@ -262,6 +308,93 @@ async def test_anonymous_wildcard_grant(widget_ds):
     )
     assert not await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+@pytest.mark.asyncio
+async def test_actor_grant_with_legacy_wildcard_looking_id(widget_ds):
+    # An actor whose id happens to look like an old wildcard is just an
+    # ordinary actor: the grant allows exactly that signed-in user and never
+    # anonymous callers.
+    resource = WidgetResource("shelf", "gadget")
+    await grant(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        actor_id="_anonymous",
+        actions=["widget-view"],
+        by_actor="root",
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "someone-else"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_public_and_actor_grants_coexist(widget_ds):
+    # An 'anonymous' audience grant and an actor grant for a user literally
+    # named '_anonymous' are distinct rows: each matches only its own
+    # audience, and revoking one leaves the other.
+    resource = WidgetResource("shelf", "gadget")
+    await grant(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        principal_type="anonymous",
+        actions=["widget-view"],
+        by_actor="root",
+    )
+    await grant(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        actor_id="_anonymous",
+        actions=["widget-view"],
+        by_actor="root",
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
+    )
+    # Other signed-in users match neither row
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "someone-else"}
+    )
+    # Revoking the audience leaves the actor's grant intact...
+    await revoke(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        principal_type="anonymous",
+        by_actor="root",
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
+    )
+    # ...and vice versa.
+    await revoke(
+        widget_ds,
+        "widget",
+        "shelf",
+        "gadget",
+        actor_id="_anonymous",
+        by_actor="root",
+    )
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "_anonymous"}
     )
 
 
@@ -384,8 +517,6 @@ async def test_generic_resource_view_grants_via_post(widget_ds):
     assert not await widget_ds.allowed(
         action="widget-view", resource=resource, actor=actor
     )
-
-
 @pytest.mark.asyncio
 async def test_generic_resource_view_revokes_via_post(widget_ds):
     actor = {"id": "alice"}

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -8,7 +8,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant, revoke
+from datasette_acl.grants import grant, revoke, Principal
 import pytest
 import pytest_asyncio
 
@@ -320,7 +320,7 @@ async def test_actor_grant_with_legacy_wildcard_looking_id(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -346,7 +346,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        principal_type="anonymous",
+        principal=Principal.anonymous(),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -355,7 +355,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -375,7 +375,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        principal_type="anonymous",
+        principal=Principal.anonymous(),
         by_actor="root",
     )
     assert not await widget_ds.allowed(
@@ -390,7 +390,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         by_actor="root",
     )
     assert not await widget_ds.allowed(

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -14,7 +14,7 @@ from datasette_acl.grants import (
     revoke,
     update_role,
     list_grants,
-    principal_type_for,
+    Principal,
     _insert_grant,
 )
 from datasette_acl.roles import AclRole
@@ -179,7 +179,12 @@ async def test_build_resource_unknown_type(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_by_role(grants_ds):
     result = await grant(
-        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
@@ -192,7 +197,12 @@ async def test_grant_by_role(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_by_raw_actions(grants_ds):
     result = await grant(
-        grants_ds, "doc", "42", actor_id="bob", actions=["doc-view"], by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("bob"),
+        actions=["doc-view"],
+        by_actor="root",
     )
     assert result == ["doc-view"]
     assert await _actions_for(grants_ds, "bob") == ["doc-view"]
@@ -200,10 +210,22 @@ async def test_grant_by_raw_actions(grants_ds):
 
 @pytest.mark.asyncio
 async def test_grant_is_idempotent(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
     # Granting again with overlap only inserts the new action
     result = await grant(
-        grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-manage", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == [
@@ -224,7 +246,12 @@ async def test_grant_is_idempotent(grants_ds):
 async def test_grant_to_group(grants_ds):
     gid = await _group_id(grants_ds, "staff")
     result = await grant(
-        grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
     )
     assert result == ["doc-view"]
     grants = await list_grants(grants_ds, "doc", "42")
@@ -242,25 +269,27 @@ async def test_grant_to_group(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_unknown_role_raises(grants_ds):
     with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="alice", role="Nope")
-
-
-@pytest.mark.asyncio
-async def test_grant_requires_exactly_one_principal(grants_ds):
-    with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", role="Viewer")
-    gid = await _group_id(grants_ds, "staff")
-    with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="a", group_id=gid, role="Viewer")
+        await grant(
+            grants_ds,
+            "doc",
+            "42",
+            principal=Principal.actor("alice"),
+            role="Nope",
+        )
 
 
 @pytest.mark.asyncio
 async def test_grant_requires_exactly_one_of_role_or_actions(grants_ds):
     with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="a")
+        await grant(grants_ds, "doc", "42", principal=Principal.actor("a"))
     with pytest.raises(ValueError):
         await grant(
-            grants_ds, "doc", "42", actor_id="a", role="Viewer", actions=["doc-view"]
+            grants_ds,
+            "doc",
+            "42",
+            principal=Principal.actor("a"),
+            role="Viewer",
+            actions=["doc-view"],
         )
 
 
@@ -269,17 +298,50 @@ async def test_grant_requires_exactly_one_of_role_or_actions(grants_ds):
 
 @pytest.mark.asyncio
 async def test_revoke_removes_all_rows(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
-    removed = await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
+    removed = await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     assert removed == ["doc-edit", "doc-manage", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == []
 
 
 @pytest.mark.asyncio
 async def test_revoke_only_targets_principal(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", actor_id="bob", role="Viewer", by_actor="root")
-    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Viewer",
+        by_actor="root",
+    )
+    await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     assert await _actions_for(grants_ds, "alice") == []
     assert await _actions_for(grants_ds, "bob") == ["doc-view"]
 
@@ -289,9 +351,21 @@ async def test_revoke_only_targets_principal(grants_ds):
 
 @pytest.mark.asyncio
 async def test_update_role_swaps_atomically(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
     result = await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
     )
     assert result == ["doc-view"]
     # Only doc-view remains: doc-edit and doc-manage removed
@@ -300,9 +374,21 @@ async def test_update_role_swaps_atomically(grants_ds):
 
 @pytest.mark.asyncio
 async def test_update_role_upgrades(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
+    )
     result = await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
@@ -313,11 +399,29 @@ async def test_update_role_upgrades(grants_ds):
 
 @pytest.mark.asyncio
 async def test_audit_rows_written(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="admin"
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
-    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await update_role(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="admin",
+    )
+    await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     ops = await _audit_ops(grants_ds)
     # grant Editor: +doc-view +doc-edit; update to Viewer: -doc-edit;
     # revoke: -doc-view
@@ -336,8 +440,22 @@ async def test_audit_rows_written(grants_ds):
 @pytest.mark.asyncio
 async def test_list_grants_actor_and_group(grants_ds):
     gid = await _group_id(grants_ds, "staff")
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     grants = await list_grants(grants_ds, "doc", "42")
     assert grants == [
         {
@@ -369,10 +487,29 @@ async def test_list_grants_public_principal_and_ordering(grants_ds):
     # then groups, then audiences.
     gid = await _group_id(grants_ds, "staff")
     await grant(
-        grants_ds, "doc", "42", principal_type="everyone", role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.public("everyone"),
+        role="Viewer",
+        by_actor="root",
     )
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     grants = await list_grants(grants_ds, "doc", "42")
     assert [(g["principal"], g["actor_id"], g["group_id"]) for g in grants] == [
         ("actor", "alice", None),
@@ -381,50 +518,49 @@ async def test_list_grants_public_principal_and_ordering(grants_ds):
     ]
 
 
-# --- principal_type -------------------------------------------------------
+# --- Principal ------------------------------------------------------------
 
 
-def test_principal_type_for():
+def test_principal_constructors():
+    assert Principal.actor("alice") == Principal("actor", actor_id="alice")
+    assert Principal.group(1) == Principal("group", group_id=1)
+    assert Principal.everyone() == Principal("everyone")
+    assert Principal.authenticated() == Principal("authenticated")
+    assert Principal.anonymous() == Principal("anonymous")
+    assert Principal.public("everyone") == Principal("everyone")
+    # public() rejects names that aren't a known audience
+    with pytest.raises(ValueError):
+        Principal.public("actor")
+
+
+def test_principal_from_parts():
     # Resolution from whichever id was supplied
-    assert principal_type_for("alice", None) == "actor"
-    assert principal_type_for(None, 1) == "group"
+    assert Principal.from_parts("alice", None) == Principal.actor("alice")
+    assert Principal.from_parts(None, 1) == Principal.group(1)
     # Redundant explicit types are accepted alongside the matching id
-    assert principal_type_for("alice", None, "actor") == "actor"
-    assert principal_type_for(None, 1, "group") == "group"
+    assert Principal.from_parts("alice", None, "actor") == Principal.actor("alice")
+    assert Principal.from_parts(None, 1, "group") == Principal.group(1)
     # Public audiences are named by principal_type alone, with no id
-    assert principal_type_for(None, None, "everyone") == "everyone"
-    assert principal_type_for(None, None, "authenticated") == "authenticated"
-    assert principal_type_for(None, None, "anonymous") == "anonymous"
+    assert Principal.from_parts(None, None, "everyone") == Principal.everyone()
+    assert Principal.from_parts(None, None, "authenticated") == Principal.authenticated()
+    assert Principal.from_parts(None, None, "anonymous") == Principal.anonymous()
     # Invalid combinations
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "everyone")  # audience with actor_id
+        Principal.from_parts("bob", None, "everyone")  # audience with actor_id
     with pytest.raises(ValueError):
-        principal_type_for(None, 1, "anonymous")  # audience with group_id
+        Principal.from_parts(None, 1, "anonymous")  # audience with group_id
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "group")  # group needs group_id
+        Principal.from_parts("bob", None, "group")  # group needs group_id
     with pytest.raises(ValueError):
-        principal_type_for(None, 1, "actor")  # group_id with actor type
+        Principal.from_parts(None, 1, "actor")  # group_id with actor type
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "alien")  # unknown type
+        Principal.from_parts("bob", None, "alien")  # unknown type
     with pytest.raises(ValueError):
-        principal_type_for(None, None)  # no principal
+        Principal.from_parts(None, None)  # no principal
     with pytest.raises(ValueError):
-        principal_type_for(None, None, "actor")  # actor type without an id
+        Principal.from_parts(None, None, "actor")  # actor type without an id
     with pytest.raises(ValueError):
-        principal_type_for("bob", 1)  # both ids
-
-
-@pytest.mark.asyncio
-async def test_grant_audience_with_actor_id_raises(grants_ds):
-    with pytest.raises(ValueError):
-        await grant(
-            grants_ds,
-            "doc",
-            "42",
-            actor_id="bob",
-            role="Viewer",
-            principal_type="everyone",
-        )
+        Principal.from_parts("bob", 1)  # both ids
 
 
 @pytest.mark.asyncio
@@ -452,7 +588,14 @@ async def test_insert_grant_dedupes(grants_ds):
     # read-modify-write guard -- yield one row: the partial unique indexes
     # actually enforce non-duplication (the old UNIQUE constraint never fired
     # across its always-NULL columns).
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
+    )
     db = grants_ds.get_internal_database()
     resource_id = (
         await db.execute(
@@ -461,7 +604,7 @@ async def test_insert_grant_dedupes(grants_ds):
     ).single_value()
     for _ in range(2):
         await _insert_grant(
-            db, resource_id, "actor", "alice", None, "doc-view", "root"
+            db, resource_id, Principal.actor("alice"), "doc-view", "root"
         )
     count = (
         await db.execute("select count(*) from acl where actor_id = 'alice'")
@@ -470,7 +613,7 @@ async def test_insert_grant_dedupes(grants_ds):
     # Same for a public audience (covered by acl_public_unique)
     for _ in range(2):
         await _insert_grant(
-            db, resource_id, "everyone", None, None, "doc-view", "root"
+            db, resource_id, Principal.everyone(), "doc-view", "root"
         )
     count = (
         await db.execute(

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -9,7 +9,14 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.grants import (
+    grant,
+    revoke,
+    update_role,
+    list_grants,
+    principal_type_for,
+    _insert_grant,
+)
 from datasette_acl.roles import AclRole
 from datasette_acl.utils import build_resource
 import pytest
@@ -353,3 +360,121 @@ async def test_list_grants_actor_and_group(grants_ds):
 @pytest.mark.asyncio
 async def test_list_grants_empty(grants_ds):
     assert await list_grants(grants_ds, "doc", "42") == []
+
+
+@pytest.mark.asyncio
+async def test_list_grants_public_principal_and_ordering(grants_ds):
+    # Public-audience grants come back with principal naming the audience,
+    # straight from the stored column, with no id; the list is ordered actors,
+    # then groups, then audiences.
+    gid = await _group_id(grants_ds, "staff")
+    await grant(
+        grants_ds, "doc", "42", principal_type="everyone", role="Viewer", by_actor="root"
+    )
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    grants = await list_grants(grants_ds, "doc", "42")
+    assert [(g["principal"], g["actor_id"], g["group_id"]) for g in grants] == [
+        ("actor", "alice", None),
+        ("group", None, gid),
+        ("everyone", None, None),
+    ]
+
+
+# --- principal_type -------------------------------------------------------
+
+
+def test_principal_type_for():
+    # Resolution from whichever id was supplied
+    assert principal_type_for("alice", None) == "actor"
+    assert principal_type_for(None, 1) == "group"
+    # Redundant explicit types are accepted alongside the matching id
+    assert principal_type_for("alice", None, "actor") == "actor"
+    assert principal_type_for(None, 1, "group") == "group"
+    # Public audiences are named by principal_type alone, with no id
+    assert principal_type_for(None, None, "everyone") == "everyone"
+    assert principal_type_for(None, None, "authenticated") == "authenticated"
+    assert principal_type_for(None, None, "anonymous") == "anonymous"
+    # Invalid combinations
+    with pytest.raises(ValueError):
+        principal_type_for("bob", None, "everyone")  # audience with actor_id
+    with pytest.raises(ValueError):
+        principal_type_for(None, 1, "anonymous")  # audience with group_id
+    with pytest.raises(ValueError):
+        principal_type_for("bob", None, "group")  # group needs group_id
+    with pytest.raises(ValueError):
+        principal_type_for(None, 1, "actor")  # group_id with actor type
+    with pytest.raises(ValueError):
+        principal_type_for("bob", None, "alien")  # unknown type
+    with pytest.raises(ValueError):
+        principal_type_for(None, None)  # no principal
+    with pytest.raises(ValueError):
+        principal_type_for(None, None, "actor")  # actor type without an id
+    with pytest.raises(ValueError):
+        principal_type_for("bob", 1)  # both ids
+
+
+@pytest.mark.asyncio
+async def test_grant_audience_with_actor_id_raises(grants_ds):
+    with pytest.raises(ValueError):
+        await grant(
+            grants_ds,
+            "doc",
+            "42",
+            actor_id="bob",
+            role="Viewer",
+            principal_type="everyone",
+        )
+
+
+@pytest.mark.asyncio
+async def test_raw_audience_insert_with_actor_id_rejected(grants_ds):
+    # The CHECK constraint is the storage-layer backstop behind the Python
+    # validation: an audience row carrying an actor_id can never be stored,
+    # even by raw SQL.
+    import sqlite3
+
+    db = grants_ds.get_internal_database()
+    with pytest.raises(sqlite3.IntegrityError):
+        await db.execute_write(
+            """
+            insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
+            values ('everyone', 'bob', null,
+                (select min(id) from acl_resources),
+                (select min(id) from acl_actions))
+            """
+        )
+
+
+@pytest.mark.asyncio
+async def test_insert_grant_dedupes(grants_ds):
+    # Two identical _insert_grant calls -- bypassing grant()'s
+    # read-modify-write guard -- yield one row: the partial unique indexes
+    # actually enforce non-duplication (the old UNIQUE constraint never fired
+    # across its always-NULL columns).
+    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    db = grants_ds.get_internal_database()
+    resource_id = (
+        await db.execute(
+            "select id from acl_resources where resource_type = 'doc' and parent = '42'"
+        )
+    ).single_value()
+    for _ in range(2):
+        await _insert_grant(
+            db, resource_id, "actor", "alice", None, "doc-view", "root"
+        )
+    count = (
+        await db.execute("select count(*) from acl where actor_id = 'alice'")
+    ).single_value()
+    assert count == 1
+    # Same for a public audience (covered by acl_public_unique)
+    for _ in range(2):
+        await _insert_grant(
+            db, resource_id, "everyone", None, None, "doc-view", "root"
+        )
+    count = (
+        await db.execute(
+            "select count(*) from acl where principal_type = 'everyone'"
+        )
+    ).single_value()
+    assert count == 1

--- a/tests/test_table_acls.py
+++ b/tests/test_table_acls.py
@@ -543,7 +543,7 @@ async def test_table_creator_permissions():
 
 @pytest.mark.asyncio
 async def test_fresh_acl_resources_schema():
-    # A fresh internal DB should get the new (resource_type, parent, child) schema.
+    # A fresh internal DB has the (resource_type, parent, child) schema.
     datasette = Datasette(memory=True)
     await datasette.invoke_startup()
     db = datasette.get_internal_database()
@@ -551,60 +551,52 @@ async def test_fresh_acl_resources_schema():
     assert cols == ["id", "resource_type", "parent", "child"]
 
 
-@pytest.mark.asyncio
-async def test_acl_resources_migration():
-    # Drive the migrations directly: apply everything up to m002 to get the OLD
-    # (database, resource) acl_resources schema, insert rows, then run m002 and
-    # assert the data migrates to (resource_type, parent, child), backfilling
-    # resource_type='table' and preserving id/parent/child values.
-    datasette = Datasette(memory=True)
-    db = datasette.get_internal_database()
+def test_acl_schema_constraints():
+    # A fresh internal DB enforces the acl shape at the SQL layer: the CHECK
+    # constraint rejects malformed principal rows and the partial unique
+    # indexes dedupe each principal kind. Uses a plain sqlite_utils Database
+    # (not Datasette's internal db wrapper, which needs a started-up Datasette)
+    # to drive the migrations outside the startup hook.
+    import sqlite3
 
-    await db.execute_write_fn(
-        lambda conn: internal_migrations.apply(
-            Database(conn), stop_before="m002_generalize_acl_resources"
-        )
+    db = Database(memory=True)
+    internal_migrations.apply(db)
+
+    db.execute("insert into acl_resources (resource_type, parent) values ('doc', '42')")
+    db.execute("insert into acl_actions (name) values ('doc-view')")
+    db.execute("insert into acl_groups (name) values ('staff')")
+    insert = (
+        "insert into acl (principal_type, actor_id, group_id, resource_id, action_id) "
+        "values (?, ?, ?, 1, 1)"
     )
+    db.execute(insert, ["actor", "alice", None])
+    db.execute(insert, ["group", None, 1])
+    db.execute(insert, ["authenticated", None, None])
+    assert db.execute("select count(*) from acl").fetchone()[0] == 3
 
-    # m001 created acl_resources with the old (database, resource) columns
-    cols_before = [
-        r["name"] for r in (await db.execute("PRAGMA table_info(acl_resources)"))
-    ]
-    assert cols_before == ["id", "database", "resource"]
+    # The partial unique indexes dedupe per kind: re-inserting an existing
+    # (actor / group / audience) grant with OR IGNORE is a no-op.
+    db.execute(insert.replace("insert into", "insert or ignore into"), ["actor", "alice", None])
+    db.execute(insert.replace("insert into", "insert or ignore into"), ["group", None, 1])
+    db.execute(insert.replace("insert into", "insert or ignore into"), ["authenticated", None, None])
+    assert db.execute("select count(*) from acl").fetchone()[0] == 3
 
-    await db.execute_write(
-        "insert into acl_resources (database, resource) values (?, ?)", ["db1", "t1"]
-    )
-    await db.execute_write(
-        "insert into acl_resources (database, resource) values (?, ?)", ["db2", "t2"]
-    )
+    # An actor whose id merely looks like an old wildcard is an ordinary actor
+    # row -- no reserved id namespace exists, so it coexists with the audience.
+    db.execute(insert, ["actor", "_signed_in", None])
+    assert db.execute("select count(*) from acl").fetchone()[0] == 4
 
-    # Apply the remaining migrations (m002)
-    await db.execute_write_fn(lambda conn: internal_migrations.apply(Database(conn)))
-
-    cols_after = [
-        r["name"] for r in (await db.execute("PRAGMA table_info(acl_resources)"))
-    ]
-    assert cols_after == ["id", "resource_type", "parent", "child"]
-
-    rows = [
-        dict(r)
-        for r in (await db.execute("select * from acl_resources order by id"))
-    ]
-    assert rows == [
-        {"id": 1, "resource_type": "table", "parent": "db1", "child": "t1"},
-        {"id": 2, "resource_type": "table", "parent": "db2", "child": "t2"},
-    ]
-    # The leftover scratch table must be gone.
-    assert "acl_resources_old" not in await db.table_names()
-
-    # Re-applying is idempotent: no error, no duplicate rows.
-    await db.execute_write_fn(lambda conn: internal_migrations.apply(Database(conn)))
-    rows_again = [
-        dict(r)
-        for r in (await db.execute("select * from acl_resources order by id"))
-    ]
-    assert rows_again == rows
+    # CHECK rejects malformed shapes.
+    for bad in (
+        ("everyone", "bob", None),  # audience with an actor_id
+        ("anonymous", None, 1),  # audience with a group_id
+        ("actor", None, None),  # actor without an id
+        ("actor", "carol", 1),  # actor with a group_id
+        ("group", "carol", None),  # group with an actor_id
+        ("alien", "dave", None),  # unknown principal_type
+    ):
+        with pytest.raises(sqlite3.IntegrityError):
+            db.execute(insert, list(bad))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
> *Note: this description was generated with Claude.*

## `principal_type`: explicit storage model + enforcement + JSON API

Introduces a `principal_type` column as the whole principal model — `actor`, `group`, and three public audiences (`everyone` / `authenticated` / `anonymous`) that carry no id at all — replacing the old in-band wildcard actor-ids (`*`, `_signed_in`, `_anonymous`).

**Why it matters.** Storing public audiences as magic `actor_id` strings let an actor literally named `_anonymous` match an anonymous-audience grant. Audiences now have no id, so no actor id can collide with one. Enforcement branches purely on `principal_type`:

```sql
a.principal_type = 'everyone'
OR (:actor_id IS NOT NULL AND a.principal_type = 'actor' AND a.actor_id = :actor_id)
OR (:actor_id IS NOT NULL AND a.principal_type = 'authenticated')
OR (:actor_id IS NULL  AND a.principal_type = 'anonymous')
OR (a.principal_type = 'group' AND a.group_id IN (...))
```

**What a maintainer needs to know**
- `m001_initial` builds the final schema directly — the column, its `CHECK` constraint, and partial unique indexes. There are no released DBs to migrate, so the old `m002`–`m004` migration dance is collapsed away.
- `grants.py` threads `principal_type` through the single write choke point; `grant()/revoke()/update_role()` each take one of `actor_id=`, `group_id=`, or an audience `principal_type=`.
- The JSON API grants audiences via `{"principal_type": "authenticated"}` and renders them as `{"principal": "public", "id": "<audience>", "kind": "public"}`.
- Admin views are rewired to read/write explicit `principal_type`. The **admin web UI general-access section is intentionally deferred to PR 5** — this PR is storage + enforcement + JSON API.

**Testing**
`test_grants.py`, `test_api_*`, `test_custom_resources.py` and `test_table_acls.py` cover the fresh-schema `CHECK`/dedup, the `_anonymous` leak regression, and audience/actor coexistence. Full suite green.

---
**Merge** — PR 3 of 5 (the large one). Base: `asg017/2-roles-on-demand`. Merge after PR 2 (auto-retargets to `main` once PR 2's branch is deleted). See `STACK-MERGE.md`.
