### PR TITLE
2/5 Gather acl roles on demand, drop _acl_roles_registry cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ venv
 .vscode
 dist
 build
+tmp.db
+internal.db
+uv.lock

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,31 @@
+# datasette-acl — dev recipes
+#
+# `just dev` loads the widgets sample plugin (tests/sample-plugin) +
+# datasette-debug-gotham. Visit http://localhost:5172/-/widgets, "log in" as a
+# character via the gotham actor switcher, create a widget (you become its
+# Manager), then share/restrict it from /-/acl/resource/widget/widgets/<id>.
+#
+# The gotham actors carry a `newsroom` attribute; the dynamic-groups config
+# below turns it into daily-planet / gotham-gazette groups so group grants can
+# be exercised too. `root` (via the --root sign-in link) holds the global
+# datasette-acl admin permission.
+
+dev *flags:
+  DATASETTE_SECRET=abc123 uv run \
+    --prerelease=allow \
+    --with-editable . \
+    --with datasette-debug-gotham \
+    datasette \
+    --root \
+    --plugins-dir tests/sample-plugin \
+    --template-dir tests/sample-plugin/templates \
+    -s permissions.datasette-acl.id root \
+    -s plugins.datasette-acl.dynamic-groups.daily-planet.newsroom daily-planet \
+    -s plugins.datasette-acl.dynamic-groups.gotham-gazette.newsroom gotham-gazette \
+    tmp.db internal.db --create \
+    --internal internal.db \
+    -p 5172 \
+    {{flags}}
+
+test *options:
+  uv run pytest {{options}}

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -16,7 +16,6 @@ from datasette_acl.views.api import (
     groups_json,
     actors_json,
 )
-from datasette_acl.roles import build_roles_registry
 from sqlite_utils import Database
 from . import hookspecs
 import json
@@ -84,11 +83,6 @@ def startup(datasette):
                 "insert or ignore into acl_groups (name) values (:name)",
                 [{"name": name} for name in groups.keys()],
             )
-        # Collect friendly roles declared by plugins via datasette_acl_roles
-        # into a registry keyed by resource_type and stash it on datasette.
-        # Re-gathering is cheap; we do it once at startup.
-        datasette._acl_roles_registry = await build_roles_registry(datasette)
-
     return inner
 
 

--- a/datasette_acl/hookspecs.py
+++ b/datasette_acl/hookspecs.py
@@ -26,7 +26,7 @@ def datasette_acl_roles(datasette):
     wins for display) and `manage=True` marks the role(s) whose actions
     authorize re-sharing the resource.
 
-    May return a list directly, or a function / awaitable returning one.
+    Return a list of AclRole directly.
 
     For the common Viewer/Editor/Manager triple, use
     ``datasette_acl.roles.standard_roles()`` instead of declaring each

--- a/datasette_acl/roles.py
+++ b/datasette_acl/roles.py
@@ -2,9 +2,9 @@
 
 acl stores per-action grants, but users think in roles (Viewer / Editor /
 Manager). Plugins declare roles for their resource types via the
-``datasette_acl_roles`` hook; they are collected at startup into a registry
-keyed by ``resource_type``. Helpers resolve a granted action-set to its
-best-matching role and back.
+``datasette_acl_roles`` hook; :func:`roles_for` gathers them on demand into a
+registry keyed by ``resource_type``. Helpers resolve a granted action-set to
+its best-matching role and back.
 """
 
 from __future__ import annotations
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
 from datasette.plugins import pm
-from datasette.utils import await_me_maybe
 
 if TYPE_CHECKING:
     from datasette.app import Datasette
@@ -119,17 +118,16 @@ def standard_roles(
     ]
 
 
-async def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
+def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
     """Gather declared roles into ``{resource_type: [AclRole, ...]}``.
 
