### PR TITLE
2/5 Gather acl roles on demand, drop _acl_roles_registry cache

### DIFF
--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -16,7 +16,6 @@ from datasette_acl.views.api import (
     groups_json,
     actors_json,
 )
-from datasette_acl.roles import build_roles_registry
 from sqlite_utils import Database
 from . import hookspecs
 import json
@@ -84,11 +83,6 @@ def startup(datasette):
                 "insert or ignore into acl_groups (name) values (:name)",
                 [{"name": name} for name in groups.keys()],
             )
-        # Collect friendly roles declared by plugins via datasette_acl_roles
-        # into a registry keyed by resource_type and stash it on datasette.
-        # Re-gathering is cheap; we do it once at startup.
-        datasette._acl_roles_registry = await build_roles_registry(datasette)
-
     return inner
 
 

--- a/datasette_acl/hookspecs.py
+++ b/datasette_acl/hookspecs.py
@@ -26,7 +26,7 @@ def datasette_acl_roles(datasette):
     wins for display) and `manage=True` marks the role(s) whose actions
     authorize re-sharing the resource.
 
-    May return a list directly, or a function / awaitable returning one.
+    Return a list of AclRole directly.
 
     For the common Viewer/Editor/Manager triple, use
     ``datasette_acl.roles.standard_roles()`` instead of declaring each

--- a/datasette_acl/roles.py
+++ b/datasette_acl/roles.py
@@ -2,9 +2,9 @@
 
 acl stores per-action grants, but users think in roles (Viewer / Editor /
 Manager). Plugins declare roles for their resource types via the
-``datasette_acl_roles`` hook; they are collected at startup into a registry
-keyed by ``resource_type``. Helpers resolve a granted action-set to its
-best-matching role and back.
+``datasette_acl_roles`` hook; :func:`roles_for` gathers them on demand into a
+registry keyed by ``resource_type``. Helpers resolve a granted action-set to
+its best-matching role and back.
 """
 
 from __future__ import annotations
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
 from datasette.plugins import pm
-from datasette.utils import await_me_maybe
 
 if TYPE_CHECKING:
     from datasette.app import Datasette
@@ -119,17 +118,16 @@ def standard_roles(
     ]
 
 
-async def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
+def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
     """Gather declared roles into ``{resource_type: [AclRole, ...]}``.
 
-    Calls the ``datasette_acl_roles`` hook across all plugins, awaiting any
-    callables/awaitables they return, and groups the resulting AclRole objects
-    by ``resource_type``. Within each resource type the roles are sorted by
-    ``rank`` ascending (so the highest-rank role is last) for stable ordering.
+    Calls the ``datasette_acl_roles`` hook across all plugins and groups the
+    resulting AclRole objects by ``resource_type``. Within each resource type
+    the roles are sorted by ``rank`` ascending (so the highest-rank role is
+    last) for stable ordering.
     """
     registry: Dict[str, List[AclRole]] = {}
-    for hook_result in pm.hook.datasette_acl_roles(datasette=datasette):
-        roles = await await_me_maybe(hook_result)
+    for roles in pm.hook.datasette_acl_roles(datasette=datasette):
         if not roles:
             continue
         for role in roles:
@@ -142,13 +140,11 @@ async def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
 def roles_for(datasette: Datasette, resource_type: str) -> List[AclRole]:
     """Return the registered roles for ``resource_type`` (``[]`` if none).
 
-    Reads the registry cached on the Datasette instance at startup by
-    :func:`build_roles_registry` (see ``datasette_acl.startup``). Shared by the
-    grants layer and the JSON API so neither pokes ``_acl_roles_registry``
-    directly.
+    Gathers roles from the ``datasette_acl_roles`` hook on demand via
+    :func:`build_roles_registry`. Shared by the grants layer and the JSON API
+    as the single way to ask "what roles exist for this resource type?".
     """
-    registry = getattr(datasette, "_acl_roles_registry", None) or {}
-    return registry.get(resource_type, [])
+    return build_roles_registry(datasette).get(resource_type, [])
 
 
 def role_for_actions(

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,5 +1,5 @@
 """
-Tests for the friendly-roles layer: the datasette_acl_roles hook, the startup
+Tests for the friendly-roles layer: the datasette_acl_roles hook, the
 registry keyed by resource_type, and the role<->action resolution helpers.
 """
 
@@ -9,6 +9,7 @@ from datasette.permissions import Action, Resource
 from datasette.plugins import pm
 from datasette_acl.roles import (
     AclRole,
+    build_roles_registry,
     role_for_actions,
     actions_for_role,
     manage_actions,
@@ -76,7 +77,7 @@ async def doc_ds():
 
 @pytest.mark.asyncio
 async def test_registry_built_and_grouped_by_resource_type(doc_ds):
-    registry = doc_ds._acl_roles_registry
+    registry = build_roles_registry(doc_ds)
     assert set(registry.keys()) == {"mock-doc"}
     roles = registry["mock-doc"]
     # All three roles present, sorted by rank ascending


### PR DESCRIPTION
> *Note: this description was generated with Claude.*

## Gather acl roles on demand, drop `_acl_roles_registry` cache

`roles_for()` now gathers declared roles directly via `build_roles_registry()` instead of reading a registry stashed on the Datasette instance at startup.

**What changed**
- `build_roles_registry()` is now synchronous, and the `datasette_acl_roles` hook returns a list directly (no awaitable form).
- `startup()` no longer builds/stashes `datasette._acl_roles_registry`. The startup cache only existed to bridge async hook-gathering to sync consumers; making the gather synchronous removes the need for it, along with the silent `getattr` fallback that masked a missing startup.
- Every consumer already went through `roles_for()`, so nothing else changes.

**Testing**
`tests/test_roles.py` updated for the synchronous hook. Full suite green.

---
**Merge** — PR 2 of 5. Base: `asg017/1-dev-tooling`. Merge after PR 1; deleting PR 1's branch auto-retargets this PR's base to `main`. See `STACK-MERGE.md`.
