### PR TITLE
4/5 Introduce Principal value object for the grant helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,32 +221,37 @@ def datasette_acl_valid_actors(datasette):
 
 `datasette_acl.grants` provides async helpers so other plugins can read and modify grants without writing raw SQL against the ACL tables. Each call resolves the `(resource_type, parent, child)` resource, writes the `acl` rows, and appends audit entries attributed to `by_actor`.
 
-Provide exactly one principal (`actor_id=` or `group_id=`), and for `grant()` exactly one of `role=` or `actions=`.
+The principal — who a grant targets — is a `Principal` value object, built via one of its constructors: `Principal.actor(id)`, `Principal.group(id)`, or a [public audience](#principals-and-general-access) `Principal.everyone()` / `Principal.authenticated()` / `Principal.anonymous()`. Pass it as `principal=`, and for `grant()` supply exactly one of `role=` or `actions=`:
 
 ```python
-from datasette_acl.grants import grant, revoke, update_role, list_grants
+from datasette_acl.grants import grant, revoke, update_role, list_grants, Principal
+
+# Any signed-in user becomes a Viewer
+await grant(datasette, "doc", "doc1", principal=Principal.authenticated(), role="Viewer")
+# A specific user becomes an Editor
+await grant(datasette, "doc", "doc1", principal=Principal.actor("alice"), role="Editor")
 ```
 
 `grant(...)` — give a principal access, by raw actions or by a role (idempotent). Returns the actions now held. Role names come from the `datasette_acl_roles` hook:
 
 ```python
-await grant(datasette, "table", "mydb", "mytable", actor_id="alice", actions=["insert-row"])
-await grant(datasette, "table", "mydb", "mytable", group_id=3, actions=["insert-row"], by_actor="root")
+await grant(datasette, "table", "mydb", "mytable", principal=Principal.actor("alice"), actions=["insert-row"])
+await grant(datasette, "table", "mydb", "mytable", principal=Principal.group(3), actions=["insert-row"], by_actor="root")
 ```
 
 `update_role(...)` — atomically swap a principal's actions to exactly those of a registered `role`. Returns the new actions:
 
 ```python
-await update_role(datasette, "doc", "doc1", actor_id="alice", role="Viewer")
+await update_role(datasette, "doc", "doc1", principal=Principal.actor("alice"), role="Viewer")
 ```
 
 `revoke(...)` — remove all of a principal's grants on a resource. Returns the actions that were removed:
 
 ```python
-await revoke(datasette, "table", "mydb", "mytable", actor_id="alice")
+await revoke(datasette, "table", "mydb", "mytable", principal=Principal.actor("alice"))
 ```
 
-`list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`):
+`list_grants(...)` — list current grants on a resource as dicts (`{"principal", "actor_id", "group_id", "group_name", "actions"}`, where `principal` is the stored `principal_type`; audience grants carry no id):
 
 ```python
 grants = await list_grants(datasette, "table", "mydb", "mytable")

--- a/datasette_acl/grants.py
+++ b/datasette_acl/grants.py
@@ -11,17 +11,18 @@ Every mutating helper:
   * writes the ``acl`` rows, and
   * appends ``acl_audit`` entries (``operation_by`` = ``by_actor``).
 
-Principal invariant: a grant targets exactly one principal -- an actor
-(``actor_id=``), a group (``group_id=``), or a public audience
-(``principal_type=`` one of ``'everyone'`` / ``'authenticated'`` /
-``'anonymous'``, with no id at all) -- matching the CHECK constraint on the
-``acl`` table. :func:`principal_type_for` is the single place that resolves
-and validates the combination.
+Principal invariant: a grant targets exactly one principal -- an actor, a
+group, or a public audience -- matching the CHECK constraint on the ``acl``
+table. The :class:`Principal` value object is the single place that resolves
+and validates the combination; every helper takes one ``principal`` rather
+than threading ``(principal_type, actor_id, group_id)`` around by hand.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import (
+    Dict,
     Iterable,
     List,
     Literal,
@@ -40,6 +41,127 @@ if TYPE_CHECKING:
 
 
 PrincipalType = Literal["actor", "group", "everyone", "authenticated", "anonymous"]
+
+
+@dataclass(frozen=True)
+class Principal:
+    """A grant's target: an actor, a group, or a public audience.
+
+    Build one via the classmethods rather than the raw constructor so the
+    "exactly one principal" invariant (which mirrors the ``acl`` CHECK
+    constraint) is enforced in a single place::
+
+        Principal.actor("alice")
+        Principal.group(7)
+        Principal.everyone()        # / .authenticated() / .anonymous()
+        Principal.public("everyone")
+
+    :meth:`from_parts` resolves the looser ``(actor_id, group_id,
+    principal_type)`` combination that arrives from a request body, validating
+    it the same way. :meth:`where_sql` / :meth:`sql_params` produce the
+    principal-matching SQL fragment shared by every read/write helper.
+    """
+
+    principal_type: PrincipalType
+    actor_id: Optional[str] = None
+    group_id: Optional[int] = None
+
+    @classmethod
+    def actor(cls, actor_id: str) -> "Principal":
+        if actor_id is None:
+            raise ValueError("actor principal requires an actor_id")
+        return cls("actor", actor_id=actor_id)
+
+    @classmethod
+    def group(cls, group_id: int) -> "Principal":
+        if group_id is None:
+            raise ValueError("group principal requires a group_id")
+        return cls("group", group_id=group_id)
+
+    @classmethod
+    def public(cls, principal_type: str) -> "Principal":
+        if principal_type not in PUBLIC_PRINCIPAL_TYPES:
+            raise ValueError(
+                f"Unknown public principal_type {principal_type!r}; expected "
+                f"one of {', '.join(sorted(PUBLIC_PRINCIPAL_TYPES))}"
+            )
+        return cls(principal_type)
+
+    @classmethod
+    def everyone(cls) -> "Principal":
+        return cls("everyone")
+
+    @classmethod
+    def authenticated(cls) -> "Principal":
+        return cls("authenticated")
+
+    @classmethod
+    def anonymous(cls) -> "Principal":
+        return cls("anonymous")
+
+    @classmethod
+    def from_parts(
+        cls,
+        actor_id: Optional[str],
+        group_id: Optional[int],
+        principal_type: Optional[str] = None,
+    ) -> "Principal":
+        """Resolve a principal from a loose ``(actor_id, group_id, type)`` set.
+
+        A principal is exactly one of: an actor (``actor_id``), a group
+        (``group_id``), or a public audience (``principal_type`` in
+        ``PUBLIC_PRINCIPAL_TYPES``, with neither id). ``principal_type`` may
+        also redundantly name ``'actor'`` / ``'group'`` alongside the matching
+        id. Raises ``ValueError`` for any other combination, mirroring the
+        acl table's CHECK constraint.
+        """
+        if principal_type in PUBLIC_PRINCIPAL_TYPES:
+            if actor_id is not None or group_id is not None:
+                raise ValueError(
+                    f"principal_type {principal_type!r} cannot be combined "
+                    "with actor_id= or group_id="
+                )
+            return cls(principal_type)
+        if (actor_id is None) == (group_id is None):
+            raise ValueError(
+                "Provide exactly one principal: actor_id=, group_id=, or a "
+                f"public principal_type ({', '.join(PUBLIC_PRINCIPAL_TYPES)})"
+            )
+        if group_id is not None:
+            if principal_type not in (None, "group"):
+                raise ValueError(
+                    f"principal_type {principal_type!r} cannot be used "
+                    "with group_id="
+                )
+            return cls("group", group_id=group_id)
+        if principal_type not in (None, "actor"):
+            raise ValueError(
+                f"principal_type {principal_type!r} cannot be used "
+                "with actor_id="
+            )
+        return cls("actor", actor_id=actor_id)
+
+    def where_sql(self, alias: Optional[str] = None) -> str:
+        """SQL fragment matching this principal's acl rows.
+
+        ``alias`` qualifies the column references (e.g. ``"acl"`` for a joined
+        query); omit it for a single-table statement. Pair with
+        :meth:`sql_params` for the bind values.
+        """
+        col = f"{alias}." if alias else ""
+        if self.principal_type == "actor":
+            return f"{col}principal_type = 'actor' AND {col}actor_id = :actor_id"
+        if self.principal_type == "group":
+            return f"{col}principal_type = 'group' AND {col}group_id = :group_id"
+        # Public audience: the type alone identifies the principal.
+        return f"{col}principal_type = :principal_type"
+
+    def sql_params(self) -> Dict[str, object]:
+        return {
+            "principal_type": self.principal_type,
+            "actor_id": self.actor_id,
+            "group_id": self.group_id,
+        }
 
 
 class Grant(TypedDict):
@@ -93,45 +215,6 @@ def _resolve_actions(
     return requested
 
 
-def principal_type_for(
-    actor_id: Optional[str],
-    group_id: Optional[int],
-    principal_type: Optional[str] = None,
-) -> PrincipalType:
-    """Resolve and validate the ``principal_type`` for a grant's principal.
-
-    A principal is exactly one of: an actor (``actor_id=``), a group
-    (``group_id=``), or a public audience (``principal_type=`` one of
-    ``PUBLIC_PRINCIPAL_TYPES``, with neither id). ``principal_type`` may also
-    redundantly name ``'actor'`` / ``'group'`` alongside the matching id.
-    Raises ``ValueError`` for any other combination, mirroring the acl table's
-    CHECK constraint.
-    """
-    if principal_type in PUBLIC_PRINCIPAL_TYPES:
-        if actor_id is not None or group_id is not None:
-            raise ValueError(
-                f"principal_type {principal_type!r} cannot be combined with "
-                "actor_id= or group_id="
-            )
-        return principal_type
-    if (actor_id is None) == (group_id is None):
-        raise ValueError(
-            "Provide exactly one principal: actor_id=, group_id=, or a "
-            f"public principal_type ({', '.join(PUBLIC_PRINCIPAL_TYPES)})"
-        )
-    if group_id is not None:
-        if principal_type not in (None, "group"):
-            raise ValueError(
-                f"principal_type {principal_type!r} cannot be used with group_id="
-            )
-        return "group"
-    if principal_type not in (None, "actor"):
-        raise ValueError(
-            f"principal_type {principal_type!r} cannot be used with actor_id="
-        )
-    return "actor"
-
-
 async def _ensure_resource_id(
     db: Database, resource_type: str, parent: str, child: Optional[str]
 ) -> int:
@@ -168,31 +251,17 @@ async def _ensure_actions(db: Database, actions: Iterable[str]) -> None:
 async def _current_actions(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
 ) -> Set[str]:
     """Return the set of action names currently granted to a principal."""
-    if principal_type == "actor":
-        where = "acl.principal_type = 'actor' AND acl.actor_id = :actor_id"
-    elif principal_type == "group":
-        where = "acl.principal_type = 'group' AND acl.group_id = :group_id"
-    else:
-        # Public audience: the type alone identifies the principal.
-        where = "acl.principal_type = :principal_type"
     rows = await db.execute(
         f"""
         SELECT acl_actions.name AS name
         FROM acl
         JOIN acl_actions ON acl.action_id = acl_actions.id
-        WHERE acl.resource_id = :resource_id AND {where}
+        WHERE acl.resource_id = :resource_id AND {principal.where_sql("acl")}
         """,
-        {
-            "resource_id": resource_id,
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
-        },
+        {"resource_id": resource_id, **principal.sql_params()},
     )
     return {row["name"] for row in rows.rows}
 
@@ -200,9 +269,7 @@ async def _current_actions(
 async def _insert_grant(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
@@ -220,68 +287,42 @@ async def _insert_grant(
         )
         """,
         {
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(
-        db, "added", resource_id, principal_type, actor_id, group_id, action_name, by_actor
-    )
+    await _audit(db, "added", resource_id, principal, action_name, by_actor)
 
 
 async def _delete_grant(
     db: Database,
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
-    if principal_type == "actor":
-        principal_where = "principal_type = 'actor' AND actor_id = :actor_id"
-    elif principal_type == "group":
-        principal_where = "principal_type = 'group' AND group_id = :group_id"
-    else:
-        # Public audience: the type alone identifies the principal.
-        principal_where = "principal_type = :principal_type"
     await db.execute_write(
         f"""
         DELETE FROM acl
-        WHERE {principal_where}
+        WHERE {principal.where_sql()}
           AND resource_id = :resource_id
           AND action_id = (SELECT id FROM acl_actions WHERE name = :action_name)
         """,
         {
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
         },
     )
-    await _audit(
-        db,
-        "removed",
-        resource_id,
-        principal_type,
-        actor_id,
-        group_id,
-        action_name,
-        by_actor,
-    )
+    await _audit(db, "removed", resource_id, principal, action_name, by_actor)
 
 
 async def _audit(
     db: Database,
     operation: Literal["added", "removed"],
     resource_id: int,
-    principal_type: PrincipalType,
-    actor_id: Optional[str],
-    group_id: Optional[int],
+    principal: Principal,
     action_name: str,
     by_actor: Optional[str],
 ) -> None:
@@ -302,9 +343,7 @@ async def _audit(
         """,
         {
             "operation": operation,
-            "principal_type": principal_type,
-            "actor_id": actor_id,
-            "group_id": group_id,
+            **principal.sql_params(),
             "resource_id": resource_id,
             "action_name": action_name,
             "operation_by": by_actor,
@@ -318,33 +357,27 @@ async def grant(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     role: Optional[str] = None,
     actions: Optional[Iterable[str]] = None,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Grant a principal access to a resource, by role or by raw actions.
 
-    The principal is exactly one of ``actor_id=``, ``group_id=``, or a public
-    audience passed as ``principal_type=`` (``'everyone'`` /
-    ``'authenticated'`` / ``'anonymous'``, with neither id). Exactly one of
-    ``role`` / ``actions`` must be supplied. Only actions not already granted
-    are inserted (idempotent). Returns the list of action names now held by
-    the principal.
+    ``principal`` is a :class:`Principal` (``Principal.actor(...)`` /
+    ``.group(...)`` / ``.everyone()`` / etc). Exactly one of ``role`` /
+    ``actions`` must be supplied. Only actions not already granted are
+    inserted (idempotent). Returns the list of action names now held by the
+    principal.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = _resolve_actions(datasette, resource_type, role, actions)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in resolved:
         if action_name not in existing:
-            await _insert_grant(
-                db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-            )
+            await _insert_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(existing | set(resolved))
 
 
@@ -354,24 +387,19 @@ async def revoke(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Remove all acl rows for a principal on a resource. Audits each removal.
 
     The principal is specified as in :func:`grant`. Returns the list of action
     names that were removed.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in sorted(existing):
-        await _delete_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _delete_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(existing)
 
 
@@ -381,11 +409,9 @@ async def update_role(
     parent: str,
     child: Optional[str] = None,
     *,
-    actor_id: Optional[str] = None,
-    group_id: Optional[int] = None,
+    principal: Principal,
     role: str,
     by_actor: Optional[str] = None,
-    principal_type: Optional[PrincipalType] = None,
 ) -> List[str]:
     """Atomically swap a principal's action set on a resource to ``role``.
 
@@ -393,20 +419,15 @@ async def update_role(
     granted actions that are not in the new role, then adds any missing ones.
     Audits each change. Returns the new action list.
     """
-    ptype = principal_type_for(actor_id, group_id, principal_type)
     resolved = set(_resolve_actions(datasette, resource_type, role, None))
     db = datasette.get_internal_database()
     resource_id = await _ensure_resource_id(db, resource_type, parent, child)
     await _ensure_actions(db, resolved)
-    existing = await _current_actions(db, resource_id, ptype, actor_id, group_id)
+    existing = await _current_actions(db, resource_id, principal)
     for action_name in sorted(existing - resolved):
-        await _delete_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _delete_grant(db, resource_id, principal, action_name, by_actor)
     for action_name in sorted(resolved - existing):
-        await _insert_grant(
-            db, resource_id, ptype, actor_id, group_id, action_name, by_actor
-        )
+        await _insert_grant(db, resource_id, principal, action_name, by_actor)
     return sorted(resolved)
 
 

--- a/datasette_acl/views/api.py
+++ b/datasette_acl/views/api.py
@@ -49,7 +49,7 @@ from datasette_acl.grants import (
     revoke,
     update_role,
     list_grants,
-    principal_type_for,
+    Principal,
 )
 from datasette_acl.roles import role_for_actions, roles_for
 from datasette_acl.utils import (
@@ -202,22 +202,18 @@ async def _group_grant_entry(datasette, roles, group_id, actions):
     return _group_entry(group_id, role, actions, info)
 
 
-def _principal_from_body(body):
-    """Extract ``(actor_id, group_id, principal_type)`` from a request body.
+def _principal_from_body(body) -> Principal:
+    """Build a :class:`Principal` from a request body.
 
     The principal is exactly one of ``actor_id``, ``group_id``, or a public
     audience named by ``principal_type`` (``"everyone"`` / ``"authenticated"``
     / ``"anonymous"`` with neither id). Raises ``ValueError`` for invalid
-    combinations (via :func:`principal_type_for`) so handlers can translate it
-    to a 400.
+    combinations (via :meth:`Principal.from_parts`) so handlers can translate
+    it to a 400.
     """
-    actor_id = body.get("actor_id")
-    group_id = body.get("group_id")
-    principal_type = body.get("principal_type")
-    # Validates the combination eagerly (exactly-one principal, no audience
-    # alongside an id, no 'group' alongside actor_id).
-    principal_type_for(actor_id, group_id, principal_type)
-    return actor_id, group_id, principal_type
+    return Principal.from_parts(
+        body.get("actor_id"), body.get("group_id"), body.get("principal_type")
+    )
 
 
 def _parse_json_body(request_body):
@@ -233,16 +229,18 @@ def _parse_json_body(request_body):
     return data
 
 
-async def _enriched_grant(
-    datasette, roles, actor_id, group_id, actions, principal_type=None
-):
+async def _enriched_grant(datasette, roles, principal: Principal, actions):
     """Build the enriched grant entry for whichever principal was supplied."""
-    if actor_id is not None:
-        return await _actor_grant_entry(datasette, roles, actor_id, actions)
-    if group_id is not None:
-        return await _group_grant_entry(datasette, roles, group_id, actions)
+    if principal.principal_type == "actor":
+        return await _actor_grant_entry(
+            datasette, roles, principal.actor_id, actions
+        )
+    if principal.principal_type == "group":
+        return await _group_grant_entry(
+            datasette, roles, principal.group_id, actions
+        )
     role = role_for_actions(roles, set(actions))
-    return _public_entry(principal_type, role, actions)
+    return _public_entry(principal.principal_type, role, actions)
 
 
 async def resource_grants_json(request, datasette):
@@ -379,27 +377,23 @@ async def grant_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         actions = await grant(
             datasette,
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             role=body.get("role"),
             actions=body.get("actions"),
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(
-        datasette, roles, actor_id, group_id, actions, principal_type
-    )
+    entry = await _enriched_grant(datasette, roles, principal, actions)
     return Response.json({"ok": True, "grant": entry})
 
 
@@ -566,17 +560,15 @@ async def revoke_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         by_actor = (request.actor or {}).get("id")
         removed = await revoke(
             datasette,
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
@@ -597,7 +589,7 @@ async def update_json(request, datasette):
         resource_type, parent, child, roles, body = await _begin_mutation(
             request, datasette
         )
-        actor_id, group_id, principal_type = _principal_from_body(body)
+        principal = _principal_from_body(body)
         role = body.get("role")
         if not role:
             raise _ApiError(400, "update requires a role")
@@ -607,17 +599,13 @@ async def update_json(request, datasette):
             resource_type,
             parent,
             child,
-            actor_id=actor_id,
-            group_id=group_id,
+            principal=principal,
             role=role,
             by_actor=by_actor,
-            principal_type=principal_type,
         )
     except _ApiError as exc:
         return _error_response(exc)
     except ValueError as exc:
         return _error_response(_ApiError(400, str(exc)))
-    entry = await _enriched_grant(
-        datasette, roles, actor_id, group_id, actions, principal_type
-    )
+    entry = await _enriched_grant(datasette, roles, principal, actions)
     return Response.json({"ok": True, "grant": entry})

--- a/tests/sample-plugin/widgets.py
+++ b/tests/sample-plugin/widgets.py
@@ -28,7 +28,7 @@ turns into daily-planet / gotham-gazette groups for group-grant demos.
 from datasette import hookimpl, Forbidden, Response
 from datasette.permissions import Action, Resource
 
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import role_for_actions, roles_for, standard_roles
 
 # datasette-debug-gotham's demo actors (Clark Kent, Bruce Wayne, …). Imported
@@ -201,7 +201,7 @@ async def widgets_index(request, datasette):
             "widget",
             WIDGETS_PARENT,
             str(widget_id),
-            actor_id=actor_id,
+            principal=Principal.actor(actor_id),
             role="Manager",
             by_actor=actor_id,
         )

--- a/tests/test_api_mutations.py
+++ b/tests/test_api_mutations.py
@@ -15,7 +15,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant, list_grants
+from datasette_acl.grants import grant, list_grants, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -284,7 +284,14 @@ async def test_grant_invalid_principal_type_is_400(api_ds):
 
 @pytest.mark.asyncio
 async def test_update_swaps_role(api_ds):
-    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         UPDATE_URL,
@@ -309,7 +316,14 @@ async def test_update_swaps_role(api_ds):
 
 @pytest.mark.asyncio
 async def test_revoke_removes_all(api_ds):
-    await grant(api_ds, "mock-doc", "42", actor_id="bob", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         REVOKE_URL,
@@ -333,7 +347,14 @@ async def test_revoke_removes_all(api_ds):
 @pytest.mark.asyncio
 async def test_revoke_group(api_ds):
     gid = await _group_id(api_ds, "staff")
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         REVOKE_URL,
@@ -372,7 +393,14 @@ async def test_anonymous_cannot_grant(api_ds):
 async def test_manager_role_grants_manage_ability(api_ds):
     # Granting mallory the Manager role (which includes doc-manage) lets her
     # re-share, without the global datasette-acl permission.
-    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -387,7 +415,14 @@ async def test_manager_role_grants_manage_ability(api_ds):
 @pytest.mark.asyncio
 async def test_non_manager_role_cannot_grant(api_ds):
     # Editor is not a manage role, so it must NOT confer re-share ability.
-    await grant(api_ds, "mock-doc", "42", actor_id="mallory", role="Editor", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Editor",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -406,7 +441,14 @@ async def test_group_manager_role_grants_manage_ability(api_ds):
         "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
         ["mallory", gid],
     )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Manager",
+        by_actor="root",
+    )
     response = await _post(
         api_ds,
         GRANT_URL,
@@ -544,7 +586,12 @@ HTML_PAGE_URL = "/-/acl/resource/mock-doc/42"
 async def test_html_page_manager_can_view(api_ds):
     # mallory holds the Manager role on mock-doc/42 but is NOT the global admin.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 200
@@ -555,7 +602,12 @@ async def test_html_page_manager_can_grant_via_post(api_ds):
     # A per-resource Manager can grant a raw action through the HTML form,
     # without the global datasette-acl permission.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.post(
         HTML_PAGE_URL,
@@ -578,7 +630,12 @@ async def test_html_page_group_manager_can_view(api_ds):
         ["mallory", gid],
     )
     await grant(
-        api_ds, "mock-doc", "42", group_id=gid, role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Manager",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 200
@@ -595,7 +652,12 @@ async def test_html_page_non_manager_forbidden(api_ds):
 async def test_html_page_non_manage_role_forbidden(api_ds):
     # Editor is not a manage role, so it must NOT unlock the admin page.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Editor", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Editor",
+        by_actor="root",
     )
     response = await api_ds.client.get(HTML_PAGE_URL, cookies=_cookie(api_ds, "mallory"))
     assert response.status_code == 403
@@ -635,7 +697,12 @@ async def test_grant_helper_rejects_unknown_raw_action(api_ds):
     # register, rather than silently inventing it.
     with pytest.raises(ValueError):
         await grant(
-            api_ds, "mock-doc", "42", actor_id="bob", actions=["not-real"], by_actor="root"
+            api_ds,
+            "mock-doc",
+            "42",
+            principal=Principal.actor("bob"),
+            actions=["not-real"],
+            by_actor="root",
         )
     # And nothing must have been persisted.
     assert "not-real" not in await _acl_action_names(api_ds)
@@ -664,7 +731,7 @@ async def test_grant_unknown_action_partial_list_is_atomic(api_ds):
             api_ds,
             "mock-doc",
             "42",
-            actor_id="bob",
+            principal=Principal.actor("bob"),
             actions=["doc-view", "not-real"],
             by_actor="root",
         )
@@ -678,7 +745,12 @@ async def test_future_action_name_not_persisted_as_stale_grant(api_ds):
     # mock-doc today, but which a future version might add. It must be rejected,
     # and must never reach acl_actions, so it cannot go live later.
     await grant(
-        api_ds, "mock-doc", "42", actor_id="mallory", role="Manager", by_actor="root"
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("mallory"),
+        role="Manager",
+        by_actor="root",
     )
     response = await _post(
         api_ds,

--- a/tests/test_api_pickers.py
+++ b/tests/test_api_pickers.py
@@ -18,7 +18,7 @@ from datasette import Response
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -369,7 +369,11 @@ async def resource_ds():
         await db.execute_write("INSERT INTO acl_groups (name) VALUES ('staff')")
         # bruce is a per-resource Manager (no global admin).
         await grant(
-            datasette, "mock-doc", "42", actor_id="bruce", role="Manager",
+            datasette,
+            "mock-doc",
+            "42",
+            principal=Principal.actor("bruce"),
+            role="Manager",
             by_actor="root",
         )
         yield datasette

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -13,7 +13,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant
+from datasette_acl.grants import grant, Principal
 from datasette_acl.roles import AclRole
 import pytest
 import pytest_asyncio
@@ -166,7 +166,14 @@ async def test_read_nonexistent_resource_forbidden(api_ds):
 async def test_per_resource_manager_can_read(api_ds):
     # Grant alice the Manager role (which includes the manage action) and prove
     # she can read the endpoint without the global datasette-acl permission.
-    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
     cookies = {"ds_actor": api_ds.client.actor_cookie({"id": "alice"})}
     response = await _get(api_ds, "/-/acl/api/resource/mock-doc/42", cookies=cookies)
     assert response.status_code == 200
@@ -179,16 +186,35 @@ async def test_per_resource_manager_can_read(api_ds):
 @pytest.mark.asyncio
 async def test_read_full_shape(api_ds):
     gid = await _group_id(api_ds, "staff")
-    await grant(api_ds, "mock-doc", "42", actor_id="alice", role="Manager", by_actor="root")
-    await grant(
-        api_ds, "mock-doc", "42", actor_id="agent:researcher", role="Editor", by_actor="root"
-    )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
     await grant(
         api_ds,
         "mock-doc",
         "42",
-        principal_type="authenticated",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("agent:researcher"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.public("authenticated"),
         role="Viewer",
         by_actor="root",
     )
@@ -250,7 +276,14 @@ async def test_group_member_count(api_ds):
             "INSERT INTO acl_actor_groups (actor_id, group_id) VALUES (?, ?)",
             [actor_id, gid],
         )
-    await grant(api_ds, "mock-doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _get(
         api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
     )
@@ -275,7 +308,14 @@ async def test_read_empty_resource(api_ds):
 @pytest.mark.asyncio
 async def test_unknown_actor_falls_back(api_ds):
     # An actor with no directory entry still resolves (kind user, no names).
-    await grant(api_ds, "mock-doc", "42", actor_id="ghost", role="Viewer", by_actor="root")
+    await grant(
+        api_ds,
+        "mock-doc",
+        "42",
+        principal=Principal.actor("ghost"),
+        role="Viewer",
+        by_actor="root",
+    )
     response = await _get(
         api_ds, "/-/acl/api/resource/mock-doc/42", cookies=_root_cookie(api_ds)
     )

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -8,7 +8,7 @@ from datasette import hookimpl
 from datasette.app import Datasette
 from datasette.permissions import Action, Resource
 from datasette.plugins import pm
-from datasette_acl.grants import grant, revoke
+from datasette_acl.grants import grant, revoke, Principal
 import pytest
 import pytest_asyncio
 
@@ -320,7 +320,7 @@ async def test_actor_grant_with_legacy_wildcard_looking_id(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -346,7 +346,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        principal_type="anonymous",
+        principal=Principal.anonymous(),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -355,7 +355,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         actions=["widget-view"],
         by_actor="root",
     )
@@ -375,7 +375,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        principal_type="anonymous",
+        principal=Principal.anonymous(),
         by_actor="root",
     )
     assert not await widget_ds.allowed(
@@ -390,7 +390,7 @@ async def test_public_and_actor_grants_coexist(widget_ds):
         "widget",
         "shelf",
         "gadget",
-        actor_id="_anonymous",
+        principal=Principal.actor("_anonymous"),
         by_actor="root",
     )
     assert not await widget_ds.allowed(

--- a/tests/test_grants.py
+++ b/tests/test_grants.py
@@ -14,7 +14,7 @@ from datasette_acl.grants import (
     revoke,
     update_role,
     list_grants,
-    principal_type_for,
+    Principal,
     _insert_grant,
 )
 from datasette_acl.roles import AclRole
@@ -179,7 +179,12 @@ async def test_build_resource_unknown_type(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_by_role(grants_ds):
     result = await grant(
-        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
@@ -192,7 +197,12 @@ async def test_grant_by_role(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_by_raw_actions(grants_ds):
     result = await grant(
-        grants_ds, "doc", "42", actor_id="bob", actions=["doc-view"], by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("bob"),
+        actions=["doc-view"],
+        by_actor="root",
     )
     assert result == ["doc-view"]
     assert await _actions_for(grants_ds, "bob") == ["doc-view"]
@@ -200,10 +210,22 @@ async def test_grant_by_raw_actions(grants_ds):
 
 @pytest.mark.asyncio
 async def test_grant_is_idempotent(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
     # Granting again with overlap only inserts the new action
     result = await grant(
-        grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-manage", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == [
@@ -224,7 +246,12 @@ async def test_grant_is_idempotent(grants_ds):
 async def test_grant_to_group(grants_ds):
     gid = await _group_id(grants_ds, "staff")
     result = await grant(
-        grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
     )
     assert result == ["doc-view"]
     grants = await list_grants(grants_ds, "doc", "42")
@@ -242,25 +269,27 @@ async def test_grant_to_group(grants_ds):
 @pytest.mark.asyncio
 async def test_grant_unknown_role_raises(grants_ds):
     with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="alice", role="Nope")
-
-
-@pytest.mark.asyncio
-async def test_grant_requires_exactly_one_principal(grants_ds):
-    with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", role="Viewer")
-    gid = await _group_id(grants_ds, "staff")
-    with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="a", group_id=gid, role="Viewer")
+        await grant(
+            grants_ds,
+            "doc",
+            "42",
+            principal=Principal.actor("alice"),
+            role="Nope",
+        )
 
 
 @pytest.mark.asyncio
 async def test_grant_requires_exactly_one_of_role_or_actions(grants_ds):
     with pytest.raises(ValueError):
-        await grant(grants_ds, "doc", "42", actor_id="a")
+        await grant(grants_ds, "doc", "42", principal=Principal.actor("a"))
     with pytest.raises(ValueError):
         await grant(
-            grants_ds, "doc", "42", actor_id="a", role="Viewer", actions=["doc-view"]
+            grants_ds,
+            "doc",
+            "42",
+            principal=Principal.actor("a"),
+            role="Viewer",
+            actions=["doc-view"],
         )
 
 
@@ -269,17 +298,50 @@ async def test_grant_requires_exactly_one_of_role_or_actions(grants_ds):
 
 @pytest.mark.asyncio
 async def test_revoke_removes_all_rows(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
-    removed = await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
+    removed = await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     assert removed == ["doc-edit", "doc-manage", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == []
 
 
 @pytest.mark.asyncio
 async def test_revoke_only_targets_principal(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", actor_id="bob", role="Viewer", by_actor="root")
-    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("bob"),
+        role="Viewer",
+        by_actor="root",
+    )
+    await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     assert await _actions_for(grants_ds, "alice") == []
     assert await _actions_for(grants_ds, "bob") == ["doc-view"]
 
@@ -289,9 +351,21 @@ async def test_revoke_only_targets_principal(grants_ds):
 
 @pytest.mark.asyncio
 async def test_update_role_swaps_atomically(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Manager", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Manager",
+        by_actor="root",
+    )
     result = await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
     )
     assert result == ["doc-view"]
     # Only doc-view remains: doc-edit and doc-manage removed
@@ -300,9 +374,21 @@ async def test_update_role_swaps_atomically(grants_ds):
 
 @pytest.mark.asyncio
 async def test_update_role_upgrades(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
+    )
     result = await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
     assert result == ["doc-edit", "doc-view"]
     assert await _actions_for(grants_ds, "alice") == ["doc-edit", "doc-view"]
@@ -313,11 +399,29 @@ async def test_update_role_upgrades(grants_ds):
 
 @pytest.mark.asyncio
 async def test_audit_rows_written(grants_ds):
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await update_role(
-        grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="admin"
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
     )
-    await revoke(grants_ds, "doc", "42", actor_id="alice", by_actor="root")
+    await update_role(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="admin",
+    )
+    await revoke(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        by_actor="root",
+    )
     ops = await _audit_ops(grants_ds)
     # grant Editor: +doc-view +doc-edit; update to Viewer: -doc-edit;
     # revoke: -doc-view
@@ -336,8 +440,22 @@ async def test_audit_rows_written(grants_ds):
 @pytest.mark.asyncio
 async def test_list_grants_actor_and_group(grants_ds):
     gid = await _group_id(grants_ds, "staff")
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     grants = await list_grants(grants_ds, "doc", "42")
     assert grants == [
         {
@@ -369,10 +487,29 @@ async def test_list_grants_public_principal_and_ordering(grants_ds):
     # then groups, then audiences.
     gid = await _group_id(grants_ds, "staff")
     await grant(
-        grants_ds, "doc", "42", principal_type="everyone", role="Viewer", by_actor="root"
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.public("everyone"),
+        role="Viewer",
+        by_actor="root",
     )
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Editor", by_actor="root")
-    await grant(grants_ds, "doc", "42", group_id=gid, role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Editor",
+        by_actor="root",
+    )
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.group(gid),
+        role="Viewer",
+        by_actor="root",
+    )
     grants = await list_grants(grants_ds, "doc", "42")
     assert [(g["principal"], g["actor_id"], g["group_id"]) for g in grants] == [
         ("actor", "alice", None),
@@ -381,50 +518,49 @@ async def test_list_grants_public_principal_and_ordering(grants_ds):
     ]
 
 
-# --- principal_type -------------------------------------------------------
+# --- Principal ------------------------------------------------------------
 
 
-def test_principal_type_for():
+def test_principal_constructors():
+    assert Principal.actor("alice") == Principal("actor", actor_id="alice")
+    assert Principal.group(1) == Principal("group", group_id=1)
+    assert Principal.everyone() == Principal("everyone")
+    assert Principal.authenticated() == Principal("authenticated")
+    assert Principal.anonymous() == Principal("anonymous")
+    assert Principal.public("everyone") == Principal("everyone")
+    # public() rejects names that aren't a known audience
+    with pytest.raises(ValueError):
+        Principal.public("actor")
+
+
+def test_principal_from_parts():
     # Resolution from whichever id was supplied
-    assert principal_type_for("alice", None) == "actor"
-    assert principal_type_for(None, 1) == "group"
+    assert Principal.from_parts("alice", None) == Principal.actor("alice")
+    assert Principal.from_parts(None, 1) == Principal.group(1)
     # Redundant explicit types are accepted alongside the matching id
-    assert principal_type_for("alice", None, "actor") == "actor"
-    assert principal_type_for(None, 1, "group") == "group"
+    assert Principal.from_parts("alice", None, "actor") == Principal.actor("alice")
+    assert Principal.from_parts(None, 1, "group") == Principal.group(1)
     # Public audiences are named by principal_type alone, with no id
-    assert principal_type_for(None, None, "everyone") == "everyone"
-    assert principal_type_for(None, None, "authenticated") == "authenticated"
-    assert principal_type_for(None, None, "anonymous") == "anonymous"
+    assert Principal.from_parts(None, None, "everyone") == Principal.everyone()
+    assert Principal.from_parts(None, None, "authenticated") == Principal.authenticated()
+    assert Principal.from_parts(None, None, "anonymous") == Principal.anonymous()
     # Invalid combinations
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "everyone")  # audience with actor_id
+        Principal.from_parts("bob", None, "everyone")  # audience with actor_id
     with pytest.raises(ValueError):
-        principal_type_for(None, 1, "anonymous")  # audience with group_id
+        Principal.from_parts(None, 1, "anonymous")  # audience with group_id
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "group")  # group needs group_id
+        Principal.from_parts("bob", None, "group")  # group needs group_id
     with pytest.raises(ValueError):
-        principal_type_for(None, 1, "actor")  # group_id with actor type
+        Principal.from_parts(None, 1, "actor")  # group_id with actor type
     with pytest.raises(ValueError):
-        principal_type_for("bob", None, "alien")  # unknown type
+        Principal.from_parts("bob", None, "alien")  # unknown type
     with pytest.raises(ValueError):
-        principal_type_for(None, None)  # no principal
+        Principal.from_parts(None, None)  # no principal
     with pytest.raises(ValueError):
-        principal_type_for(None, None, "actor")  # actor type without an id
+        Principal.from_parts(None, None, "actor")  # actor type without an id
     with pytest.raises(ValueError):
-        principal_type_for("bob", 1)  # both ids
-
-
-@pytest.mark.asyncio
-async def test_grant_audience_with_actor_id_raises(grants_ds):
-    with pytest.raises(ValueError):
-        await grant(
-            grants_ds,
-            "doc",
-            "42",
-            actor_id="bob",
-            role="Viewer",
-            principal_type="everyone",
-        )
+        Principal.from_parts("bob", 1)  # both ids
 
 
 @pytest.mark.asyncio
@@ -452,7 +588,14 @@ async def test_insert_grant_dedupes(grants_ds):
     # read-modify-write guard -- yield one row: the partial unique indexes
     # actually enforce non-duplication (the old UNIQUE constraint never fired
     # across its always-NULL columns).
-    await grant(grants_ds, "doc", "42", actor_id="alice", role="Viewer", by_actor="root")
+    await grant(
+        grants_ds,
+        "doc",
+        "42",
+        principal=Principal.actor("alice"),
+        role="Viewer",
+        by_actor="root",
+    )
     db = grants_ds.get_internal_database()
     resource_id = (
         await db.execute(
@@ -461,7 +604,7 @@ async def test_insert_grant_dedupes(grants_ds):
     ).single_value()
     for _ in range(2):
         await _insert_grant(
-            db, resource_id, "actor", "alice", None, "doc-view", "root"
+            db, resource_id, Principal.actor("alice"), "doc-view", "root"
         )
     count = (
         await db.execute("select count(*) from acl where actor_id = 'alice'")
@@ -470,7 +613,7 @@ async def test_insert_grant_dedupes(grants_ds):
     # Same for a public audience (covered by acl_public_unique)
     for _ in range(2):
         await _insert_grant(
-            db, resource_id, "everyone", None, None, "doc-view", "root"
+            db, resource_id, Principal.everyone(), "doc-view", "root"
         )
     count = (
         await db.execute(


### PR DESCRIPTION
> *Note: this description was generated with Claude.*

## Introduce `Principal` value object for the grant helpers

Pure refactor: replaces the loose `(actor_id, group_id, principal_type)` triple threaded through the grant helpers with a single frozen `Principal` value object. No behavior change.

```python
from datasette_acl.grants import grant, Principal

await grant(ds, "doc", "doc1", principal=Principal.authenticated(), role="Viewer")
await grant(ds, "doc", "doc1", principal=Principal.actor("alice"), role="Editor")
```

**What changed**
- `Principal` is a frozen dataclass with validating constructors (`actor` / `group` / `everyone` / `authenticated` / `anonymous` / `public`), plus `from_parts()` (absorbs the old `principal_type_for`) and `where_sql()` / `sql_params()` that own the principal-matching SQL.
- `grant()/revoke()/update_role()/list_grants()` now take one keyword-only `principal=`; internal helpers drop from 7 positional args to ~4. `principal_type_for` is gone.
- The JSON API still accepts the same `actor_id` / `group_id` / `principal_type` request-body fields — `_principal_from_body` just builds a `Principal` from them.

**Testing**
Tests and the README Python-API examples updated to the `Principal` constructors — same assertions, no behavior change. Full suite green.

---
**Merge** — PR 4 of 5. Base: `asg017/3-principal-type`. Merge after PR 3. See `STACK-MERGE.md`.
