### PR TITLE
Support parent-only grants: grant an action on all children of a parent resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ The page also offers a **General access** section for granting table actions to 
 
 An audit log tracks which permissions were added and removed, displayed at the bottom of the permissions page.
 
+### Managing permissions for every table in a database
+
+To grant an action on **every table in a database** — for example letting a group `view-table` everything in `mydb`, including tables created later — use the database-wide page at `/-/acl/resource/table/<database-name>` (the table page URL with the table segment omitted). It can be accessed from the database actions menu on the database page, which also links to the page for the database's own actions such as `view-database`.
+
+Database-wide grants combine with per-table grants: an actor can access a table if either level allows it.
+
 ### Custom resource types
 
 `datasette-acl` is not limited to tables. It can store and resolve grants for *any* resource type defined by a plugin - documents, lists, workbooks, comment spaces, kanban boards and so on.
@@ -70,7 +76,7 @@ A generic admin page for any resource type lives at:
 /-/acl/resource/<resource-type>/<parent>/<child>
 ```
 
-For example `/-/acl/resource/playlist/workspace-1/playlist-42`. The `<child>` segment is optional for parent-only resource types (`/-/acl/resource/<resource-type>/<parent>`). The page presents group, user, general-access grants and an audit log, with checkboxes for exactly the actions registered for that resource type. Access to this admin page is granted to users with the `datasette-acl` permission described below, or users who can manage that specific resource.
+For example `/-/acl/resource/playlist/workspace-1/playlist-42`. The `<child>` segment is optional: for parent-only resource types it names the resource itself (`/-/acl/resource/<resource-type>/<parent>`), while for child-bearing resource types it names the parent-level resource — grants made there apply to **every child under that parent** (e.g. `/-/acl/resource/table/mydb` manages all tables in `mydb`). The page presents group, user, general-access grants and an audit log, with checkboxes for exactly the actions registered for that resource type. Access to this admin page is granted to users with the `datasette-acl` permission described below, or users who can manage that specific resource.
 
 The page also has a **General access** section for exposing a resource without naming individual users — see [Principals and general access](#principals-and-general-access) below.
 

--- a/datasette_acl/__init__.py
+++ b/datasette_acl/__init__.py
@@ -310,6 +310,26 @@ def table_actions(datasette, actor, database, table, request=None):
 
 
 @hookimpl
+def database_actions(datasette, actor, database, request=None):
+    async def inner():
+        if await can_edit_permissions(datasette, actor):
+            return [
+                {
+                    "href": datasette.urls.path(f"/-/acl/resource/database/{database}"),
+                    "label": "Manage database permissions",
+                    "description": "Control who can view this database",
+                },
+                {
+                    "href": datasette.urls.path(f"/-/acl/resource/table/{database}"),
+                    "label": "Manage permissions for all tables",
+                    "description": "Grants here apply to every table in this database",
+                },
+            ]
+
+    return inner
+
+
+@hookimpl
 def track_event(datasette, event):
     async def inner():
         config = datasette.plugin_config("datasette-acl") or {}

--- a/datasette_acl/templates/manage_resource_acls.html
+++ b/datasette_acl/templates/manage_resource_acls.html
@@ -165,7 +165,11 @@ table.audit tbody tr:first-child td {
   <span class="acl-badge">{{ resource_type }}</span>
 </div>
 
+{% if parent_only %}
+<p class="resource-acl-heading">Every <strong>{{ resource_type }}</strong> in {{ parent_type }} <code>{{ parent }}</code> — these permissions apply to all of them, including ones created later. They combine with any per-{{ resource_type }} permissions.</p>
+{% else %}
 <p class="resource-acl-heading">Resource <code>{{ parent }}{% if child %}/{{ child }}{% endif %}</code></p>
+{% endif %}
 
 <form action="{{ request.path }}" method="post" class="permissions-form">
   {% if groups %}

--- a/datasette_acl/utils.py
+++ b/datasette_acl/utils.py
@@ -110,11 +110,27 @@ async def resource_exists(
     creating it (issue #43). ``IS`` is NULL-safe, so a parent-only resource
     (``child`` NULL) matches correctly.
 
+    A ``child`` of NULL for a *child-bearing* resource type (one with a
+    ``parent_class``, e.g. ``table``) names the parent-level resource: "all
+    tables in this database". Its ``resources_sql`` only enumerates concrete
+    children, so existence is instead defined by the parent class: the
+    parent-level resource exists iff the parent itself does. Core caps the
+    hierarchy at two levels, so the parent class's rows are always
+    ``(name, NULL)``. Grants on such a resource cascade to every child via
+    core's (parent, child=NULL) allow-row resolution.
+
     Returns False for unknown resource types.
     """
     rc = resource_class_for(datasette, resource_type)
     if rc is None:
         return False
+    if child is None and rc.parent_class is not None:
+        inner = await rc.parent_class.resources_sql(datasette, actor=None)
+        result = await datasette.get_internal_database().execute(
+            f"SELECT 1 FROM ({inner}) WHERE parent IS :parent LIMIT 1",
+            {"parent": parent},
+        )
+        return bool(result.rows)
     inner = await rc.resources_sql(datasette, actor=None)
     result = await datasette.get_internal_database().execute(
         f"SELECT 1 FROM ({inner}) WHERE parent IS :parent AND child IS :child LIMIT 1",

--- a/datasette_acl/views/resource_acls.py
+++ b/datasette_acl/views/resource_acls.py
@@ -21,8 +21,13 @@ async def manage_resource_acls(request, datasette):
 
     # The resource type must correspond to a known, action-bearing resource
     # class, otherwise there is nothing to manage.
-    if resource_class_for(datasette, resource_type) is None:
+    resource_class = resource_class_for(datasette, resource_type)
+    if resource_class is None:
         raise Forbidden(f"Unknown resource type: {resource_type}")
+
+    # No child for a child-bearing type names the parent-level resource:
+    # grants made here cascade to every child (e.g. all tables in a database).
+    parent_only = child is None and resource_class.parent_class is not None
 
     # Per-resource authorization: the global datasette-acl admin OR an actor who
     # holds a manage=True role (Manager/Owner) on this specific resource —
@@ -393,6 +398,10 @@ async def manage_resource_acls(request, datasette):
                 "resource_type": resource_type,
                 "parent": parent,
                 "child": child,
+                "parent_only": parent_only,
+                "parent_type": (
+                    resource_class.parent_class.name if parent_only else None
+                ),
                 "actions": actions,
                 "groups": groups,
                 "group_sizes": group_sizes,

--- a/docs/json-api.md
+++ b/docs/json-api.md
@@ -36,6 +36,8 @@ A resource is addressed by a `(resource_type, parent, child)` triple:
 
 In URLs the child segment is **optional** — every resource route is registered in both a `/{parent}/{child}` and a `/{parent}` form. For a parent-only resource, omit the child segment entirely; in JSON responses the absent child is reported as `"child": null`.
 
+For a **two-level** type, omitting the child addresses the parent-level resource: grants made on it apply to **every child under that parent**. For example `POST /-/acl/api/resource/table/mydb/grant` with `{"actions": ["view-table"]}` lets the principal view all tables in `mydb`, including tables created later. Such a grant exists only if the parent itself exists, and it combines (unions) with any per-child grants.
+
 All three segments are single path components (no slashes). URL-encode values that contain reserved characters.
 
 ### Principals

--- a/tests/test_datasette_acl_valid_actors.py
+++ b/tests/test_datasette_acl_valid_actors.py
@@ -31,11 +31,13 @@ def register_plugin():
 @pytest.mark.asyncio
 async def test_datasette_acl_valid_actors(ds, register_plugin):
     plugins_response = await ds.client.get("/-/plugins.json")
-    assert any(
-        plugin
-        for plugin in plugins_response.json()
-        if plugin["name"] == "TestActorIdsPlugin"
+    plugins_data = plugins_response.json()
+    # datasette 1.0a36 wrapped the response: {"ok": true, "plugins": [...]};
+    # earlier alphas returned the bare list
+    plugins = (
+        plugins_data["plugins"] if isinstance(plugins_data, dict) else plugins_data
     )
+    assert any(plugin["name"] == "TestActorIdsPlugin" for plugin in plugins)
     await ds.get_internal_database().execute_write_script("""
         create table if not exists users (username text primary key);
         insert or ignore into users (username) values ('one');

--- a/tests/test_parent_only_grants.py
+++ b/tests/test_parent_only_grants.py
@@ -1,0 +1,264 @@
+"""Tests for parent-only grants on child-bearing resource types.
+
+A grant on ``(resource_type="table", parent=db, child=NULL)`` means "this
+action on every table in the database" — core's permission resolution already
+cascades a (parent, child=NULL) allow row to all children, and acl's storage
+layer already accepts it. These tests cover the HTTP surface that used to
+reject such a resource at the ``resource_exists`` gate: the JSON API
+(grant/read/revoke), the manage UI page, and the database_actions menu links
+that make the page discoverable.
+"""
+
+from datasette import hookimpl
+from datasette.app import Datasette
+from datasette.permissions import Action, Resource
+from datasette.plugins import pm
+from datasette.resources import DatabaseResource
+from datasette_acl.utils import resource_exists
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def deny_ds():
+    """A default-deny instance: two tables, root holds datasette-acl."""
+    datasette = Datasette(
+        default_deny=True,
+        config={"permissions": {"datasette-acl": {"id": "root"}}},
+    )
+    db = datasette.add_memory_database("scratch")
+    await db.execute_write("create table t1 (id integer primary key)")
+    await db.execute_write("create table t2 (id integer primary key)")
+    await datasette.invoke_startup()
+    await datasette.refresh_schemas()
+    yield datasette
+    # In-memory databases are shared across tests, so drop everything
+    for table in ("t1", "t2"):
+        await db.execute_write(f"drop table {table}")
+    internal_db = datasette.get_internal_database()
+    for table in await internal_db.table_names():
+        if table.startswith("acl"):
+            await internal_db.execute_write(f"drop table {table}")
+
+
+def _cookie(datasette, actor_id):
+    return {"ds_actor": datasette.client.actor_cookie({"id": actor_id})}
+
+
+@pytest.mark.asyncio
+async def test_resource_exists_parent_only(deny_ds):
+    # Parent-only table resource exists iff the database does
+    assert await resource_exists(deny_ds, "table", "scratch", None)
+    assert not await resource_exists(deny_ds, "table", "nope", None)
+    # Concrete children behave as before
+    assert await resource_exists(deny_ds, "table", "scratch", "t1")
+    assert not await resource_exists(deny_ds, "table", "scratch", "missing")
+    # Parent-only resource types (database) are unaffected
+    assert await resource_exists(deny_ds, "database", "scratch", None)
+    assert not await resource_exists(deny_ds, "database", "nope", None)
+
+
+@pytest.mark.asyncio
+async def test_api_parent_only_grant_read_revoke(deny_ds):
+    root = _cookie(deny_ds, "root")
+    alice = _cookie(deny_ds, "alice")
+
+    # Baseline: alice sees nothing
+    assert (await deny_ds.client.get("/scratch.json", cookies=alice)).status_code == 403
+    assert (
+        await deny_ds.client.get("/scratch/t1.json", cookies=alice)
+    ).status_code == 403
+
+    # view-database on the database, view-table on all its tables
+    response = await deny_ds.client.post(
+        "/-/acl/api/resource/database/scratch/grant",
+        json={"actor_id": "alice", "actions": ["view-database"]},
+        cookies=root,
+    )
+    assert response.status_code == 200
+    response = await deny_ds.client.post(
+        "/-/acl/api/resource/table/scratch/grant",
+        json={"actor_id": "alice", "actions": ["view-table"]},
+        cookies=root,
+    )
+    assert response.status_code == 200
+    assert response.json()["ok"] is True
+
+    # Alice now sees every table, individually and in the database listing
+    for path in ("/scratch/t1.json", "/scratch/t2.json"):
+        assert (await deny_ds.client.get(path, cookies=alice)).status_code == 200
+    database_json = (await deny_ds.client.get("/scratch.json", cookies=alice)).json()
+    assert {t["name"] for t in database_json["tables"]} == {"t1", "t2"}
+
+    # The read endpoint reports the parent-only grant
+    response = await deny_ds.client.get(
+        "/-/acl/api/resource/table/scratch", cookies=root
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["parent"] == "scratch"
+    assert data["child"] is None
+    assert data["grants"] == [
+        {
+            "principal": "actor",
+            "id": "alice",
+            "role": None,
+            "actions": ["view-table"],
+            "kind": "user",
+        }
+    ]
+
+    # Revoke removes access to the tables again
+    response = await deny_ds.client.post(
+        "/-/acl/api/resource/table/scratch/revoke",
+        json={"actor_id": "alice"},
+        cookies=root,
+    )
+    assert response.status_code == 200
+    assert response.json()["removed"] == ["view-table"]
+    assert (
+        await deny_ds.client.get("/scratch/t1.json", cookies=alice)
+    ).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_api_parent_only_unknown_database_still_403(deny_ds):
+    response = await deny_ds.client.post(
+        "/-/acl/api/resource/table/nope/grant",
+        json={"actor_id": "alice", "actions": ["view-table"]},
+        cookies=_cookie(deny_ds, "root"),
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_ui_parent_only_page(deny_ds):
+    root = _cookie(deny_ds, "root")
+    alice = _cookie(deny_ds, "alice")
+
+    # Admin sees the page, labelled with its database-wide scope
+    response = await deny_ds.client.get("/-/acl/resource/table/scratch", cookies=root)
+    assert response.status_code == 200
+    assert "Every <strong>table</strong> in database <code>scratch</code>" in response.text
+
+    # Non-admins and made-up databases still get the opaque 403
+    assert (
+        await deny_ds.client.get("/-/acl/resource/table/scratch", cookies=alice)
+    ).status_code == 403
+    assert (
+        await deny_ds.client.get("/-/acl/resource/table/nope", cookies=root)
+    ).status_code == 403
+
+    # Granting view-table to a user through the form cascades to every table
+    response = await deny_ds.client.post(
+        "/-/acl/resource/table/scratch",
+        data={"new_actor_id": "alice", "new_user_actions": "view-table"},
+        cookies=root,
+    )
+    assert response.status_code == 302
+    for path in ("/scratch/t1.json", "/scratch/t2.json"):
+        assert (await deny_ds.client.get(path, cookies=alice)).status_code == 200
+
+
+class GadgetResource(Resource):
+    """Custom two-level resource type whose parent is a database."""
+
+    name = "gadget"
+    parent_class = DatabaseResource
+
+    def __init__(self, database, gadget):
+        super().__init__(parent=database, child=gadget)
+
+    @classmethod
+    async def resources_sql(cls, datasette, actor=None):
+        return """
+            SELECT 'scratch' AS parent, 'g1' AS child
+            UNION ALL SELECT 'scratch', 'g2'
+            UNION ALL SELECT 'elsewhere', 'g3'
+        """
+
+
+class GadgetPlugin:
+    __name__ = "GadgetPlugin"
+
+    @hookimpl
+    def register_actions(self, datasette):
+        return [
+            Action(
+                name="gadget-view",
+                description="View a gadget",
+                resource_class=GadgetResource,
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_custom_two_level_resource_parent_only_grant():
+    """Parent-only grants work for custom resource types with a parent class."""
+    pm.register(GadgetPlugin(), name="gadget-plugin")
+    try:
+        datasette = Datasette(
+            default_deny=True,
+            config={"permissions": {"datasette-acl": {"id": "root"}}},
+        )
+        datasette.add_memory_database("scratch")
+        datasette.add_memory_database("elsewhere")
+        await datasette.invoke_startup()
+        await datasette.refresh_schemas()
+        root = _cookie(datasette, "root")
+        alice = {"id": "alice"}
+
+        # The parent-level gadget resource exists iff its database does
+        assert await resource_exists(datasette, "gadget", "scratch", None)
+        assert not await resource_exists(datasette, "gadget", "nope", None)
+
+        # "alice can gadget-view every gadget in database scratch"
+        response = await datasette.client.post(
+            "/-/acl/api/resource/gadget/scratch/grant",
+            json={"actor_id": "alice", "actions": ["gadget-view"]},
+            cookies=root,
+        )
+        assert response.status_code == 200
+
+        # The grant cascades to every gadget under scratch — and only those
+        for gadget, expected in (("g1", True), ("g2", True)):
+            assert (
+                await datasette.allowed(
+                    actor=alice,
+                    action="gadget-view",
+                    resource=GadgetResource("scratch", gadget),
+                )
+                is expected
+            )
+        assert not await datasette.allowed(
+            actor=alice,
+            action="gadget-view",
+            resource=GadgetResource("elsewhere", "g3"),
+        )
+
+        # A grant against a made-up parent database is still refused
+        response = await datasette.client.post(
+            "/-/acl/api/resource/gadget/nope/grant",
+            json={"actor_id": "alice", "actions": ["gadget-view"]},
+            cookies=root,
+        )
+        assert response.status_code == 403
+
+        internal_db = datasette.get_internal_database()
+        for table in await internal_db.table_names():
+            if table.startswith("acl"):
+                await internal_db.execute_write(f"drop table {table}")
+    finally:
+        pm.unregister(name="gadget-plugin")
+
+
+@pytest.mark.asyncio
+async def test_database_actions_menu_links(ds):
+    # ds (conftest) is default-allow, so root can render the database page
+    response = await ds.client.get("/db", cookies=_cookie(ds, "root"))
+    assert response.status_code == 200
+    assert "/-/acl/resource/database/db" in response.text
+    assert "/-/acl/resource/table/db" in response.text
+    # Anonymous users don't see the management links
+    response = await ds.client.get("/db")
+    assert "/-/acl/resource/database/db" not in response.text


### PR DESCRIPTION
## Problem

On a `--default-deny` instance there is no ACL surface that lets an admin say "these actors can `view-table` every table in database X". The only database-level action is `view-database`, which yields a database page showing 0 tables; making tables visible requires one `view-table` grant per table (18 for the database that prompted this).

The whole stack below the HTTP layer already supports the natural representation — an acl row on `(resource_type="table", parent=db, child=NULL)`:

- Core's resolution cascades a `(parent, child=NULL)` allow row to all children (`datasette/utils/actions_sql.py` treats a NULL-child rule as parent-level for any resource class).
- acl's storage accepts a NULL child, `grants.grant(..., child=None)` works, and `permission_resources_sql` passes the row through.

But the row was uncreatable through the API/UI: `resource_exists()` defines existence via the resource type's own `resources_sql`, which only enumerates concrete children, so `POST /-/acl/api/resource/table/{db}/grant` (and the manage page at `/-/acl/resource/table/{db}`) rejected the parent-level resource with the opaque 403 — the existence gate from #43, not authz.

## Fix

`resource_exists()` now defines existence for a parent-only resource of a *child-bearing* type by the parent class: `("table", "mydb", None)` exists iff database `mydb` exists per `DatabaseResource.resources_sql`. Core caps the resource hierarchy at two levels, so the parent class's rows are always `(name, NULL)`. Everything else — grant/revoke/update, audit, the read endpoint, the manage UI form — already handled the NULL child once past that gate.

Semantics: parent-level and per-child grants union, matching core's existing resolution. A grant against a made-up parent still gets the same opaque 403 (preserves the no-leak behavior from #43).

This is generic over custom resource types: any type with a `parent_class` (including custom parents) gets "grant on all children" for free.

Also:
- New `database_actions` menu links for `datasette-acl` admins: "Manage database permissions" (`/-/acl/resource/database/{db}`) and "Manage permissions for all tables" (`/-/acl/resource/table/{db}`), making both pages discoverable.
- The parent-only manage page now states its scope ("Every **table** in database `mydb` — these permissions apply to all of them, including ones created later") instead of looking like a resource named after the database.
- README and docs/json-api.md document the parent-only form and union semantics.

## Tests

New `tests/test_parent_only_grants.py` on a `default_deny=True` instance:
- `resource_exists` parent-only true/false, concrete children and parent-only types unchanged
- JSON API grant → both tables visible to the grantee (individually and in the database listing), read endpoint reports the grant with `child: null`, revoke restores 403
- Unknown parent database still 403s (API and UI)
- Manage UI page renders with the scope note and its form POST cascades to every table
- Custom two-level resource type (`gadget` with `parent_class = DatabaseResource`): parent-only grant cascades to all gadgets in that database only
- `database_actions` menu links present for admins, absent for anonymous

145 passed, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)