### PR TITLE
5/5 General access: admin UI section for public audiences + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Every grant names exactly one **principal**, recorded in the `principal_type` co
 
 The generic resource admin page presents the three audiences as its **General access** section (labelled "Anyone (signed in or not)", "Any signed-in user" and "Signed-out (anonymous) visitors only"), and the audit log's Principal column shows the same labels. Audiences can also be granted programmatically: pass `principal_type` to the [JSON API](docs/json-api.md), or an audience `Principal` (e.g. `Principal.authenticated()`) to the [Python helpers](#python-api-for-managing-grants).
 
-Because an audience grant stores no id at all, there is no reserved actor-id namespace: permission checks match audiences on `principal_type` alone and actors on their literal id, so no user id — however unusual — can collide with a general-access grant. One note for third-party code writing raw SQL into the `acl` table: the `principal_type` column is NOT NULL and CHECK-constrained, so such writers must supply it themselves (use the [Python API](#python-api-for-managing-grants) instead).
+Audience grants store `principal_type` only; their `actor_id` and `group_id` columns are both null. Permission checks match actor grants by `actor_id`, group grants by `group_id`, and general-access grants by `principal_type`. Code writing rows directly to the `acl` table must provide a valid `principal_type` and respect the table's CHECK constraint; prefer the [Python API](#python-api-for-managing-grants).
 
 ### Declaring roles
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ datasette install datasette-acl
 ```
 ## Usage
 
-This plugin is under active development. It currently only supports configuring [permissions](https://docs.datasette.io/en/latest/authentication.html#permissions) for individual tables, controlling the following:
+This plugin is under active development. It supports configuring [permissions](https://docs.datasette.io/en/latest/authentication.html#permissions) for individual tables — controlling the following actions — as well as for [any custom resource type](#custom-resource-types) registered by a plugin:
 
 - `insert-row`
 - `delete-row`
 - `update-row`
 - `alter-table`
 - `drop-table`
+
+Grants can target individual users, [user groups](#user-groups), or [general-access audiences](#principals-and-general-access) like "any signed-in user".
 
 Permissions are saved in the internal database. This means you should run Datasette with the `--internal path/to/internal.db` option, otherwise your permissions will be reset every time you restart Datasette.
 
@@ -32,6 +34,8 @@ A JSON HTTP API for reading and managing per-resource grants programmatically is
 The interface for configuring table permissions lives at `/database-name/table-name/-/acl`. It can be accessed from the table actions menu on the table page.
 
 Permission can be granted for each of the above table actions. They can be assigned to both groups and individual users, who can be added using their `actor["id"]`.
+
+The table page does not (yet) offer the **General access** section found on the generic resource page — to grant a table action to a public audience such as "any signed-in user", use the [JSON API](docs/json-api.md) or the [Python helpers](#python-api-for-managing-grants). See [Principals and general access](#principals-and-general-access).
 
 An audit log tracks which permissions were added and removed, displayed at the bottom of the table permissions page.
 
@@ -68,7 +72,25 @@ A generic admin page for any resource type lives at:
 
 For example `/-/acl/resource/playlist/workspace-1/playlist-42`. The `<child>` segment is optional for parent-only resource types (`/-/acl/resource/<resource-type>/<parent>`). The page presents the same group/user grant interface and audit log as the table page, with checkboxes for exactly the actions registered for that resource type. Access to this admin page is gated on the `datasette-acl` permission described below.
 
+The page also has a **General access** section for exposing a resource without naming individual users — see [Principals and general access](#principals-and-general-access) below.
+
 Grants made here flow through Datasette's permission system: once granted, `await datasette.allowed(actor=..., action="playlist-edit", resource=Playlist("workspace-1", "playlist-42"))` returns `True`.
+
+### Principals and general access
+
+Every grant names exactly one **principal**, recorded in the `principal_type` column on each stored grant. There are five kinds — two identified by an id, and three public audiences identified by the type alone:
+
+| `principal_type` | Grants to | Identified by |
+| --- | --- | --- |
+| `actor` | An individual user | `actor_id` |
+| `group` | All members of a [user group](#user-groups) | `group_id` |
+| `everyone` | Anyone, signed in or not | — |
+| `authenticated` | Any signed-in actor | — |
+| `anonymous` | Signed-out (anonymous) visitors only | — |
+
+The generic resource admin page presents the three audiences as its **General access** section (labelled "Anyone (signed in or not)", "Any signed-in user" and "Signed-out (anonymous) visitors only"), and the audit log's Principal column shows the same labels. Audiences can also be granted programmatically: pass `principal_type` to the [JSON API](docs/json-api.md), or an audience `Principal` (e.g. `Principal.authenticated()`) to the [Python helpers](#python-api-for-managing-grants).
+
+Because an audience grant stores no id at all, there is no reserved actor-id namespace: permission checks match audiences on `principal_type` alone and actors on their literal id, so no user id — however unusual — can collide with a general-access grant. One note for third-party code writing raw SQL into the `acl` table: the `principal_type` column is NOT NULL and CHECK-constrained, so such writers must supply it themselves (use the [Python API](#python-api-for-managing-grants) instead).
 
 ### Declaring roles
 

--- a/datasette_acl/templates/manage_resource_acls.html
+++ b/datasette_acl/templates/manage_resource_acls.html
@@ -47,6 +47,18 @@ table.audit td {
   {% endfor %}
 {% endif %}
 
+<h3>General access</h3>
+{% for principal, label in public_principals.items() %}
+  <div style="margin-bottom: 1em">
+    <label style="display: block" for="id_public_permissions_{{ loop.index }}">{{ label }}</label>
+    <select multiple name="public_permissions_{{ principal }}" id="id_public_permissions_{{ loop.index }}">
+      {% for action in actions %}
+        <option value="{{ action }}" {% if public_permissions and public_permissions.get(principal, {}).get(action) %}selected{% endif %}>{{ action }}</option>
+      {% endfor %}
+    </select>
+  </div>
+{% endfor %}
+
 <h3>Users</h3>
 {% for user in user_permissions %}
   <div>
@@ -109,8 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
       <th>Date and time</th>
       <th>Operation by</th>
       <th>Operation</th>
-      <th>Group</th>
-      <th>User</th>
+      <th>Principal</th>
       <th>Action</th>
     </tr>
   </thead>
@@ -120,8 +131,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <td>{{ entry.timestamp }}</td>
         <td>{{ entry.operation_by }}</td>
         <td>{{ entry.operation }}</td>
-        <td>{{ entry.group_name or '' }}</td>
-        <td>{{ entry.actor_id or '' }}</td>
+        <td>{% if entry.principal_type == 'group' %}{{ entry.group_name }} (group){% elif entry.principal_type in public_principals %}{{ public_principals[entry.principal_type] }} (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
         <td>{{ entry.action_name }}</td>
       </tr>
     {% endfor %}

--- a/datasette_acl/templates/manage_table_acls.html
+++ b/datasette_acl/templates/manage_table_acls.html
@@ -111,8 +111,7 @@ document.addEventListener('DOMContentLoaded', function() {
       <th>Date and time</th>
       <th>Operation by</th>
       <th>Operation</th>
-      <th>Group</th>
-      <th>User</th>
+      <th>Principal</th>
       <th>Action</th>
     </tr>
   </thead>
@@ -122,8 +121,7 @@ document.addEventListener('DOMContentLoaded', function() {
         <td>{{ entry.timestamp }}</td>
         <td>{{ entry.operation_by }}</td>
         <td>{{ entry.operation }}</td>
-        <td>{{ entry.group_name or '' }}</td>
-        <td>{{ entry.actor_id or '' }}</td>
+        <td>{% if entry.principal_type == 'group' %}{{ entry.group_name }} (group){% elif entry.principal_type in public_principals %}{{ public_principals[entry.principal_type] }} (general access){% else %}{{ entry.actor_id or '' }}{% endif %}</td>
         <td>{{ entry.action_name }}</td>
       </tr>
     {% endfor %}

--- a/datasette_acl/views/resource_acls.py
+++ b/datasette_acl/views/resource_acls.py
@@ -1,6 +1,7 @@
 from datasette import Response, Forbidden
 from datasette_acl.grants import _ensure_resource_id
 from datasette_acl.utils import (
+    PUBLIC_PRINCIPAL_TYPES,
     actions_for_resource_type,
     can_manage,
     generate_changes_message,
@@ -59,6 +60,7 @@ async def manage_resource_acls(request, datasette):
 
     current_group_permissions = {}
     current_user_permissions = {}
+    current_public_permissions = {}
     acl_rows = await internal_db.execute(
         """
         select
@@ -80,11 +82,14 @@ async def manage_resource_acls(request, datasette):
             current_group_permissions.setdefault(row["group_name"], {})[
                 action_name
             ] = True
-        elif principal_type == "actor":
+        elif principal_type in PUBLIC_PRINCIPAL_TYPES:
+            current_public_permissions.setdefault(principal_type, {})[
+                action_name
+            ] = True
+        else:
             current_user_permissions.setdefault(row["actor_id"], {})[
                 action_name
             ] = True
-        # Public-audience rows are not surfaced by this view.
 
     if request.method == "POST":
         group_changes_made = {"added": [], "removed": []}
@@ -162,6 +167,90 @@ async def manage_resource_acls(request, datasette):
                         {
                             "operation": operation,
                             "group_name": group_name,
+                            "resource_id": resource_id,
+                            "action_name": action_name,
+                            "operation_by": request.actor["id"],
+                        },
+                    )
+        public_changes_made = {"added": [], "removed": []}
+        # Public audiences are identified by principal_type alone -- no id.
+        # Like groups, their selects are always present in the form, so
+        # unchecking removes the grant.
+        for principal_type, display_name in PUBLIC_PRINCIPAL_TYPES.items():
+            selected_public_actions = post_vars.getlist(
+                f"public_permissions_{principal_type}"
+            )
+            for action_name in actions:
+                new_value = action_name in selected_public_actions
+                current_value = bool(
+                    current_public_permissions.get(principal_type, {}).get(
+                        action_name
+                    )
+                )
+                if new_value != current_value:
+                    if new_value:
+                        await internal_db.execute_write(
+                            """
+                            insert into acl (principal_type, actor_id, group_id, resource_id, action_id)
+                            values (
+                                :principal_type,
+                                null,
+                                null,
+                                :resource_id,
+                                (select id from acl_actions where name = :action_name)
+                            )
+                            """,
+                            {
+                                "principal_type": principal_type,
+                                "action_name": action_name,
+                                "resource_id": resource_id,
+                            },
+                        )
+                        operation = "added"
+                        public_changes_made["added"].append(
+                            (display_name, action_name)
+                        )
+                    else:
+                        await internal_db.execute_write(
+                            """
+                            delete from acl where
+                                principal_type = :principal_type
+                                and resource_id = :resource_id
+                                and action_id = (select id from acl_actions where name = :action_name)
+                            """,
+                            {
+                                "principal_type": principal_type,
+                                "action_name": action_name,
+                                "resource_id": resource_id,
+                            },
+                        )
+                        operation = "removed"
+                        public_changes_made["removed"].append(
+                            (display_name, action_name)
+                        )
+                    await internal_db.execute_write(
+                        """
+                        insert into acl_audit (
+                            operation,
+                            principal_type,
+                            actor_id,
+                            group_id,
+                            resource_id,
+                            action_id,
+                            operation_by
+                        ) values (
+                            :operation,
+                            :principal_type,
+                            null,
+                            null,
+                            :resource_id,
+                            (SELECT id FROM acl_actions WHERE name = :action_name),
+                            :operation_by
+                        )
+                        """,
+                        {
+                            "operation": operation,
+                            "principal_type": principal_type,
                             "resource_id": resource_id,
                             "action_name": action_name,
                             "operation_by": request.actor["id"],
@@ -256,10 +345,15 @@ async def manage_resource_acls(request, datasette):
                         },
                     )
 
-        if group_changes_made or user_changes_made:
+        if group_changes_made or public_changes_made or user_changes_made:
             group_message = generate_changes_message(group_changes_made, "group")
             if group_message:
                 datasette.add_message(request, group_message)
+            public_message = generate_changes_message(
+                public_changes_made, "general access"
+            )
+            if public_message:
+                datasette.add_message(request, public_message)
             user_message = generate_changes_message(user_changes_made, "user")
             if user_message:
                 datasette.add_message(request, user_message)
@@ -317,6 +411,8 @@ async def manage_resource_acls(request, datasette):
                 "group_sizes": group_sizes,
                 "group_permissions": current_group_permissions,
                 "user_permissions": current_user_permissions,
+                "public_principals": PUBLIC_PRINCIPAL_TYPES,
+                "public_permissions": current_public_permissions,
                 "audit_log": audit_log.rows,
                 "valid_actors": await get_acl_valid_actors(datasette),
             },

--- a/tests/test_custom_resources.py
+++ b/tests/test_custom_resources.py
@@ -309,6 +309,34 @@ async def test_anonymous_public_grant(widget_ds):
     assert not await widget_ds.allowed(
         action="widget-view", resource=resource, actor={"id": "anyone"}
     )
+
+
+@pytest.mark.asyncio
+async def test_anonymous_grant_never_matches_a_signed_in_actor(widget_ds):
+    # Historic regression: when public audiences were stored in-band as magic
+    # actor_id values, the enforcement SQL's direct-grant branch matched the
+    # stored '_anonymous' wildcard row for a *signed-in* caller whose actor id
+    # was literally '_anonymous'. Audiences now carry no id at all, so no
+    # actor id -- however weird -- can collide with one. Granted via the admin
+    # form, the same write path an admin uses.
+    resource = WidgetResource("shelf", "gadget")
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={"public_permissions_anonymous": "widget-view"},
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+    # Anonymous callers are allowed
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    # Signed-in actors are denied, even ones with legacy-wildcard-looking ids
+    for actor_id in ("_anonymous", "anonymous", "*", "_signed_in"):
+        assert not await widget_ds.allowed(
+            action="widget-view", resource=resource, actor={"id": actor_id}
+        )
+
+
 @pytest.mark.asyncio
 async def test_actor_grant_with_legacy_wildcard_looking_id(widget_ds):
     # An actor whose id happens to look like an old wildcard is just an
@@ -517,6 +545,81 @@ async def test_generic_resource_view_grants_via_post(widget_ds):
     assert not await widget_ds.allowed(
         action="widget-view", resource=resource, actor=actor
     )
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_renders_general_access(widget_ds):
+    response = await widget_ds.client.get(
+        "/-/acl/resource/widget/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 200
+    assert "General access" in response.text
+    for principal_type in ("everyone", "authenticated", "anonymous"):
+        assert f'name="public_permissions_{principal_type}"' in response.text
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_grants_public_via_post(widget_ds):
+    resource = WidgetResource("shelf", "gadget")
+    # Anonymous has no access yet
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={"public_permissions_everyone": "widget-view"},
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+    # 'everyone' exposes the resource to anyone, including anonymous
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor=None
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+    # The other action remains denied
+    assert not await widget_ds.allowed(
+        action="widget-edit", resource=resource, actor=None
+    )
+    # The public grant renders in the General access section, not as a user
+    page = await widget_ds.client.get(
+        "/-/acl/resource/widget/shelf/gadget",
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert 'name="user_permissions_everyone"' not in page.text
+    # Audit history shows the friendly label
+    assert "Anyone (signed in or not) (general access)" in page.text
+
+
+@pytest.mark.asyncio
+async def test_generic_resource_view_revokes_public_via_post(widget_ds):
+    resource = WidgetResource("shelf", "gadget")
+    await _grant_public(
+        widget_ds,
+        principal_type="authenticated",
+        resource_type="widget",
+        parent="shelf",
+        child="gadget",
+        action="widget-view",
+    )
+    assert await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+    # The general-access selects are always present in the form, so a POST with
+    # the principal's select empty removes the grant (same as groups)
+    response = await widget_ds.client.post(
+        "/-/acl/resource/widget/shelf/gadget",
+        data={"public_permissions_authenticated": ""},
+        cookies={"ds_actor": widget_ds.client.actor_cookie({"id": "root"})},
+    )
+    assert response.status_code == 302
+    assert not await widget_ds.allowed(
+        action="widget-view", resource=resource, actor={"id": "anyone"}
+    )
+
+
 @pytest.mark.asyncio
 async def test_generic_resource_view_revokes_via_post(widget_ds):
     actor = {"id": "alice"}

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -231,8 +231,8 @@ async def test_create_delete_group(ds):
         },
     )
     assert "/groups/sales" not in table_page2.text
-    # But it should still be visible in the audit log
-    assert "<td>sales</td>" in table_page2.text
+    # But it should still be visible in the audit log's Principal column
+    assert "<td>sales (group)</td>" in table_page2.text
 
     # Check the audit log
     audit_rows = [


### PR DESCRIPTION
> *Note: this description was generated with Claude.*

## General access: admin UI section for public audiences + docs

Adds the user-facing **General access** section — the only genuinely new web surface in the stack — to the generic resource admin page, letting an admin grant the `everyone` / `authenticated` / `anonymous` audiences with checkboxes.

**What changed**
- Generic resource page (`resource_acls.py` + `manage_resource_acls.html`): a General access section alongside the group/user grids, posting `public_permissions_<audience>` fields.
- Both admin templates render the audit log's **Principal** column by type (e.g. `sales (group)`, `Any signed-in user (general access)`) instead of separate Group/User columns.
- The legacy table page deliberately has **no** General access section (it only manages real users); a README note points admins to the JSON API / Python helpers for table audiences.
- README gains a "Principals and general access" section documenting the five principal types.

**Testing**
Re-introduces the admin-form tests deferred from PR 3: rendering, granting and revoking audiences via POST, the `_anonymous`-vs-signed-in regression exercised through the admin write path, and the audit-log Principal column. Full suite green (125 tests).

---
**Merge** — PR 5 of 5 (top). Base: `asg017/4-principal-object`. Merge last; `main` then contains the whole feature. Verify with `git diff origin/main asg017/5-general-access-ui` (should be empty). See `STACK-MERGE.md`.