-    Calls the ``datasette_acl_roles`` hook across all plugins, awaiting any
-    callables/awaitables they return, and groups the resulting AclRole objects
-    by ``resource_type``. Within each resource type the roles are sorted by
-    ``rank`` ascending (so the highest-rank role is last) for stable ordering.
+    Calls the ``datasette_acl_roles`` hook across all plugins and groups the
+    resulting AclRole objects by ``resource_type``. Within each resource type
+    the roles are sorted by ``rank`` ascending (so the highest-rank role is
+    last) for stable ordering.
     """
     registry: Dict[str, List[AclRole]] = {}
-    for hook_result in pm.hook.datasette_acl_roles(datasette=datasette):
-        roles = await await_me_maybe(hook_result)
+    for roles in pm.hook.datasette_acl_roles(datasette=datasette):
         if not roles:
             continue
         for role in roles:
@@ -142,13 +140,11 @@ async def build_roles_registry(datasette) -> Dict[str, List[AclRole]]:
 def roles_for(datasette: Datasette, resource_type: str) -> List[AclRole]:
     """Return the registered roles for ``resource_type`` (``[]`` if none).
 
-    Reads the registry cached on the Datasette instance at startup by
-    :func:`build_roles_registry` (see ``datasette_acl.startup``). Shared by the
-    grants layer and the JSON API so neither pokes ``_acl_roles_registry``
-    directly.
+    Gathers roles from the ``datasette_acl_roles`` hook on demand via
+    :func:`build_roles_registry`. Shared by the grants layer and the JSON API
+    as the single way to ask "what roles exist for this resource type?".
     """
-    registry = getattr(datasette, "_acl_roles_registry", None) or {}
-    return registry.get(resource_type, [])
+    return build_roles_registry(datasette).get(resource_type, [])
 
 
 def role_for_actions(

--- a/tests/sample-plugin/templates/widget.html
+++ b/tests/sample-plugin/templates/widget.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% block title %}Widget: {{ widget.name }}{% endblock %}
+
+{% block content %}
+<p><a href="{{ urls.path("/-/widgets") }}">&larr; All widgets</a></p>
+
+<h1>{{ widget.name }}</h1>
+
+<p>
+  Created by {{ widget.creator_name }} on {{ widget.created_at }}.
+  Your role: <strong>{{ role }}</strong>
+</p>
+
+{% if can_edit %}
+  <form action="{{ request.path }}" method="post" style="margin-bottom: 1em">
+    <input data-1p-ignore name="name" value="{{ widget.name }}" required>
+    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+    <input type="submit" value="Rename" class="core">
+  </form>
+{% endif %}
+
+{% if can_manage %}
+  <p><a href="{{ acl_url }}">Manage permissions</a> — share this widget with
+  other actors, groups, or expose it via General access.</p>
+{% endif %}
+{% endblock %}

--- a/tests/sample-plugin/templates/widgets_index.html
+++ b/tests/sample-plugin/templates/widgets_index.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block title %}Widgets{% endblock %}
+
+{% block content %}
+<h1>Widgets</h1>
+
+{% if signed_in %}
+  <form action="{{ urls.path("/-/widgets") }}" method="post" style="margin-bottom: 1.5em">
+    <input data-1p-ignore name="name" placeholder="Widget name" required>
+    <input type="hidden" name="csrftoken" value="{{ csrftoken() }}">
+    <input type="submit" value="Create widget" class="core">
+  </form>
+{% else %}
+  <p>Sign in (pick a character from the actor switcher) to create widgets.</p>
+{% endif %}
+
+{% if widgets %}
+  <table>
+    <thead>
+      <tr><th>Widget</th><th>Created by</th><th>Your role</th></tr>
+    </thead>
+    <tbody>
+      {% for widget in widgets %}
+        <tr>
+          <td><a href="{{ urls.path("/-/widgets/" + widget.id|string) }}">{{ widget.name }}</a></td>
+          <td>{{ widget.creator_name }}</td>
+          <td>{{ widget.role }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+{% else %}
+  <p>No widgets are visible to you yet.</p>
+{% endif %}
+{% endblock %}

--- a/tests/sample-plugin/widgets.py
+++ b/tests/sample-plugin/widgets.py
@@ -1,0 +1,306 @@
+"""A throwaway sample plugin for exercising datasette-acl end-to-end.
+
+Loaded via ``--plugins-dir tests/sample-plugin`` from ``just dev`` (NOT a
+packaged plugin — it is dev/demo scaffolding only). It implements a minimal
+"widgets" feature the way a real consumer plugin would:
+
+- A ``widgets`` table in the internal database. Any signed-in actor can create
+  widgets from ``/-/widgets``.
+- An acl resource type ``widget`` (parent ``widgets``, child = the widget id,
+  mirroring e.g. datasette-apps' ``app``/``apps`` shape) with actions
+  ``widget-view`` / ``widget-edit`` / ``widget-manage``.
+- The canonical Viewer / Editor / Manager triple declared via acl's
+  ``standard_roles()`` factory.
+- The creator is granted the Manager role on their widget, so they "own" it:
+  they can rename it, and — because Manager carries ``manage=True`` — acl's
+  ``can_manage`` gate lets them open the admin page at
+  ``/-/acl/resource/widget/widgets/<id>`` to share it with other actors,
+  groups, or the General access audiences, without holding the global
+  ``datasette-acl`` permission.
+
+Pair with datasette-debug-gotham: its actor switcher signs you in as Clark,
+Bruce, etc., and its cast feeds the admin page's user picker via the
+``datasette_acl_valid_actors`` hook below. The gotham actors carry a
+``newsroom`` attribute, which the ``dynamic-groups`` config in the Justfile
+turns into daily-planet / gotham-gazette groups for group-grant demos.
+"""
+
+from datasette import hookimpl, Forbidden, Response
+from datasette.permissions import Action, Resource
+
+from datasette_acl.grants import grant
+from datasette_acl.roles import role_for_actions, roles_for, standard_roles
+
+# datasette-debug-gotham's demo actors (Clark Kent, Bruce Wayne, …). Imported
+# softly so this plugin still loads without gotham — the picker just goes
+# empty and creators show as raw ids.
+try:
+    from datasette_debug_gotham import ACTORS as GOTHAM_ACTORS
+except Exception:  # pragma: no cover - depends on dev env
+    GOTHAM_ACTORS = {}
+
+WIDGETS_PARENT = "widgets"
+
+
+# --- the resource type -------------------------------------------------------
+
+
+class WidgetsResource(Resource):
+    """The parent container — exists so WidgetResource is a two-level type.
+
+    acl's ``build_resource`` builds two-level types as ``rc(parent, child)``,
+    which is what makes the ``/-/acl/resource/widget/widgets/<id>`` admin URL
+    resolve.
+    """
+
+    name = "widgets"
+    parent_class = None
+
+    def __init__(self):
+        super().__init__(parent=WIDGETS_PARENT, child=None)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return f"SELECT '{WIDGETS_PARENT}' AS parent, NULL AS child"
+
+
+class WidgetResource(Resource):
+    name = "widget"
+    parent_class = WidgetsResource
+
+    def __init__(self, parent=None, child=None):
+        # Accept both the ergonomic WidgetResource(widget_id) and acl's
+        # positional build_resource convention WidgetResource("widgets", id).
+        if child is None:
+            child = parent
+        super().__init__(
+            parent=WIDGETS_PARENT, child=str(child) if child is not None else None
+        )
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        # acl stores resource ids as text; CAST so `child IS :child` matches.
+        return (
+            f"SELECT '{WIDGETS_PARENT}' AS parent, "
+            "CAST(id AS TEXT) AS child FROM widgets"
+        )
+
+
+# --- acl hooks ---------------------------------------------------------------
+
+
+@hookimpl
+def register_actions(datasette):
+    return [
+        Action(
+            name="widget-view",
+            description="View a widget",
+            resource_class=WidgetResource,
+        ),
+        Action(
+            name="widget-edit",
+            description="Edit a widget",
+            resource_class=WidgetResource,
+        ),
+        Action(
+            name="widget-manage",
+            description="Manage sharing for a widget",
+            resource_class=WidgetResource,
+        ),
+    ]
+
+
+@hookimpl
+def datasette_acl_roles(datasette):
+    return standard_roles(
+        "widget",
+        view="widget-view",
+        edit="widget-edit",
+        manage="widget-manage",
+        descriptions={"Manager": "Full control, including sharing"},
+    )
+
+
+@hookimpl
+def datasette_acl_valid_actors(datasette):
+    """Feed the gotham cast into the admin page's "Other user" picker."""
+    return [
+        {"id": actor_id, "display": info.get("name", actor_id)}
+        for actor_id, info in GOTHAM_ACTORS.items()
+    ]
+
+
+# --- storage -----------------------------------------------------------------
+
+
+@hookimpl
+def startup(datasette):
+    async def inner():
+        db = datasette.get_internal_database()
+        await db.execute_write(
+            """
+            CREATE TABLE IF NOT EXISTS widgets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                created_by TEXT NOT NULL,
+                created_at TEXT NOT NULL
+                    DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+            )
+            """
+        )
+
+    return inner
+
+
+def _creator_name(actor_id):
+    return GOTHAM_ACTORS.get(actor_id, {}).get("name", actor_id)
+
+
+async def _role_name(datasette, widget_id, actor):
+    """The actor's highest role on a widget, or None when they have no access.
+
+    Resolved the same way acl does it: collect the actions the actor is
+    ``allowed`` on this resource, then map that set to the best-fit role.
+    """
+    roles = roles_for(datasette, "widget")
+    resource = WidgetResource(widget_id)
+    granted = set()
+    for action in {a for role in roles for a in role.actions}:
+        if await datasette.allowed(action=action, resource=resource, actor=actor):
+            granted.add(action)
+    role = role_for_actions(roles, granted)
+    return role.name if role else None
+
+
+# --- pages -------------------------------------------------------------------
+
+
+async def widgets_index(request, datasette):
+    db = datasette.get_internal_database()
+
+    if request.method == "POST":
+        actor_id = (request.actor or {}).get("id")
+        if not actor_id:
+            raise Forbidden("Sign in to create widgets")
+        post_vars = await request.post_vars()
+        name = (post_vars.get("name") or "").strip()
+        if not name:
+            datasette.add_message(request, "A widget needs a name", datasette.ERROR)
+            return Response.redirect(request.path)
+        widget_id = await db.execute_write_fn(
+            lambda conn: conn.execute(
+                "INSERT INTO widgets (name, created_by) VALUES (?, ?)",
+                [name, actor_id],
+            ).lastrowid
+        )
+        # The creator owns their widget: a Manager grant gives them
+        # view + edit + manage, and manage authorizes re-sharing from the
+        # /-/acl/resource/widget/widgets/<id> admin page.
+        await grant(
+            datasette,
+            "widget",
+            WIDGETS_PARENT,
+            str(widget_id),
+            actor_id=actor_id,
+            role="Manager",
+            by_actor=actor_id,
+        )
+        datasette.add_message(
+            request, f"Widget '{name}' created — you are its Manager"
+        )
+        return Response.redirect(datasette.urls.path(f"/-/widgets/{widget_id}"))
+
+    # Only list widgets the current actor may view, tagged with their role —
+    # Viewer already implies widget-view, so a non-None role is the view gate.
+    widgets = []
+    rows = await db.execute("SELECT * FROM widgets ORDER BY id")
+    for row in rows.rows:
+        role = await _role_name(datasette, row["id"], request.actor)
+        if role is None:
+            continue
+        widgets.append(
+            {
+                **dict(row),
+                "creator_name": _creator_name(row["created_by"]),
+                "role": role,
+            }
+        )
+    return Response.html(
+        await datasette.render_template(
+            "widgets_index.html",
+            {"widgets": widgets, "signed_in": bool(request.actor)},
+            request=request,
+        )
+    )
+
+
+async def widget_page(request, datasette):
+    db = datasette.get_internal_database()
+    widget_id = request.url_vars["id"]
+    row = (
+        await db.execute("SELECT * FROM widgets WHERE id = ?", [widget_id])
+    ).first()
+    if row is None:
+        return Response.html("Widget not found", status=404)
+
+    resource = WidgetResource(widget_id)
+    if not await datasette.allowed(
+        action="widget-view", resource=resource, actor=request.actor
+    ):
+        raise Forbidden("You don't have access to this widget")
+    can_edit = await datasette.allowed(
+        action="widget-edit", resource=resource, actor=request.actor
+    )
+    can_manage = await datasette.allowed(
+        action="widget-manage", resource=resource, actor=request.actor
+    )
+
+    if request.method == "POST":
+        if not can_edit:
+            raise Forbidden("You cannot edit this widget")
+        post_vars = await request.post_vars()
+        name = (post_vars.get("name") or "").strip()
+        if name:
+            await db.execute_write(
+                "UPDATE widgets SET name = ? WHERE id = ?", [name, widget_id]
+            )
+            datasette.add_message(request, f"Renamed to '{name}'")
+        return Response.redirect(request.path)
+
+    return Response.html(
+        await datasette.render_template(
+            "widget.html",
+            {
+                "widget": {
+                    **dict(row),
+                    "creator_name": _creator_name(row["created_by"]),
+                },
+                "role": await _role_name(datasette, widget_id, request.actor),
+                "can_edit": can_edit,
+                "can_manage": can_manage,
+                "acl_url": datasette.urls.path(
+                    f"/-/acl/resource/widget/{WIDGETS_PARENT}/{widget_id}"
+                ),
+            },
+            request=request,
+        )
+    )
+
+
+@hookimpl
+def register_routes():
+    return [
+        (r"^/-/widgets$", widgets_index),
+        (r"^/-/widgets/(?P<id>[0-9]+)$", widget_page),
+    ]
+
+
+@hookimpl
+def homepage_actions(datasette, actor, request):
+    return [
+        {
+            "href": datasette.urls.path("/-/widgets"),
+            "label": "Widgets",
+            "description": "Sample widgets for exercising acl sharing",
+        }
+    ]

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,5 +1,5 @@
 """
-Tests for the friendly-roles layer: the datasette_acl_roles hook, the startup
+Tests for the friendly-roles layer: the datasette_acl_roles hook, the
 registry keyed by resource_type, and the role<->action resolution helpers.
 """
 
@@ -9,6 +9,7 @@ from datasette.permissions import Action, Resource
 from datasette.plugins import pm
 from datasette_acl.roles import (
     AclRole,
+    build_roles_registry,
     role_for_actions,
     actions_for_role,
     manage_actions,
@@ -76,7 +77,7 @@ async def doc_ds():
 
 @pytest.mark.asyncio
 async def test_registry_built_and_grouped_by_resource_type(doc_ds):
-    registry = doc_ds._acl_roles_registry
+    registry = build_roles_registry(doc_ds)
     assert set(registry.keys()) == {"mock-doc"}
     roles = registry["mock-doc"]
     # All three roles present, sorted by rank ascending


### PR DESCRIPTION
> *Note: this description was generated with Claude.*

## Gather acl roles on demand, drop `_acl_roles_registry` cache

`roles_for()` now gathers declared roles directly via `build_roles_registry()` instead of reading a registry stashed on the Datasette instance at startup.

**What changed**
- `build_roles_registry()` is now synchronous, and the `datasette_acl_roles` hook returns a list directly (no awaitable form).
- `startup()` no longer builds/stashes `datasette._acl_roles_registry`. The startup cache only existed to bridge async hook-gathering to sync consumers; making the gather synchronous removes the need for it, along with the silent `getattr` fallback that masked a missing startup.
- Every consumer already went through `roles_for()`, so nothing else changes.

**Testing**
`tests/test_roles.py` updated for the synchronous hook. Full suite green.

---
**Merge** — PR 2 of 5. Base: `asg017/1-dev-tooling`. Merge after PR 1; deleting PR 1's branch auto-retargets this PR's base to `main`. See `STACK-MERGE.md`.
